### PR TITLE
Add redis support to nextcloud

### DIFF
--- a/docs/services/nextcloud.md
+++ b/docs/services/nextcloud.md
@@ -9,6 +9,7 @@ This service requires the following other services:
 
 - a [Postgres](postgres.md) database
 - a [Traefik](traefik.md) reverse-proxy server
+- a [Redis](redis.md) data-store (optional)
 
 
 ## Configuration
@@ -26,6 +27,9 @@ nextcloud_enabled: true
 
 nextcloud_hostname: mash.example.com
 nextcloud_path_prefix: /nextcloud
+
+# Enable redis (optional)
+#nextcloud_redis_enabled: true
 
 ########################################################################
 #                                                                      #

--- a/docs/services/nextcloud.md
+++ b/docs/services/nextcloud.md
@@ -9,7 +9,7 @@ This service requires the following other services:
 
 - a [Postgres](postgres.md) database
 - a [Traefik](traefik.md) reverse-proxy server
-- a [Redis](redis.md) data-store (optional)
+- a [Redis](redis.md) data-store (optional), installation details [below](#redis)
 
 
 ## Configuration
@@ -28,8 +28,7 @@ nextcloud_enabled: true
 nextcloud_hostname: mash.example.com
 nextcloud_path_prefix: /nextcloud
 
-# Enable redis (optional)
-#nextcloud_redis_enabled: true
+# Redis configuration, as described below
 
 ########################################################################
 #                                                                      #
@@ -42,6 +41,143 @@ In the example configuration above, we configure the service to be hosted at `ht
 
 You can remove the `nextcloud_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
 
+### Redis
+
+As described on the [Redis](redis.md) documentation page, if you're hosting additional services which require Redis on the same server, you'd better go for installing a separate Redis instance for each service. See [Creating a Redis instance dedicated to Nextcloud](#creating-a-redis-instance-dedicated-to-nextcloud).
+
+If you're only running Nextcloud on this server and don't need to use Redis for anything else, you can [use a single Redis instance](#using-the-shared-redis-instance-for-nextcloud).
+
+#### Using the shared Redis instance for Nextcloud
+
+To install a single (non-dedicated) Redis instance (`mash-redis`) and hook Nextcloud to it, add the following **additional** configuration:
+
+```yaml
+########################################################################
+#                                                                      #
+# redis                                                                #
+#                                                                      #
+########################################################################
+
+redis_enabled: true
+
+########################################################################
+#                                                                      #
+# /redis                                                               #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# nextcloud                                                            #
+#                                                                      #
+########################################################################
+
+# Base configuration as shown above
+
+# Point Nextcloud to the shared Redis instance
+nextcloud_redis_hostname: "{{ redis_identifier }}"
+
+# Make sure the Nextcloud service (mash-nextcloud.service) starts after the shared Redis service (mash-redis.service)
+nextcloud_systemd_required_services_list_custom:
+  - "{{ redis_identifier }}.service"
+
+# Make sure the Nextcloud container is connected to the container network of the shared Redis service (mash-redis)
+nextcloud_container_additional_networks_custom:
+  - "{{ redis_identifier }}"
+
+########################################################################
+#                                                                      #
+# /nextcloud                                                           #
+#                                                                      #
+########################################################################
+```
+This will create a `mash-redis` Redis instance on this host.
+
+This is only recommended if you won't be installing other services which require Redis. Alternatively, go for [Creating a Redis instance dedicated to Nextcloud](#creating-a-redis-instance-dedicated-to-nextcloud).
+
+#### Creating a Redis instance dedicated to Nextcloud
+
+The following instructions are based on the [Running multiple instances of the same service on the same host](../running-multiple-instances.md) documentation.
+
+Adjust your `inventory/hosts` file as described in [Re-do your inventory to add supplementary hosts](../running-multiple-instances.md#re-do-your-inventory-to-add-supplementary-hosts), adding a new supplementary host (e.g. if `nextcloud.example.com` is your main one, create `nectcloud.example.com-deps`).
+
+Then, create a new `vars.yml` file for the
+
+`inventory/host_vars/nextcloud.example.com-deps/vars.yml`:
+
+```yaml
+---
+
+########################################################################
+#                                                                      #
+# Playbook                                                             #
+#                                                                      #
+########################################################################
+
+# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
+# Various other secrets will be derived from this secret automatically.
+mash_playbook_generic_secret_key: ''
+
+# Override service names and directory path prefixes
+mash_playbook_service_identifier_prefix: 'mash-nextcloud-'
+mash_playbook_service_base_directory_name_prefix: 'nextcloud-'
+
+########################################################################
+#                                                                      #
+# /Playbook                                                            #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# redis                                                                #
+#                                                                      #
+########################################################################
+
+redis_enabled: true
+
+########################################################################
+#                                                                      #
+# /redis                                                               #
+#                                                                      #
+########################################################################
+```
+
+This will create a `mash-nextcloud-redis` instance on this host with its data in `/mash/nextcloud-redis`.
+
+Then, adjust your main inventory host's variables file (`inventory/host_vars/nextcloud.example.com/vars.yml`) like this:
+
+```yaml
+########################################################################
+#                                                                      #
+# nextcloud                                                            #
+#                                                                      #
+########################################################################
+
+# Base configuration as shown above
+
+# Point Nextcloud to its dedicated Redis instance
+nextcloud_redis_hostname: mash-nextcloud-redis
+
+# Make sure the Nextcloud service (mash-nextcloud.service) starts after its dedicated Redis service (mash-nextcloud-redis.service)
+nextcloud_systemd_required_services_list_custom:
+  - "mash-nextcloud-redis.service"
+
+# Make sure the Nextcloud container is connected to the container network of its dedicated Redis service (mash-nextcloud-redis)
+nextcloud_container_additional_networks_custom:
+  - "mash-nextcloud-redis"
+
+########################################################################
+#                                                                      #
+# /nextcloud                                                           #
+#                                                                      #
+########################################################################
+```
+## Installation
+
+If you've decided to install a dedicated Redis instance for Nextcloud, make sure to first do [installation](../installing.md) for the supplementary inventory host (e.g. `nextcloud.example.com-deps`), before running installation for the main one (e.g. `nextcloud.example.com`).
 
 ## Usage
 

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -730,23 +730,19 @@ nextcloud_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 nextcloud_uid: "{{ mash_playbook_uid }}"
 nextcloud_gid: "{{ mash_playbook_gid }}"
 
-nextcloud_systemd_required_systemd_services_list: |
+nextcloud_systemd_required_services_list_auto: |
   {{
     (['docker.service'])
     +
     ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and nextcloud_database_hostname == devture_postgres_identifier else [])
-    +
-    ([redis_identifier ~ '.service'] if redis_enabled and nextcloud_redis_enabled and nextcloud_redis_hostname == redis_identifier else [])
   }}
 
-nextcloud_container_additional_networks: |
+nextcloud_container_additional_networks_auto: |
   {{
     ( 
       ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
       +
       ([devture_postgres_container_network] if devture_postgres_enabled and nextcloud_database_hostname == devture_postgres_identifier and nextcloud_container_network != devture_postgres_container_network else [])
-      +
-      ([redis_container_network] if redis_enabled and nextcloud_redis_enabled and nextcloud_redis_hostname == redis_identifier else [])
     ) | unique
   }}
 
@@ -759,9 +755,6 @@ nextcloud_database_hostname: "{{ devture_postgres_identifier if devture_postgres
 nextcloud_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
 nextcloud_database_username: "nextcloud"
 nextcloud_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nextcloud', rounds=655555) | to_uuid }}"
-
-nextcloud_redis_enabled: false
-nextcloud_redis_hostname: "{{ redis_identifier if redis_enabled and nextcloud_redis_enabled else '' }}"
 
 ########################################################################
 #                                                                      #

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -735,13 +735,19 @@ nextcloud_systemd_required_systemd_services_list: |
     (['docker.service'])
     +
     ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and nextcloud_database_hostname == devture_postgres_identifier else [])
+    +
+    ([redis_identifier ~ '.service'] if redis_enabled and nextcloud_redis_enabled and nextcloud_redis_hostname == redis_identifier else [])
   }}
 
 nextcloud_container_additional_networks: |
   {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([devture_postgres_container_network] if devture_postgres_enabled and nextcloud_database_hostname == devture_postgres_identifier and nextcloud_container_network != devture_postgres_container_network else [])
+    ( 
+      ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+      +
+      ([devture_postgres_container_network] if devture_postgres_enabled and nextcloud_database_hostname == devture_postgres_identifier and nextcloud_container_network != devture_postgres_container_network else [])
+      +
+      ([redis_container_network] if redis_enabled and nextcloud_redis_enabled and nextcloud_redis_hostname == redis_identifier else [])
+    ) | unique
   }}
 
 nextcloud_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
@@ -753,6 +759,9 @@ nextcloud_database_hostname: "{{ devture_postgres_identifier if devture_postgres
 nextcloud_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
 nextcloud_database_username: "nextcloud"
 nextcloud_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nextcloud', rounds=655555) | to_uuid }}"
+
+nextcloud_redis_enabled: false
+nextcloud_redis_hostname: "{{ redis_identifier if redis_enabled and nextcloud_redis_enabled else '' }}"
 
 ########################################################################
 #                                                                      #


### PR DESCRIPTION
I've made some changes to add redis support to nextcloud. I still got some comments/questions. Could you guys give some feedback?

### Open issues

- [x]  Change needs https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/pull/1 and update of `requirements.yml`.
- [x] I'm not sure if it should be enabled by default. Maybe you guys got an opinion on that? Redis docs claims: `Enabling the Redis database service will automatically wire all other services to use it`. So either the docs for redis need to be changed or the docs for nextcloud.

### Comments
- `nextcloud_redis_enabled` is a new variable made in `group_vars/mash_servers`. I'm not sure if it's the right place to put it because I'm not very into ansible yet.