### PR TITLE
Update requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -85,7 +85,7 @@
   version: v21.0.2-0
   name: keycloak
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-lago.git
-  version: v0.29.0-0
+  version: v0.29.1-0
   name: lago
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-mariadb.git
   version: v10.11.2-0


### PR DESCRIPTION
Reference to non-existent tag. Updating version `v0.29.1-0`  allows `just roles` to complete successfully.