### PR TITLE
Document workaround needed for Adguard Home

### DIFF
--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -97,6 +97,7 @@ mar 02 19:11:59 $hostname mash-adguard-home[872496]: 2024/03/02 18:11:59.706257 
 You can get around this issue by using the following workaround which changes the user to root for the first time setup and then changes it back. You will need root to run the commands so unless you're already root, prepend the commands with `sudo` or change to root with `su`.   
 
 1. Edit `/etc/systemd/system/mash-adguard-home.service` and remove the line `--user=996:3992 \`
+	
 	```
 	ExecStartPre=/usr/bin/env docker create \
 	                        --rm \

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -109,7 +109,7 @@ You can get around this issue by using the following workaround which changes th
 3. Run `systemctl restart mash-adguard-home` to restart the service
 4. Perform the first time setup as documented under [usage](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/adguard-home.md#usage)
 5. Run `systemctl stop mash-adguard-home` to stop the service
-6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the permissions before and after running `chrown`.
+6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the file ownership before and after running `chrown`.
 7. Edit `/etc/systemd/system/mash-adguard-home.service` and add the line `--user=996:3992 \` back
 8. Run `systemctl daemon-reload` to reload systemd
 9. Run `systemctl restart mash-adguard-home` to restart the service

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -87,7 +87,7 @@ Things you should consider doing later:
 
 ## Troubleshooting and workaround
 
-Adguard Home does currently support being setup with a non-root account (see [issue](https://github.com/AdguardTeam/AdGuardHome/issues/4714)). As the playbook uses the user 'mash', meaning you will encounter the following error when it tries to start for the first time: 
+Adguard Home does currently support being setup with a non-root account (see [issue](https://github.com/AdguardTeam/AdGuardHome/issues/4714)). As the playbook uses the user `mash`, meaning you will encounter the following error when it tries to start for the first time: 
 
 ```
 mar 02 19:11:59 $hostname mash-adguard-home[872496]: 2024/03/02 18:11:59.706251 [info] Checking if AdGuard Home has necessary permissions

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -96,21 +96,19 @@ mar 02 19:11:59 $hostname mash-adguard-home[872496]: 2024/03/02 18:11:59.706257 
 
 You can get around this issue by using the following workaround which changes the user to root for the first time setup and then changes it back. You will need root to run the commands so unless you're already root, prepend the commands with `sudo` or change to root with `su`.   
 
-1. Edit `/etc/systemd/system/mash-adguard-home.service` and remove or comment out the line `--user=996:3992 \`
+1. Edit `/etc/systemd/system/mash-adguard-home.service` and remove or comment out the line starting with `--user` (e.g. `--user=996:3992 \` - the numbers represent the uid/gid of the `mash` user, so your values may be different):
 	
 	```
 	ExecStartPre=/usr/bin/env docker create \
 	                        --rm \
 	                        --name=mash-adguard-home \
 	                        --log-driver=none \
-	                        --user=996:3992 \  <--- remove temorarily
+	                        --user=996:3992 \  <--- remove temporarily
 	```
 2. Run `systemctl daemon-reload` to reload systemd
 3. Run `systemctl restart mash-adguard-home` to restart the service
 4. Perform the first time setup as documented under [usage](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/adguard-home.md#usage)
 5. Run `systemctl stop mash-adguard-home` to stop the service
 6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the file ownership before and after running `chown`.
-7. Edit `/etc/systemd/system/mash-adguard-home.service` and add or uncomment the line `--user=996:3992 \` back
-8. Run `systemctl daemon-reload` to reload systemd
-9. Run `systemctl restart mash-adguard-home` to restart the service
-10. Check that the service is running correctly with `journalctl -fu mash-adguard-home`
+7. Run the playbook again to rebuild `/etc/systemd/system/mash-adguard-home.service` and start AdGuard Home again: `just install-service adguard-home`
+8. If you didn't get any errors, Adguard Home should be running correctly. You can also check on the service with: `journalctl -fu mash-adguard-home`

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -109,7 +109,7 @@ You can get around this issue by using the following workaround which changes th
 3. Run `systemctl restart mash-adguard-home` to restart the service
 4. Perform the first time setup as documented under [usage](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/adguard-home.md#usage)
 5. Run `systemctl stop mash-adguard-home` to stop the service
-6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the file ownership before and after running `chrown`.
+6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the file ownership before and after running `chown`.
 7. Edit `/etc/systemd/system/mash-adguard-home.service` and add the line `--user=996:3992 \` back
 8. Run `systemctl daemon-reload` to reload systemd
 9. Run `systemctl restart mash-adguard-home` to restart the service

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -96,7 +96,7 @@ mar 02 19:11:59 $hostname mash-adguard-home[872496]: 2024/03/02 18:11:59.706257 
 
 You can get around this issue by using the following workaround which changes the user to root for the first time setup and then changes it back. You will need root to run the commands so unless you're already root, prepend the commands with `sudo` or change to root with `su`.   
 
-1. Edit `/etc/systemd/system/mash-adguard-home.service` and remove the line `--user=996:3992 \`
+1. Edit `/etc/systemd/system/mash-adguard-home.service` and remove or comment out the line `--user=996:3992 \`
 	
 	```
 	ExecStartPre=/usr/bin/env docker create \
@@ -110,7 +110,7 @@ You can get around this issue by using the following workaround which changes th
 4. Perform the first time setup as documented under [usage](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/adguard-home.md#usage)
 5. Run `systemctl stop mash-adguard-home` to stop the service
 6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the file ownership before and after running `chown`.
-7. Edit `/etc/systemd/system/mash-adguard-home.service` and add the line `--user=996:3992 \` back
+7. Edit `/etc/systemd/system/mash-adguard-home.service` and add or uncomment the line `--user=996:3992 \` back
 8. Run `systemctl daemon-reload` to reload systemd
 9. Run `systemctl restart mash-adguard-home` to restart the service
 10. Check that the service is running correctly with `journalctl -fu mash-adguard-home`

--- a/docs/services/adguard-home.md
+++ b/docs/services/adguard-home.md
@@ -107,7 +107,7 @@ You can get around this issue by using the following workaround which changes th
 	```
 2. Run `systemctl daemon-reload` to reload systemd
 3. Run `systemctl restart mash-adguard-home` to restart the service
-4. Perform the first time setup as documented under [usage](https://github.com/QEDeD/mash-playbook/edit/main/docs/services/adguard-home.md#usage)
+4. Perform the first time setup as documented under [usage](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/adguard-home.md#usage)
 5. Run `systemctl stop mash-adguard-home` to stop the service
 6. Run `chown -R mash:mash /mash/adguard-home/workdir` to change ownership of the files created during the first time setup from `root` to `mash`. Optionally Use `ls -ll /mash/adguard-home/workdir` check the permissions before and after running `chrown`.
 7. Edit `/etc/systemd/system/mash-adguard-home.service` and add the line `--user=996:3992 \` back


### PR DESCRIPTION
Adguard Home can't perform first time setup without root. This PR documents a workaround for this issue by running the container as root initially and change the user back afterwards.