### PR TITLE
Add support for wallabag

### DIFF
--- a/docs/services/wallabag.md
+++ b/docs/services/wallabag.md
@@ -1,0 +1,70 @@
+# Wallabag
+[Wallabag](https://wallabag.org/) is a self-hosted application for saving web pages to read them later.
+
+This role is **not** affiliated with the Wallabag project. 
+
+The role is created by [Bergrübe](https://github.com/Bergruebe/ansible-role-wallabag) with information from the official [documentation](https://doc.wallabag.org/en/) and the [Wallabag Docker Hub page](https://hub.docker.com/r/wallabag/wallabag/).
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Traefik](traefik.md) reverse-proxy server
+- (optional) the [Postgres](postgres.md) database server
+- (optional) the [exim-relay](exim-relay.md) mailer
+
+Wallabag can be run with a sqlite database, but if the Postgres database is activated, it will be used automatically.
+With manual configuration, you can also use [MariaDB](mariadb.md) instead of Postgres.
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# wallabag                                                             #
+#                                                                      #
+########################################################################
+
+wallabag_enabled: true
+wallabag_domain: "wallabag.example.com"
+
+wallabag_locale: 'en'
+
+# Put something random in here
+wallabag_secret: ''
+
+########################################################################
+#                                                                      #
+# /wallabag                                                            #
+#                                                                      #
+########################################################################
+```
+
+## Email configuration
+If the exim-relay mailer is enabled, the role will automatically configure Wallabag to use it.
+If you want to use a different mailer, you can configure it manually with following variables:
+
+```yaml
+wallabag_mailer_dsn: "smtp://user:pass@smtp.example.com:465"
+wallabag_from_email: "wallabag@example.com"
+wallabag_twofactor_sender: "wallabag@example.com"
+```
+You can find more information in the Wallabag [documentation](https://doc.wallabag.org/en/admin/mailer).
+
+## Manual database configuration
+If you don't want to use the by the playbook managed Postgres database, you can configure Wallabag to use a different database with the following variables:
+```yaml
+wallabag_database_driver: "pdo_pgsql" # or "pdo_mysql" or "pdo_sqlite"
+wallabag_database_hostname: "HOSTNAME"
+wallabag_database_port: "PORT"
+wallabag_database_name: "DATABASE"
+wallabag_database_username: "USERNAME"
+wallabag_database_password: "PASSWORD"
+wallabag_database_charset: "utf8"
+wallabag_database_table_prefix: "wallabag_"
+```
+
+## Usage
+After [installing](../installing.md), you can access Wallabag at your `wallabag_domain` with the default credentials `wallabag:wallabag`.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -76,6 +76,7 @@
 | [Traefik](https://doc.traefik.io/traefik/) | A container-aware reverse-proxy server | [Link](services/traefik.md) |
 | [Vaultwarden](https://github.com/dani-garcia/vaultwarden) | A lightweight unofficial and compatible implementation of the [Bitwarden](https://bitwarden.com/) password manager | [Link](services/vaultwarden.md) |
 | [Uptime-kuma](https://uptime.kuma.pet/) | A fancy self-hosted monitoring tool | [Link](services/uptime-kuma.md) |
+| [Wallabag](https://wallabag.org/) | A self-hosted application for saving web pages to read them later | [Link](services/wallabag.md) |
 | [Wetty](https://github.com/butlerx/wetty) | An SSH terminal over HTTP/HTTPS | [Link](services/wetty.md) |
 | [WireGuard Easy](https://github.com/WeeJeWel/wg-easy) | The easiest way to run [WireGuard](https://www.wireguard.com/) VPN + Web-based Admin UI. | [Link](services/wg-easy.md) |
 | [Forgejo](https://forgejo.org/) | An alternative fork of Gitea. Easy and painless self-hosted git server. | [Link](services/forgejo.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4978,12 +4978,14 @@ wallabag_systemd_required_systemd_services_list: |
     ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and wallabag_database_hostname == devture_postgres_identifier else [])
   }}
 
-wallabag_container_additional_networks: |
+wallabag_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +
     ([devture_postgres_container_network] if devture_postgres_enabled and wallabag_database_hostname == devture_postgres_identifier and wallabag_container_network != devture_postgres_container_network else [])
   }}
+wallabag_container_additional_networks_custom: ""
+wallabag_container_additional_networks: "{{ wallabag_container_additional_networks_auto }}{{ wallabag_container_additional_networks_custom }}"
 
 wallabag_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 wallabag_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -564,6 +564,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (vaultwarden_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'vaultwarden', 'vaultwarden-server']} if vaultwarden_enabled else omit) }}
   # /role-specific:vaultwarden
 
+  # role-specific:wallabag
+  - |-
+    {{ ({'name': (wallabag_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wallabag']} if wallabag_enabled else omit) }}
+  # /role-specific:wallabag
+
   # role-specific:uptime_kuma
   - |-
     {{ ({'name': (uptime_kuma_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'uptime-kuma']} if uptime_kuma_enabled else omit) }}
@@ -879,6 +884,17 @@ mash_playbook_devture_postgres_managed_databases_auto_itemized:
       } if vaultwarden_enabled else omit)
     }}
   # /role-specific:vaultwarden
+
+  # role-specific:wallabag
+  - |-
+    {{
+      ({
+        'name': wallabag_database,
+        'username': wallabag_database_username,
+        'password': wallabag_database_password,
+      } if wallabag_enabled else omit)
+    }}
+  # /role-specific:wallabag
 
   # role-specific:forgejo
   - |-
@@ -2547,6 +2563,16 @@ hubsite_service_vaultwarden_description: "Securely access your passwords"
 hubsite_service_vaultwarden_priority: 1000
 # /role-specific:vaultwarden
 
+# role-specific:wallabag
+# Wallabag
+hubsite_service_wallabag_enabled: "{{ wallabag_enabled }}"
+hubsite_service_wallabag_name: Wallabag
+hubsite_service_wallabag_url: "https://{{ wallabag_hostname }}{{ wallabag_path_prefix }}"
+hubsite_service_wallabag_logo_location: "{{ role_path }}/assets/wallabag.png"
+hubsite_service_wallabag_description: "Save articles to read later"
+hubsite_service_wallabag_priority: 1000
+# /role-specific:wallabag
+
 # role-specific:woodpecker_ci_server
 # Woodpecker CI
 hubsite_service_woodpecker_ci_enabled: "{{ devture_woodpecker_ci_server_enabled }}"
@@ -2896,6 +2922,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_vaultwarden_enabled else omit)
     }}
   # /role-specific:vaultwarden
+
+  # role-specific:wallabag
+  - |-
+    {{
+      ({
+        'name': hubsite_service_wallabag_name,
+        'url': hubsite_service_wallabag_url,
+        'logo_location': hubsite_service_wallabag_logo_location,
+        'description': hubsite_service_wallabag_description,
+        'priority': hubsite_service_wallabag_priority
+      } if hubsite_service_wallabag_enabled else omit)
+    }}
+  # /role-specific:wallabag
 
   # role-specific:woodpecker_ci_server
   - |-
@@ -4913,6 +4952,62 @@ forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret
 #                                                                      #
 ########################################################################
 # /role-specific:forgejo
+
+
+
+# role-specific:wallabag
+########################################################################
+#                                                                      #
+# wallabag                                                             #
+#                                                                      #
+########################################################################
+
+wallabag_enabled: false
+
+wallabag_identifier: "{{ mash_playbook_service_identifier_prefix }}wallabag"
+
+wallabag_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}wallabag"
+
+wallabag_uid: "{{ mash_playbook_uid }}"
+wallabag_gid: "{{ mash_playbook_gid }}"
+
+wallabag_systemd_required_systemd_services_list: |
+  {{
+    (['docker.service'])
+    +
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and wallabag_database_hostname == devture_postgres_identifier else [])
+  }}
+
+wallabag_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([devture_postgres_container_network] if devture_postgres_enabled and wallabag_database_hostname == devture_postgres_identifier and wallabag_container_network != devture_postgres_container_network else [])
+  }}
+
+wallabag_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+wallabag_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+wallabag_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+wallabag_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+
+wallabag_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
+wallabag_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
+wallabag_database_username: "wallabag"
+wallabag_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.wallabag', rounds=655555) | to_uuid }}"
+
+# role-specific:exim_relay
+wallabag_mailser_dsn: "{{ 'smtp://{{ exim_relay_identifier }}' if exim_relay_enabled else '' }}"
+wallabag_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+wallabag_two_factor_sender: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
+########################################################################
+#                                                                      #
+# /wallabag                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:wallabag
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4983,6 +4983,8 @@ wallabag_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +
     ([devture_postgres_container_network] if devture_postgres_enabled and wallabag_database_hostname == devture_postgres_identifier and wallabag_container_network != devture_postgres_container_network else [])
+    +
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and exim_relay_identifier in wallabag_mailser_dsn and wallabag_container_network != exim_relay_container_network) else [])
   }}
 wallabag_container_additional_networks_custom: ""
 wallabag_container_additional_networks: "{{ wallabag_container_additional_networks_auto }}{{ wallabag_container_additional_networks_custom }}"

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -889,10 +889,10 @@ mash_playbook_devture_postgres_managed_databases_auto_itemized:
   - |-
     {{
       ({
-        'name': wallabag_database,
+        'name': wallabag_database_name,
         'username': wallabag_database_username,
         'password': wallabag_database_password,
-      } if wallabag_enabled else omit)
+      } if wallabag_enabled and wallabag_database_hostname == devture_postgres_identifier else omit)
     }}
   # /role-specific:wallabag
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -349,7 +349,7 @@
   name: vaultwarden
   activation_prefix: vaultwarden_
 - src: git+https://github.com/Bergruebe/ansible-role-wallabag.git
-  version: v0.1.0
+  version: v0.1.1
   name: wallabag
   activation_prefix: wallabag_
 - src: git+https://github.com/spatterIight/ansible-role-wetty.git

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -348,6 +348,10 @@
   version: v1.30.5-1
   name: vaultwarden
   activation_prefix: vaultwarden_
+- src: git+https://github.com/Bergruebe/ansible-role-wallabag.git
+  version: v0.1.0
+  name: wallabag
+  activation_prefix: wallabag_
 - src: git+https://github.com/spatterIight/ansible-role-wetty.git
   version: v2.5-0
   name: wetty

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -358,6 +358,10 @@
     - role: galaxy/vaultwarden
     # /role-specific:vaultwarden
 
+    # role-specific:wallabag
+    - role: galaxy/wallabag
+    # /role-specific:wallabag
+
     # role-specific:uptime_kuma
     - role: galaxy/uptime_kuma
     # /role-specific:uptime_kuma


### PR DESCRIPTION
This PR add support for [Wallabag](https://wallabag.org), a read-later service with apps for mobil devices.

I followed mostly the structure of the [GotoSocial Role](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial) and the [Gitea Role](https://github.com/mother-of-all-self-hosting/ansible-role-gitea).

It would be great, if someone could take a look over the treafik configuration. It is my first time working with treafik.

To dos:
- [ ] Add [wallabag logo](https://github.com/wallabag/wallabag/tree/master/web/img) to the [Hubsite role](https://github.com/mother-of-all-self-hosting/ansible-role-hubsite)
- [ ] Add redis configuration (if necessary)