### PR TITLE
feat: paperless support exim-relay & generate paperless-secret-key

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4064,6 +4064,8 @@ paperless_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 paperless_uid: "{{ mash_playbook_uid }}"
 paperless_gid: "{{ mash_playbook_gid }}"
 
+paperless_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'paperless_secret_key', rounds=655555) | to_uuid }}"
+
 paperless_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
 paperless_database_username: "paperless"
 paperless_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
@@ -4081,12 +4083,20 @@ paperless_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +
     ([devture_postgres_container_network] if devture_postgres_enabled and paperless_database_hostname == devture_postgres_identifier and paperless_container_network != devture_postgres_container_network else [])
+    +
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and paperless_email_host == exim_relay_identifier | default('mash-exim-relay') and paperless_container_network != exim_relay_container_network) else [])
   }}
 
 paperless_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 paperless_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 paperless_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
 paperless_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+# role-specific:exim_relay
+paperless_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+paperless_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
+paperless_email_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 ########################################################################
 #                                                                      #


### PR DESCRIPTION
Add support in paperless for the exim-relay & generate [paperless-secret-key](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SECRET_KEY).

This PR require that my [PR to the ansible-role-paperless](https://github.com/mother-of-all-self-hosting/ansible-role-paperless/pull/1) to be merged and the new version to be used in the MASH playbook. 