### PR TITLE
Add Roundcube

### DIFF
--- a/docs/services/roundcube.md
+++ b/docs/services/roundcube.md
@@ -1,0 +1,55 @@
+# Roundcube
+
+[Roundcube](https://roundcube.net/) is a browser-based multilingual IMAP client with an application-like user interface. It provides full functionality you expect from an email client, including MIME support, address book, folder manipulation, message searching and spell checking.
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Postgres](postgres.md) database
+- a [Traefik](traefik.md) reverse-proxy server
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# roundcube                                                            #
+#                                                                      #
+########################################################################
+
+roundcube_enabled: true
+
+roundcube_hostname: mash.example.com
+
+roundcube_path_prefix: "/roundcube"
+
+# The default IMAP server to connect to.
+roundcube_default_imap_host: "imap.example.com"
+# If not specified, the default port is 143.
+roundcube_default_imap_port: "143"
+
+# The default SMTP server to use.
+roundcube_smtp_server: "smtp.example.com"
+# If not specified, the default port is 587.
+roundcube_smtp_port: "587"
+
+########################################################################
+#                                                                      #
+# /roundcube                                                           #
+#                                                                      #
+########################################################################
+```
+
+In the example configuration above, we configure the service to be hosted at `https://mash.example.com/roundcube`.
+
+You can remove the `roundcube_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
+
+
+## Usage
+
+After installation, you should be able to access your new Roundcube instance at the configured URL (see above).
+
+The username/password you will use to login are the same ones used in your IMAP server.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -64,6 +64,7 @@
 | [WireGuard Easy](https://github.com/WeeJeWel/wg-easy) | The easiest way to run [WireGuard](https://www.wireguard.com/) VPN + Web-based Admin UI. | [Link](services/wg-easy.md) |
 | [Forgejo](https://forgejo.org/) | An alternative fork of Gitea. Easy and painless self-hosted git server. | [Link](services/forgejo.md) |
 | [Woodpecker CI](https://woodpecker-ci.org/) | A simple Continuous Integration (CI) engine with great extensibility. | [Link](services/woodpecker-ci.md) |
+| [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | System-related | A collection of various system-related components | [Link](services/system.md) |
 
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -54,6 +54,7 @@
 | [Radicale](https://radicale.org/) | A Free and Open-Source CalDAV and CardDAV Server (solution for hosting contacts and calendars) | [Link](services/radicale.md) |
 | [Redmine](https://redmine.org/) | A flexible project management web application. | [Link](services/redmine.md) |
 | [Redis](https://redis.io/) | An in-memory data store used by millions of developers as a database, cache, streaming engine, and message broker. | [Link](services/redis.md) |
+| [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | [rumqttd](https://github.com/bytebeamio/rumqtt) | A high performance, embeddable [MQTT](https://en.wikipedia.org/wiki/MQTT) broker | [Link](services/rumqttd.md) |
 | [Soft Serve](https://github.com/charmbracelet/soft-serve) | A tasty, self-hostable [Git](https://git-scm.com/) server for the command line | [Link](services/soft-serve.md) |
 | [Syncthing](https://syncthing.net/) | A continuous file synchronization program which synchronizes files between two or more computers in real time | [Link](services/syncthing.md) |
@@ -64,7 +65,6 @@
 | [WireGuard Easy](https://github.com/WeeJeWel/wg-easy) | The easiest way to run [WireGuard](https://www.wireguard.com/) VPN + Web-based Admin UI. | [Link](services/wg-easy.md) |
 | [Forgejo](https://forgejo.org/) | An alternative fork of Gitea. Easy and painless self-hosted git server. | [Link](services/forgejo.md) |
 | [Woodpecker CI](https://woodpecker-ci.org/) | A simple Continuous Integration (CI) engine with great extensibility. | [Link](services/woodpecker-ci.md) |
-| [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | System-related | A collection of various system-related components | [Link](services/system.md) |
 
 

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -264,6 +264,8 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': (redis_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'redis']}] if redis_enabled else [])
     +
+    ([{'name': (roundcube_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'roundcube']}] if roundcube_enabled else [])
+    +
     ([{'name': (rumqttd_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'rumqttd']}] if rumqttd_enabled else [])
     +
     ([{'name': (soft_serve_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'soft-serve']}] if soft_serve_enabled else [])
@@ -279,8 +281,6 @@ devture_systemd_service_manager_services_list_auto: |
     ([{'name': (wg_easy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wg-easy']}] if wg_easy_enabled else [])
     +
     ([{'name': (forgejo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo', 'forgejo-server']}] if forgejo_enabled else [])
-    +
-    ([{'name': (roundcube_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'roundcube']}] if roundcube_enabled else [])
   }}
 
 ########################################################################

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -2812,6 +2812,57 @@ redis_gid: "{{ mash_playbook_gid }}"
 #                                                                      #
 ########################################################################
 
+
+
+########################################################################
+#                                                                      #
+# roundcube                                                            #
+#                                                                      #
+########################################################################
+
+roundcube_enabled: false
+
+roundcube_identifier: "{{ mash_playbook_service_identifier_prefix }}roundcube"
+
+roundcube_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}roundcube"
+
+roundcube_uid: "0"
+roundcube_gid: "0"
+
+roundcube_database_type: "{{ 'postgresql' if devture_postgres_enabled else 'sqlite' }}"
+roundcube_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
+roundcube_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
+roundcube_database_name: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
+roundcube_database_username: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
+roundcube_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.roundcube', rounds=655555) | to_uuid }}"
+
+roundcube_systemd_required_systemd_services_list: |
+  {{
+    (['docker.service'])
+    +
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier else [])
+  }}
+
+roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+roundcube_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+roundcube_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+roundcube_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([devture_postgres_container_network] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier and roundcube_container_network != devture_postgres_container_network else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /roundcube                                                           #
+#                                                                      #
+########################################################################
+
+
+
 ########################################################################
 #                                                                      #
 # rumqttd                                                              #
@@ -2832,6 +2883,7 @@ rumqttd_gid: "{{ mash_playbook_gid }}"
 # /rumqttd                                                             #
 #                                                                      #
 ########################################################################
+
 
 
 ########################################################################
@@ -2916,6 +2968,7 @@ telegraf_systemd_required_services_list: |
 # /telegraf                                                            #
 #                                                                      #
 ########################################################################
+
 
 
 ########################################################################
@@ -3029,6 +3082,8 @@ wg_easy_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResol
 #                                                                      #
 ########################################################################
 
+
+
 ########################################################################
 #                                                                      #
 # forgejo                                                             #
@@ -3073,6 +3128,7 @@ forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret
 # /forgejo                                                               #
 #                                                                      #
 ########################################################################
+
 
 
 ########################################################################
@@ -3162,52 +3218,5 @@ devture_woodpecker_ci_agent_config_agent_secret: "{{ devture_woodpecker_ci_serve
 ########################################################################
 #                                                                      #
 # /woodpecker-ci-agent                                                 #
-#                                                                      #
-########################################################################
-
-########################################################################
-#                                                                      #
-# roundcube                                                            #
-#                                                                      #
-########################################################################
-
-roundcube_enabled: false
-
-roundcube_identifier: "{{ mash_playbook_service_identifier_prefix }}roundcube"
-
-roundcube_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}roundcube"
-
-roundcube_uid: "0"
-roundcube_gid: "0"
-
-roundcube_database_type: "{{ 'postgresql' if devture_postgres_enabled else 'sqlite' }}"
-roundcube_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
-roundcube_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
-roundcube_database_name: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
-roundcube_database_username: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
-roundcube_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.roundcube', rounds=655555) | to_uuid }}"
-
-roundcube_systemd_required_systemd_services_list: |
-  {{
-    (['docker.service'])
-    +
-    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier else [])
-  }}
-
-roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-roundcube_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
-roundcube_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
-
-roundcube_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([devture_postgres_container_network] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier and roundcube_container_network != devture_postgres_container_network else [])
-  }}
-
-########################################################################
-#                                                                      #
-# /roundcube                                                           #
 #                                                                      #
 ########################################################################

--- a/group_vars/mash_servers
+++ b/group_vars/mash_servers
@@ -279,6 +279,8 @@ devture_systemd_service_manager_services_list_auto: |
     ([{'name': (wg_easy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wg-easy']}] if wg_easy_enabled else [])
     +
     ([{'name': (forgejo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo', 'forgejo-server']}] if forgejo_enabled else [])
+    +
+    ([{'name': (roundcube_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'roundcube']}] if roundcube_enabled else [])
   }}
 
 ########################################################################
@@ -449,6 +451,12 @@ devture_postgres_managed_databases_auto: |
      'username': forgejo_config_database_username,
      'password': forgejo_config_database_password,
     }] if forgejo_enabled else [])
+    +
+    ([{
+     'name': roundcube_database_name,
+     'username': roundcube_database_username,
+     'password': roundcube_database_password,
+    }] if roundcube_enabled and roundcube_database_hostname == devture_postgres_identifier else [])
   }}
 
 ########################################################################
@@ -3157,3 +3165,49 @@ devture_woodpecker_ci_agent_config_agent_secret: "{{ devture_woodpecker_ci_serve
 #                                                                      #
 ########################################################################
 
+########################################################################
+#                                                                      #
+# roundcube                                                            #
+#                                                                      #
+########################################################################
+
+roundcube_enabled: false
+
+roundcube_identifier: "{{ mash_playbook_service_identifier_prefix }}roundcube"
+
+roundcube_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}roundcube"
+
+roundcube_uid: "0"
+roundcube_gid: "0"
+
+roundcube_database_type: "{{ 'postgresql' if devture_postgres_enabled else 'sqlite' }}"
+roundcube_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
+roundcube_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
+roundcube_database_name: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
+roundcube_database_username: "{{ 'roundcube' if devture_postgres_enabled else '' }}"
+roundcube_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.roundcube', rounds=655555) | to_uuid }}"
+
+roundcube_systemd_required_systemd_services_list: |
+  {{
+    (['docker.service'])
+    +
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier else [])
+  }}
+
+roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+roundcube_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+roundcube_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+roundcube_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([devture_postgres_container_network] if devture_postgres_enabled and roundcube_database_hostname == devture_postgres_identifier and roundcube_container_network != devture_postgres_container_network else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /roundcube                                                           #
+#                                                                      #
+########################################################################

--- a/requirements.yml
+++ b/requirements.yml
@@ -196,6 +196,6 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-wg-easy.git
   version: v7-0
   name: wg_easy
-- src: git+https://git.sr.ht/~sergiodj/ansible-role-roundcube
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-roundcube.git
   version: v1.6.3-0
   name: roundcube

--- a/requirements.yml
+++ b/requirements.yml
@@ -196,3 +196,6 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-wg-easy.git
   version: v7-0
   name: wg_easy
+- src: git+https://git.sr.ht/~sergiodj/ansible-role-roundcube
+  version: v1.6.3-0
+  name: roundcube

--- a/setup.yml
+++ b/setup.yml
@@ -163,6 +163,8 @@
     - role: galaxy/com.devture.ansible.role.woodpecker_ci_server
     - role: galaxy/com.devture.ansible.role.woodpecker_ci_agent
 
+    - role: galaxy/roundcube
+
     - role: galaxy/auxiliary
 
     - when: devture_systemd_service_manager_enabled | bool


### PR DESCRIPTION
This PR adds initial support for Roundcube.

The ansible role lives at
https://git.sr.ht/~sergiodj/ansible-role-roundcube ; I would really
appreciate any feedback you might have about it as well.

I did my tests using a local VM, and unfortunately I haven't been able
to test some of the more advanced stuff yet (like using a different
path prefix).  I'll see if I can perform some more extensive tests
meanwhile.

As I mentioned in the mash-playbook Matrix room, I did my best to try
to run the container as non-root but doing so proved to be harder than
expected.  For that reason, the UID/GID of the service is currently
set to `0`.  If you have any ideas/suggestions on how to improve this
specific situation, I'm all ears.

Thanks in advance.