### PR TITLE
Add developer documentation

### DIFF
--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -1,0 +1,216 @@
+# Developer Documentation
+
+## Support a new service | Create your own role
+### 1. Check if the role don't exist allready 
+in [`supported-services.md`](supported-services.md) or someone else is allready [working on it](https://github.com/mother-of-all-self-hosting/mash-playbook/pulls).
+### 2. Check if the service you wish is possible in a docker container and if an docker image allready exists.
+### 3. Create the ansible role in a public git repository.
+You can follow the structure of existing roles, like the [`ansible-role-gitea`](https://github.com/mother-of-all-self-hosting/ansible-role-gitea) or the [`ansible-role-gotosocial`](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial).
+Some Advices:
+ - Your file structure will probably look something like this:
+
+```
+.
+├── defaults/
+│   └── main.yml
+├── meta/
+│   └── main.yml
+├── tasks/
+│   ├── main.yml
+│   ├── install.yml
+│   ├── uninstall.yml
+│   └── validate_config.yml
+├── templates/
+│   ├── env.j2
+│   ├── labels.j2
+│   └── NEW-SERVICE.service.j2
+├── .gitignore
+├── LICENSE
+└── README.md
+
+```
+- You will need to decide for a license, without it ansible-galaxy won't work.
+
+### 4. Update the MASH-Playbook to support your created Ansible role
+There are a few files that you need to adappt:
+ ````
+.
+├── docs/
+│   ├── supported-services.md  -> Add your service
+│   └── services/
+│       └── YOUR-SERVICE.md  -> document how to use it
+├── templates/
+│   ├── group_vars_mash_servers  -> Add default config
+│   └── requirements.yml  -> add your ansible role
+└── VERSIONS.md  -> Add the version of your service
+```
+
+#### `templates/group_vars_mash_servers`
+In this file you define the default options, which are not allready deffined by default in your ansible role and integrate it into the playbook.
+
+```yaml
+# role-specific:systemd_service_manager
+########################################################################
+#                                                                      #
+# systemd_service_manager                                              #
+#                                                                      #
+########################################################################
+
+mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
+  [...]
+  # role-specific:YOUR-SERVICE
+  - |-
+    {{ ({'name': (YOUR-SERVICE_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'YOUR-SERVICE']} if YOUR-SERVICE_enabled else omit) }}
+  # /role-specific:YOUR-SERVICE
+
+[...]
+########################################################################
+#                                                                      #
+# /systemd_service_manager                                             #
+#                                                                      #
+########################################################################
+# /role-specific:systemd_service_manager
+
+```
+##### Support Postgres
+```yaml
+# role-specific:postgres
+########################################################################
+#                                                                      #
+# postgres                                                             #
+#                                                                      #
+########################################################################
+[...]
+
+mash_playbook_devture_postgres_managed_databases_auto_itemized:
+  [...]
+  # role-specific:YOUR-SERVICE
+  - |-
+    {{
+      ({
+        'name': YOUR-SERVICE_database_name,
+        'username': YOUR-SERVICE_database_username,
+        'password': YOUR-SERVICE_database_password,
+      } if gYOUR-SERVICE_enabled else omit)
+    }}
+  # /role-specific:YOUR-SERVICE
+  
+  [...]
+########################################################################
+#                                                                      #
+# /postgres                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:postgres
+
+[...]
+
+# role-specific:YOUR-SERVICE
+########################################################################
+#                                                                      #
+# YOUR-SERVICE                                                         #
+#                                                                      #
+########################################################################
+
+[...]
+
+# role-specific:postgres
+YOUR-SERVICE_database_hostname: "{{ devture_postgres_identifier if devture_postgres_enabled else '' }}"
+YOUR-SERVICE_database_port: "{{ '5432' if devture_postgres_enabled else '' }}"
+YOUR-SERVICE_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authentik', rounds=655555) | to_uuid }}"
+YOUR-SERVICE_database_username: "{{ authentik_identifier }}"
+# /role-specific:postgres
+
+YOUR-SERVICE_container_additional_networks_auto: |
+  {{
+    ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and YOUR-SERVICE_database_hostname == devture_postgres_identifier else [])
+  }}
+
+authentik_container_additional_networks_auto: |
+  {{
+    ([devture_postgres_container_network] if devture_postgres_enabled and authentik_database_hostname == devture_postgres_identifier and authentik_container_network != devture_postgres_container_network else [])
+  }}
+  
+########################################################################
+#                                                                      #
+# /YOUR-SERVICE                                                        #
+#                                                                      #
+########################################################################
+# /role-specific:YOUR-SERVICE
+````
+
+##### Support exim-relay
+The [exim-relay](https://github.com/devture/exim-relay) is an easy way to configure for all services a way for outgoing mail.
+````
+[...]
+
+# role-specific:YOUR-SERVICE
+########################################################################
+#                                                                      #
+# YOUR-SERVICE                                                         #
+#                                                                      #
+########################################################################
+
+[...]
+
+# role-specific:exim_relay
+YOUR-SERVICE_config_mailer_enabled: "{{ 'true' if exim_relay_enabled else '' }}"
+YOUR-SERVICE_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+YOUR-SERVICE_config_mailer_smtp_port: 8025
+YOUR-SERVICE_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+YOUR-SERVICE_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+  
+########################################################################
+#                                                                      #
+# /YOUR-SERVICE                                                        #
+#                                                                      #
+########################################################################
+# /role-specific:YOUR-SERVICE
+```
+
+##### Support hubsite
+- Add the logo of your Service to [`ansible-role-hubsite/assets`](https://github.com/mother-of-all-self-hosting/ansible-role-hubsite/tree/main/assets) via a pull request.
+- configure the `group_vars_mash_servers` file:
+
+```yaml
+[...]
+# role-specific:hubsite
+########################################################################
+#                                                                      #
+# hubsite                                                              #
+#                                                                      #
+########################################################################
+[...]
+
+# Services
+##########
+[...]
+
+# role-specific:YOUR-SERVICE
+# YOUR-SERVICE
+hubsite_service_YOUR-SERVICE_enabled: "{{ YOUR-SERVICE_enabled }}"
+hubsite_service_YOUR-SERVICE_name: Adguard Home
+hubsite_service_YOUR-SERVICE_url: "https://{{ YOUR-SERVICE_hostname }}{{ YOUR-SERVICE_path_prefix }}"
+hubsite_service_YOUR-SERVICE_logo_location: "{{ role_path }}/assets/YOUR-SERVICE.png"
+hubsite_service_YOUR-SERVICE_description: "YOUR-SERVICE Description"
+hubsite_service_YOUR-SERVICE_priority: 1000
+# /role-specific:YOUR-SERVICE
+[...]
+
+mash_playbook_hubsite_service_list_auto_itemized:
+  [...]
+  # role-specific:YOUR-SERVICE
+  - |-
+    {{
+      ({
+        'name': hubsite_service_YOUR-SERVICE_name,
+        'url': hubsite_service_YOUR-SERVICE_url,
+        'logo_location': hubsite_service_YOUR-SERVICE_logo_location,
+        'description': hubsite_service_YOUR-SERVICE_description,
+        'priority': hubsite_service_YOUR-SERVICE_priority,
+      } if hubsite_service_YOUR-SERVICE_enabled else omit)
+    }}
+  # /role-specific:YOUR-SERVICE
+[...]
+```

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -27,13 +27,12 @@ Some Advices:
 ├── .gitignore
 ├── LICENSE
 └── README.md
-
 ```
 - You will need to decide for a license, without it ansible-galaxy won't work.
 
 ### 4. Update the MASH-Playbook to support your created Ansible role
 There are a few files that you need to adappt:
- ````
+ ```
 .
 ├── docs/
 │   ├── supported-services.md  -> Add your service
@@ -141,7 +140,7 @@ authentik_container_additional_networks_auto: |
 
 ##### Support exim-relay
 The [exim-relay](https://github.com/devture/exim-relay) is an easy way to configure for all services a way for outgoing mail.
-````
+```yaml
 [...]
 
 # role-specific:YOUR-SERVICE

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -1,11 +1,13 @@
 # Developer Documentation
 
 ## Support a new service | Create your own role
-### 1. Check if the role don't exist allready 
-in [`supported-services.md`](supported-services.md) or someone else is allready [working on it](https://github.com/mother-of-all-self-hosting/mash-playbook/pulls).
-### 2. Check if the service you wish is possible in a docker container and if an docker image allready exists.
-### 3. Create the ansible role in a public git repository.
+### 1. Check if
+- the role doesn't exist already in [`supported-services.md`](supported-services.md) or if someone else is already [working on it](https://github.com/mother-of-all-self-hosting/mash-playbook/pulls).
+- the service you wish is possible in a docker container
+- a docker image already exists.
+### 2. Create the ansible role in a public git repository.
 You can follow the structure of existing roles, like the [`ansible-role-gitea`](https://github.com/mother-of-all-self-hosting/ansible-role-gitea) or the [`ansible-role-gotosocial`](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial).
+
 Some Advices:
  - Your file structure will probably look something like this:
 
@@ -28,11 +30,11 @@ Some Advices:
 ├── LICENSE
 └── README.md
 ```
-- You will need to decide for a license, without it ansible-galaxy won't work.
+- You will need to decide on a licence, without it, ansible-galaxy won't work.
 
-### 4. Update the MASH-Playbook to support your created Ansible role
-There are a few files that you need to adappt:
- ```
+### 3. Update the MASH-Playbook to support your created Ansible role
+There are a few files that you need to adapt:
+```
 .
 ├── docs/
 │   ├── supported-services.md  -> Add your service
@@ -43,9 +45,10 @@ There are a few files that you need to adappt:
 │   └── requirements.yml  -> add your ansible role
 └── VERSIONS.md  -> Add the version of your service
 ```
+<details>
 
-#### `templates/group_vars_mash_servers`
-In this file you define the default options, which are not allready deffined by default in your ansible role and integrate it into the playbook.
+<summary> file: templates / group_vars_mash_servers </summary>
+In this file you define the default options, which are not already defined by default in your ansible role, and integrate it into the playbook.
 
 ```yaml
 # role-specific:systemd_service_manager
@@ -71,7 +74,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 # /role-specific:systemd_service_manager
 
 ```
-##### Support Postgres
+</details>
+
+<details>
+<summary>Support Postgres</summary>
+
 ```yaml
 # role-specific:postgres
 ########################################################################
@@ -124,11 +131,6 @@ YOUR-SERVICE_container_additional_networks_auto: |
   {{
     ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and YOUR-SERVICE_database_hostname == devture_postgres_identifier else [])
   }}
-
-authentik_container_additional_networks_auto: |
-  {{
-    ([devture_postgres_container_network] if devture_postgres_enabled and authentik_database_hostname == devture_postgres_identifier and authentik_container_network != devture_postgres_container_network else [])
-  }}
   
 ########################################################################
 #                                                                      #
@@ -136,9 +138,10 @@ authentik_container_additional_networks_auto: |
 #                                                                      #
 ########################################################################
 # /role-specific:YOUR-SERVICE
-````
+```
+</details><details>
+<summary>Support exim-relay</summary>
 
-##### Support exim-relay
 The [exim-relay](https://github.com/devture/exim-relay) is an easy way to configure for all services a way for outgoing mail.
 ```yaml
 [...]
@@ -151,6 +154,13 @@ The [exim-relay](https://github.com/devture/exim-relay) is an easy way to config
 ########################################################################
 
 [...]
+
+YOUR-SERVICE_container_additional_networks_auto: |
+  {{
+	[...]
+	+
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and YOUR-SERVICE_config_mailer_smtp_addr == exim_relay_identifier | default('mash-exim-relay') and YOUR-SERVICE_container_network != exim_relay_container_network) else [])
+  }}
 
 # role-specific:exim_relay
 YOUR-SERVICE_config_mailer_enabled: "{{ 'true' if exim_relay_enabled else '' }}"
@@ -167,8 +177,10 @@ YOUR-SERVICE_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}
 ########################################################################
 # /role-specific:YOUR-SERVICE
 ```
+</details><details>
 
-##### Support hubsite
+<summary>Support hubsite</summary>
+
 - Add the logo of your Service to [`ansible-role-hubsite/assets`](https://github.com/mother-of-all-self-hosting/ansible-role-hubsite/tree/main/assets) via a pull request.
 - configure the `group_vars_mash_servers` file:
 
@@ -213,3 +225,9 @@ mash_playbook_hubsite_service_list_auto_itemized:
   # /role-specific:YOUR-SERVICE
 [...]
 ```
+
+</details>
+
+### Advices
+- Add to the file `defaults/main.yml` in your ansible-role somewhere a line with `# Project source code URL: YOUR-SERVICE-GIT-REPO`.
+  Only then [`bin/feeds.py`](/bin/feeds.py) can find automatically the feed for new releases.

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -1,14 +1,19 @@
 # Developer Documentation
 
 ## Support a new service | Create your own role
+
 ### 1. Check if
-- the role doesn't exist already in [`supported-services.md`](supported-services.md) or if someone else is already [working on it](https://github.com/mother-of-all-self-hosting/mash-playbook/pulls).
-- the service you wish is possible in a docker container
-- a docker image already exists.
-### 2. Create the ansible role in a public git repository.
+
+- the role doesn't exist already in [`supported-services.md`](supported-services.md) and no one else is already [working on it](https://github.com/mother-of-all-self-hosting/mash-playbook/pulls)
+
+- the service you wish to add can run in a Docker container
+
+- a container image already exists
+
+### 2. Create the Ansible role in a public git repository.
 You can follow the structure of existing roles, like the [`ansible-role-gitea`](https://github.com/mother-of-all-self-hosting/ansible-role-gitea) or the [`ansible-role-gotosocial`](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial).
 
-Some Advices:
+Some advice:
  - Your file structure will probably look something like this:
 
 ```
@@ -30,9 +35,10 @@ Some Advices:
 ├── LICENSE
 └── README.md
 ```
-- You will need to decide on a licence, without it, ansible-galaxy won't work.
+- You will need to decide on a licence, without it, ansible-galaxy won't work. We recommend AGPLv3, like all of MASH.
 
 ### 3. Update the MASH-Playbook to support your created Ansible role
+
 There are a few files that you need to adapt:
 ```
 .
@@ -42,13 +48,13 @@ There are a few files that you need to adapt:
 │       └── YOUR-SERVICE.md  -> document how to use it
 ├── templates/
 │   ├── group_vars_mash_servers  -> Add default config
-│   └── requirements.yml  -> add your ansible role
-└── VERSIONS.md  -> Add the version of your service
+│   └── requirements.yml  -> add your Ansible role
+│   └── setup.yml  -> add your Ansible role
 ```
 <details>
 
 <summary> file: templates / group_vars_mash_servers </summary>
-In this file you define the default options, which are not already defined by default in your ansible role, and integrate it into the playbook.
+In this file you wire your role with the rest of the playbook - integrating with the service manager or potentially with other roles.
 
 ```yaml
 # role-specific:systemd_service_manager
@@ -228,6 +234,6 @@ mash_playbook_hubsite_service_list_auto_itemized:
 
 </details>
 
-### Advices
-- Add to the file `defaults/main.yml` in your ansible-role somewhere a line with `# Project source code URL: YOUR-SERVICE-GIT-REPO`.
-  Only then [`bin/feeds.py`](/bin/feeds.py) can find automatically the feed for new releases.
+### Additional hints
+
+- Add a line like `# Project source code URL: YOUR-SERVICE-GIT-REPO` to your Ansible role's `defaults/main.yml` file, so that [`bin/feeds.py`](/bin/feeds.py) can automatically find the Atom/RSS feed for new releases.


### PR DESCRIPTION
I tried to create an ansible-role for wallabag, and it was possible for me, who is still quite new to ansible, by just looking into the existing files and roles you already created. But it would have been much easier if there was a documentation on which steps are required to create and add a new service to this great playbook.

I'm not sure if any steps are required for `bin/versions.py` and `bin/optimize.py`.

It would be really great if someone could document how to use traefik in a role. I don't have the knowledge to do that.