### PR TITLE
Adds support for n8n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 # ignore roles pulled by ansible-galaxy
 /roles/galaxy/*
 !/roles/galaxy/.gitkeep
+
+# ignores vscode file
+.vscode
+
+# ingores macos files
+.DS_Store

--- a/docs/services/n8n.md
+++ b/docs/services/n8n.md
@@ -1,0 +1,41 @@
+# n8n
+
+[n8n](https://n8n.io/) is a workflow automation tool for technical people.
+
+## Dependencies
+
+This service requires the following other services:
+
+-   a [Postgres](postgres.md) database
+-   a [Traefik](traefik.md) reverse-proxy server
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# n8n                                                                  #
+#                                                                      #
+########################################################################
+
+n8n_enabled: true
+
+n8n_hostname: mash.example.com
+n8n_path_prefix: /n8n
+
+########################################################################
+#                                                                      #
+# /n8n                                                                 #
+#                                                                      #
+########################################################################
+```
+
+In the example configuration above, we configure the service to be hosted at `https://mash.example.com/n8n`.
+
+You can remove the `n8n_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
+
+## Usage
+
+You can create additional users (admin-privileged or not) after logging in.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -31,6 +31,7 @@
 | [Mosquitto](https://mosquitto.org/) | An open-source MQTT broker | [Link](services/mosquitto.md) |
 | [Miniflux](https://miniflux.app/) | Minimalist and opinionated feed reader. | [Link](services/miniflux.md) |
 | [Mobilizon](https://joinmobilizon.org/en/) | An ActivityPub/Fediverse server to create and share events. | [Link](services/mobilizon.md) |
+| [n8n](https://n8n.io/) | Workflow automation for technical people. | [Link](services/n8n.md) |
 | [Navidrome](https://www.navidrome.org/) | [Subsonic-API](http://www.subsonic.org/pages/api.jsp) compatible music server | [Link](services/navidrome.md)
 | [NetBox](https://docs.netbox.dev/en/stable/) | Web application that provides [IP address management (IPAM)](https://en.wikipedia.org/wiki/IP_address_management) and [data center infrastructure management (DCIM)](https://en.wikipedia.org/wiki/Data_center_management#Data_center_infrastructure_management) functionality | [Link](services/netbox.md) |
 | [Nextcloud](https://nextcloud.com/) | The most popular self-hosted collaboration solution for tens of millions of users at thousands of organizations across the globe. | [Link](services/nextcloud.md) |

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -155,6 +155,8 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': (mrs_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'mrs']}] if mrs_enabled else [])
     +
+    ([{'name': (n8n_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'n8n']}] if n8n_enabled else [])
+    +
     ([{'name': (navidrome_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'navidrome']}] if navidrome_enabled else [])
     +
     ([{'name': (netbox_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'netbox', 'netbox-server']}] if netbox_enabled else [])
@@ -235,6 +237,8 @@ devture_postgres_systemd_services_to_stop_for_maintenance_list: |
   {{
     ([(miniflux_identifier + '.service')] if miniflux_enabled else [])
     +
+    ([(n8n_identifier + '.service')] if n8n_enabled else [])
+    +
     ([(redmine_identifier + '.service')] if redmine_enabled else [])
   }}
 
@@ -304,6 +308,12 @@ devture_postgres_managed_databases_auto: |
       'username': redmine_database_username,
       'password': redmine_database_password,
     }] if redmine_enabled else [])
+    +
+    ([{
+      'name': n8n_database_name,
+      'username': n8n_database_username,
+      'password': n8n_database_password,
+    }] if n8n_enabled else [])
     +
     ([{
       'name': netbox_database_name,
@@ -1308,6 +1318,14 @@ hubsite_service_miniflux_logo_location: "{{ role_path }}/assets/miniflux.png"
 hubsite_service_miniflux_description: "An opinionated feed reader"
 hubsite_service_miniflux_priority: 1000
 
+# n8n
+hubsite_service_n8n_enabled: "{{ n8n_enabled }}"
+hubsite_service_n8n_name: n8n
+hubsite_service_n8n_url: "https://{{ n8n_hostname }}{{ n8n_path_prefix }}"
+hubsite_service_n8n_logo_location: "{{ role_path }}/assets/n8n.png"
+hubsite_service_n8n_description: "Workflow automation for technical people."
+hubsite_service_n8n_priority: 1000
+
 # Nextcloud
 hubsite_service_nextcloud_enabled: "{{ nextcloud_enabled }}"
 hubsite_service_nextcloud_name: Nextcloud
@@ -1400,6 +1418,8 @@ hubsite_service_list_auto: |
     ([{'name': hubsite_service_keycloak_name, 'url': hubsite_service_keycloak_url, 'logo_location': hubsite_service_keycloak_logo_location, 'description': hubsite_service_keycloak_description, 'priority': hubsite_service_keycloak_priority}] if hubsite_service_keycloak_enabled else [])
     +
     ([{'name': hubsite_service_miniflux_name, 'url': hubsite_service_miniflux_url, 'logo_location': hubsite_service_miniflux_logo_location, 'description': hubsite_service_miniflux_description, 'priority': hubsite_service_miniflux_priority}] if hubsite_service_miniflux_enabled else [])
+    +
+    ([{'name': hubsite_service_n8n_name, 'url': hubsite_service_n8n_url, 'logo_location': hubsite_service_n8n_logo_location, 'description': hubsite_service_n8n_description, 'priority': hubsite_service_n8n_priority}] if hubsite_service_n8n_enabled else [])
     +
     ([{'name': hubsite_service_nextcloud_name, 'url': hubsite_service_nextcloud_url, 'logo_location': hubsite_service_nextcloud_logo_location, 'description': hubsite_service_nextcloud_description, 'priority': hubsite_service_nextcloud_priority}] if hubsite_service_nextcloud_enabled else [])
     +
@@ -1848,6 +1868,51 @@ mrs_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_
 ########################################################################
 #                                                                      #
 # /mrs                                                                 #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# n8n                                                                  #
+#                                                                      #
+########################################################################
+
+n8n_enabled: false
+
+n8n_identifier: "{{ mash_playbook_service_identifier_prefix }}n8n"
+
+n8n_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}n8n"
+
+n8n_uid: "{{ mash_playbook_uid }}"
+n8n_gid: "{{ mash_playbook_gid }}"
+
+n8n_systemd_required_services_list: |
+  {{
+    (['docker.service'])
+    +
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and n8n_database_hostname == devture_postgres_identifier else [])
+  }}
+
+n8n_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([devture_postgres_container_network] if devture_postgres_enabled and n8n_database_hostname == devture_postgres_identifier and n8n_container_network != devture_postgres_container_network else [])
+  }}
+
+n8n_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+n8n_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+n8n_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+n8n_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+n8n_database_hostname: "{{ devture_postgres_connection_hostname if devture_postgres_enabled else '' }}"
+n8n_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'n8n.db', rounds=655555) | to_uuid }}"
+
+########################################################################
+#                                                                      #
+# /n8n                                                                 #
 #                                                                      #
 ########################################################################
 

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -1885,8 +1885,10 @@ n8n_identifier: "{{ mash_playbook_service_identifier_prefix }}n8n"
 
 n8n_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}n8n"
 
-n8n_uid: "{{ mash_playbook_uid }}"
-n8n_gid: "{{ mash_playbook_gid }}"
+# Please see the note attached to this comment on why we can't use mash's playbook uid and gid
+# https://github.com/kinduff/ansible-docker-n8n/blob/v1.4.2/defaults/main.yml
+n8n_uid: "1000"
+n8n_gid: "1000"
 
 n8n_systemd_required_services_list: |
   {{

--- a/requirements.yml
+++ b/requirements.yml
@@ -103,7 +103,7 @@
 - src: git+https://gitlab.com/etke.cc/roles/miniflux.git
   version: v2.0.45-0
 - src: git+https://github.com/kinduff/ansible-docker-n8n.git
-  version: v1.4.1
+  version: v1.4.2
   name: n8n
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-mobilizon.git
   version: v3.1.0-2

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,4 @@
 ---
-
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-adguard-home.git
   version: v0.107.26-1
   name: adguard_home
@@ -103,6 +102,9 @@
   name: mariadb
 - src: git+https://gitlab.com/etke.cc/roles/miniflux.git
   version: v2.0.45-0
+- src: git+https://github.com/kinduff/ansible-docker-n8n.git
+  version: v1.4.1
+  name: n8n
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-mobilizon.git
   version: v3.1.0-2
   name: mobilizon

--- a/setup.yml
+++ b/setup.yml
@@ -90,6 +90,8 @@
 
     - role: galaxy/mrs
 
+    - role: galaxy/n8n
+
     - role: galaxy/healthchecks
 
     - role: galaxy/infisical


### PR DESCRIPTION
This PR adds support to n8n using a custom role I made at ([kinduff/ansible-docker-n8n](https://github.com/kinduff/ansible-docker-n8n)).

Works like a charm, I have an instance up and running in production in my main server (works in my server, lol).

There's a big caveat and I need an advice:

The n8n Docker image uses UID and GID 1000 for the user `node` internally. This cannot be remapped as it executes `chown` and `setgroups` commands. I tried a good amount of things but all are related to modifying or extending their existing Docker image which is not ideal. Are there any other roles in this playbook that had this problem?

Besides that, works good if you specify in your config the UID and GID n8n needs:

```yml
n8n_uid: "1000"
n8n_gid: "1000"
```