### PR TITLE
Add Calibre-Web role

### DIFF
--- a/docs/services/calibre_web.md
+++ b/docs/services/calibre_web.md
@@ -18,14 +18,14 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# calibre_web                                                            #
+# calibre-web                                                            #
 #                                                                      #
 ########################################################################
 
 calibre_web_enabled: true
 
 calibre_web_hostname: mash.example.com
-calibre_web_path_prefix: /calibre_web
+calibre_web_path_prefix: /calibre-web
 
 # By default, calibre_web will look at the /books directory for your Calibre database.
 #
@@ -38,24 +38,24 @@ calibre_web_path_prefix: /calibre_web
 
 ########################################################################
 #                                                                      #
-# /calibre_web                                                           #
+# /calibre-web                                                           #
 #                                                                      #
 ########################################################################
 ```
 
 ### URL
 
-In the example configuration above, we configure the service to be hosted at `https://mash.example.com/calibre_web`.
+In the example configuration above, we configure the service to be hosted at `https://mash.example.com/calibre-web`.
 
 You can remove the `calibre_web_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
 
 ### Authentication
 
 The default username is `admin` and the default password is `admin123`.
-You'll be able to change the password and add additional users in the web UI.
+You'll be able to change the username and password, and add additional users in the web UI.
 
 On the initial setup screen, enter /books as your calibre library location.
-If you haven't placed a Calibre database in that directory yet, it will error as an invalid location.
+If you haven't placed a Calibre database in that directory on the host yet, it will error as an invalid location.
 
 ### Syncthing integration
 
@@ -104,16 +104,16 @@ syncthing_container_additional_volumes:
 ########################################################################
 ```
 
-Finally, mount the `{{ mash_playbook_base_path }}/storage/books` directory into the calibre_web container as read-only:
+Finally, mount the `{{ mash_playbook_base_path }}/storage/books` directory into the calibre-web container as read-only:
 
 ```yaml
 ########################################################################
 #                                                                      #
-# calibre_web                                                            #
+# calibre-web                                                            #
 #                                                                      #
 ########################################################################
 
-# Other calibre_web configuration..
+# Other calibre-web configuration..
 
 calibre_web_container_additional_volumes:
   - type: bind
@@ -122,14 +122,14 @@ calibre_web_container_additional_volumes:
 
 ########################################################################
 #                                                                      #
-# /calibre_web                                                           #
+# /calibre-web                                                           #
 #                                                                      #
 ########################################################################
 ```
 
 ## Usage
 
-After installation, you can go to the calibre_web URL, as defined in `calibre_web_hostname` and `calibre_web_path_prefix`.
+After installation, you can go to the calibre-web URL, as defined in `calibre_web_hostname` and `calibre_web_path_prefix`.
 
 ## Recommended other services
 

--- a/docs/services/calibre_web.md
+++ b/docs/services/calibre_web.md
@@ -2,6 +2,7 @@
 
 [calibre_web](https://github.com/janeczku/calibre-web) is a web app that offers a clean and intuitive interface for browsing, reading, and downloading eBooks using a valid [Calibre](https://calibre-ebook.com/) database.
 
+**Warning** Paperless-ngx currently [does not support](https://hub.docker.com/r/linuxserver/calibre-web) running the container rootless, therefore the role has not the usual security features of other services provided by this playbook. This put your system more at higher risk as vulnerabilities can have a higher impact.
 
 ## Dependencies
 

--- a/docs/services/calibre_web.md
+++ b/docs/services/calibre_web.md
@@ -1,6 +1,6 @@
 # Calibre-Web
 
-[calibre_web](https://github.com/janeczku/calibre-web) is a web app that offers a clean and intuitive interface for browsing, reading, and downloading eBooks using a valid [Calibre](https://calibre-ebook.com/) database.
+[Calibre-Web](https://github.com/janeczku/calibre-web) is a web app that offers a clean and intuitive interface for browsing, reading, and downloading eBooks using a valid [Calibre](https://calibre-ebook.com/) database.
 
 **Warning** Paperless-ngx currently [does not support](https://hub.docker.com/r/linuxserver/calibre-web) running the container rootless, therefore the role has not the usual security features of other services provided by this playbook. This put your system more at higher risk as vulnerabilities can have a higher impact.
 
@@ -59,7 +59,7 @@ If you haven't placed a Calibre database in that directory on the host yet, it w
 
 ### Syncthing integration
 
-If you've got a [Syncthing](syncthing.md) service running, you can use it to synchronize your music directory onto the server and then mount it as read-only into the calibre_web container.
+If you've got a [Syncthing](syncthing.md) service running, you can use it to synchronize your books directory onto the server and then mount it as read-only into the calibre_web container.
 
 We recommend that you make use of the [aux](auxiliary.md) role to create some shared directory like this:
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -186,6 +186,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (authelia_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authelia']} if authelia_enabled else omit) }}
   # /role-specific:authelia
 
+  # role-specific:calibre_web
+  - |-
+    {{ ({'name': (calibre_web_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'calibre_web']} if calibre_web_enabled else omit) }}
+  # /role-specific:calibre_web
+
   # role-specific:changedetection
   - |-
     {{ ({'name': (changedetection_identifier + '.service'), 'priority': 2100, 'groups': ['mash', 'changedetection']} if changedetection_enabled else omit) }}
@@ -1524,6 +1529,41 @@ wetty_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolve
 #                                                                      #
 ########################################################################
 # /role-specific:wetty
+
+
+
+# role-specific:calibre_web
+########################################################################
+#                                                                      #
+# calibre_web                                                            #
+#                                                                      #
+########################################################################
+
+calibre_web_enabled: false
+
+calibre_web_identifier: "{{ mash_playbook_service_identifier_prefix }}calibre_web"
+
+calibre_web_uid: "{{ mash_playbook_uid }}"
+calibre_web_gid: "{{ mash_playbook_gid }}"
+
+calibre_web_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}calibre_web"
+
+calibre_web_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+calibre_web_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+calibre_web_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+calibre_web_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+calibre_web_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+########################################################################
+#                                                                      #
+# /calibre_web                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:calibre_web
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -186,10 +186,10 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (authelia_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authelia']} if authelia_enabled else omit) }}
   # /role-specific:authelia
 
-  # role-specific:calibre_web
+  # role-specific:calibre-web
   - |-
-    {{ ({'name': (calibre_web_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'calibre_web']} if calibre_web_enabled else omit) }}
-  # /role-specific:calibre_web
+    {{ ({'name': (calibre_web_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'calibre-web']} if calibre_web_enabled else omit) }}
+  # /role-specific:calibre-web
 
   # role-specific:changedetection
   - |-
@@ -1532,21 +1532,21 @@ wetty_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolve
 
 
 
-# role-specific:calibre_web
+# role-specific:calibre-web
 ########################################################################
 #                                                                      #
-# calibre_web                                                            #
+# calibre-web                                                            #
 #                                                                      #
 ########################################################################
 
 calibre_web_enabled: false
 
-calibre_web_identifier: "{{ mash_playbook_service_identifier_prefix }}calibre_web"
+calibre_web_identifier: "{{ mash_playbook_service_identifier_prefix }}calibre-web"
 
 calibre_web_uid: "{{ mash_playbook_uid }}"
 calibre_web_gid: "{{ mash_playbook_gid }}"
 
-calibre_web_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}calibre_web"
+calibre_web_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}calibre-web"
 
 calibre_web_container_additional_networks_auto: |
   {{
@@ -1560,10 +1560,10 @@ calibre_web_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certR
 
 ########################################################################
 #                                                                      #
-# /calibre_web                                                           #
+# /calibre-web                                                           #
 #                                                                      #
 ########################################################################
-# /role-specific:calibre_web
+# /role-specific:calibre-web
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -21,7 +21,7 @@
   name: authelia
   activation_prefix: authelia_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-authentik.git
-  version: v2024.4.1-0
+  version: v2024.2.3-0
   name: authentik
   activation_prefix: authentik_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-aux.git
@@ -29,11 +29,15 @@
   name: auxiliary
   activation_prefix: aux_
 - src: git+https://gitlab.com/etke.cc/roles/backup_borg.git
-  version: v1.2.8-1.8.11-0
+  version: v1.2.8-1.8.10-0
   name: backup_borg
   activation_prefix: backup_borg_
+- src: git+https://github.com/lingawakad/ansible-role-calibre-web.git
+  version: v0.6.21
+  name: calibre-web
+  activation_prefix: calibre-web
 - src: git+https://github.com/nielscil/ansible-role-changedetection.git
-  version: v0.45.21-0
+  version: v0.45.20-0
   name: changedetection
   activation_prefix: changedetection_
 - src: git+https://gitlab.com/etke.cc/roles/cleanup.git
@@ -57,7 +61,7 @@
   name: docker
   activation_prefix: mash_playbook_docker_installation_enabled
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-docker-registry.git
-  version: v2.8.3-2
+  version: v2.8.3-1
   name: docker_registry
   activation_prefix: docker_registry_enabled
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-docker-registry-browser.git
@@ -109,7 +113,7 @@
   name: freshrss
   activation_prefix: freshrss_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-funkwhale.git
-  version: v1.4.0-5
+  version: v1.4.0-4
   name: funkwhale
   activation_prefix: funkwhale_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-gitea.git
@@ -145,7 +149,7 @@
   name: influxdb
   activation_prefix: influxdb_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
-  version: v9457-3
+  version: v9457-2
   name: jitsi
   activation_prefix: jitsi_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-keycloak.git
@@ -177,7 +181,7 @@
   name: mariadb
   activation_prefix: mariadb_
 - src: git+https://gitlab.com/etke.cc/roles/miniflux.git
-  version: v2.1.3-0
+  version: v2.1.2-0
   name: miniflux
   activation_prefix: miniflux_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-mobilizon.git
@@ -201,7 +205,7 @@
   name: n8n
   activation_prefix: n8n_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-navidrome.git
-  version: v0.52.0-0
+  version: v0.51.1-0
   name: navidrome
   activation_prefix: navidrome_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-netbox.git
@@ -345,7 +349,7 @@
   name: traefik
   activation_prefix: devture_traefik_
 - src: git+https://gitlab.com/etke.cc/roles/uptime_kuma.git
-  version: v1.23.13-0
+  version: v1.23.12-0
   name: uptime_kuma
   activation_prefix: uptime_kuma_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-vaultwarden.git

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -33,7 +33,7 @@
   name: backup_borg
   activation_prefix: backup_borg_
 - src: git+https://github.com/lingawakad/ansible-role-calibre-web.git
-  version: v0.6.21
+  version: v0.6.21-0
   name: calibre-web
   activation_prefix: calibre-web
 - src: git+https://github.com/nielscil/ansible-role-changedetection.git

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -126,6 +126,10 @@
     - role: galaxy/wetty
     # /role-specific:wetty
 
+    # role-specific:calibre-web
+    - role: galaxy/calibre-web
+    # /role-specific:calibre-web
+
     # role-specific:clickhouse
     - role: galaxy/clickhouse
     # /role-specific:clickhouse


### PR DESCRIPTION
submitting a role for Calibre-Web, based off [Linuxserver.io image](https://hub.docker.com/r/linuxserver/calibre-web) - which seems to be the ["official" image](https://github.com/janeczku/calibre-web?tab=readme-ov-file#docker-images).

unfortunately, unable to run rootless, but is set to run as the mash user internally like the LSIO images are able to.