### PR TITLE
Changed startup priority for Keycloak

### DIFF
--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -198,7 +198,7 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': (jitsi_identifier + '-jvb.service'), 'priority': 4100, 'groups': ['mash', 'jitsi', 'jitsi-jvb']}] if jitsi_enabled else [])
     +
-    ([{'name': (keycloak_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'keycloak']}] if keycloak_enabled else [])
+    ([{'name': (keycloak_identifier + '.service'), 'priority': 1000, 'groups': ['mash', 'keycloak']}] if keycloak_enabled else [])
     +
     ([{'name': (lago_identifier + '-api.service'), 'priority': 2000, 'groups': ['mash', 'lago', 'lago-api']}] if lago_enabled else [])
     +


### PR DESCRIPTION
Allows keycloak to start up before services that may depend on it.