### PR TITLE
Add support for couchDB

### DIFF
--- a/docs/services/couchdb.md
+++ b/docs/services/couchdb.md
@@ -1,0 +1,79 @@
+# CouchDB
+
+CouchDB is a NoSQL database that uses JSON for documents.
+This Ansible role is designed to install and configure CouchDB for using the [official CouchDB Docker image](https://github.com/apache/couchdb-docker) via the [ansible-role-couchdb](https://github.com/Bergruebe/ansible-role-couchdb).
+
+**Warning**: This role will not delete or modify existing databases or users. It will only create new databases and users if they do not already exist.
+
+## Features
+
+- Sets up CouchDB in a Docker container.
+- Creates necessary system tables, if `couchdb_config_single_node: true.
+- Adds users as specified in the playbook.
+- Sets database permissions.
+- Integrates with the MASH playbook for easy deployment.
+
+## Usage
+
+To use this role with the MASH playbook, add following lines to your inventory file of your MASH playbook:
+
+```yaml
+########################################################################
+#                                                                      #
+# couchdb                                                              #
+#                                                                      #
+########################################################################
+
+couchdb_enabled:: true
+
+couchdb_hostname: couchdb.example.com
+
+# enable couchdb single node mode, to automatically create databases and users
+couchdb_config_single_node: true
+
+couchdb_admins_custom:
+  - name: admin
+    password: UseASecurePassword
+
+couchdb_users_custom:
+  - name: user1
+    password: UseASecurePassword
+    roles: []
+    type: user
+
+couchdb_tables_custom:
+    - name: my_custom_table
+      permission:
+        admin:
+          names:
+            - user1
+          roles: []
+        member:
+          names: []
+          roles: []
+
+########################################################################
+#                                                                      #
+# /cocuhdb                                                             #
+#                                                                      #
+########################################################################
+```
+
+You can customize the behavior of the role by setting the following variables in your playbook:
+
+- `couchdb_environment_variables_extension`: to add additional environment variables to the CouchDB container.
+- `couchdb_config_extension`: to add additional configuration to the CouchDB configuration
+- `couchdb_config_peruser_enabled`: to enable per-user configuration in CouchDB | default is `true`.
+- `couchdb_config_require_valid_user_except_for_up`: to require a valid user for all requests except for the `_up` endpoint | default is `true`.
+- `couchdb_container_additional_networks_custom`: to add additional networks to the CouchDB container.
+- `couchdb_version`: to specify the version of the CouchDB Docker image to use
+
+For more information on possible configuration, refer to the comments in the [`defaults/main.yml`](https://github.com/Bergruebe/ansible-role-couchdb/blob/master/defaults/main.yml) file.
+
+By default, this role **will not expose the CouchDB port** to the host machine. If you want to access CouchDB from outside the Docker container, you will need to expose the port in your playbook via the `couchdb_container_http_host_bind_port` variable. Or you can just add the container to another docker network via the `couchdb_container_additional_networks_custom` variable.
+Please consider the use of a reverse proxy for secure access to CouchDB.
+
+## Contributing
+
+Contributions are welcome! Please feel free to review the [ansible-role-couchdb](https://github.com/Bergruebe/ansible-role-couchdb) repository and submit a Pull Request.
+

--- a/docs/services/couchdb.md
+++ b/docs/services/couchdb.md
@@ -1,9 +1,11 @@
 # CouchDB
 
-CouchDB is a NoSQL database that uses JSON for documents.
+[CouchDB](https://couchdb.apache.org/) is a NoSQL database that uses JSON for documents.
 This Ansible role is designed to install and configure CouchDB for using the [official CouchDB Docker image](https://github.com/apache/couchdb-docker) via the [ansible-role-couchdb](https://github.com/Bergruebe/ansible-role-couchdb).
 
 **Warning**: This role will not delete or modify existing databases or users. It will only create new databases and users if they do not already exist.
+
+**Warning**: This role **does not automatically integrate with Traefik** yet (see details below). PRs are welcome!
 
 ## Features
 
@@ -24,7 +26,7 @@ To use this role with the MASH playbook, add following lines to your inventory f
 #                                                                      #
 ########################################################################
 
-couchdb_enabled:: true
+couchdb_enabled: true
 
 couchdb_hostname: couchdb.example.com
 
@@ -54,7 +56,7 @@ couchdb_tables_custom:
 
 ########################################################################
 #                                                                      #
-# /cocuhdb                                                             #
+# /couchdb                                                             #
 #                                                                      #
 ########################################################################
 ```
@@ -72,6 +74,8 @@ For more information on possible configuration, refer to the comments in the [`d
 
 By default, this role **will not expose the CouchDB port** to the host machine. If you want to access CouchDB from outside the Docker container, you will need to expose the port in your playbook via the `couchdb_container_http_host_bind_port` variable. Or you can just add the container to another docker network via the `couchdb_container_additional_networks_custom` variable.
 Please consider the use of a reverse proxy for secure access to CouchDB.
+
+Currently, the [ansible-role-couchdb](https://github.com/Bergruebe/ansible-role-couchdb) Ansible role **does not automatically integrate with Traefik**. PRs are welcome!
 
 ## Contributing
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -213,6 +213,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (collabora_online_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'collabora-online']} if collabora_online_enabled else omit) }}
   # /role-specific:collabora_online
 
+  # role-specific:couchdb
+  - |-
+    {{ ({'name': (couchdb_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'couchdb']} if couchdb_enabled else omit) }}
+  # /role-specific:couchdb
+
   # role-specific:postgres
   - |-
     {{ ({'name': (devture_postgres_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'postgres']} if devture_postgres_enabled else omit) }}
@@ -1675,6 +1680,37 @@ collabora_online_container_labels_traefik_tls_certResolver: "{{ devture_traefik_
 #                                                                      #
 ########################################################################
 # /role-specific:collabora_online
+
+
+
+# role-specific:couchdb
+########################################################################
+#                                                                      #
+# couchdb                                                              #
+#                                                                      #
+########################################################################
+couchdb_enabled: false
+
+couchdb_identifier: "{{ mash_playbook_service_identifier_prefix }}couchdb"
+
+couchdb_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}couchdb"
+
+couchdb_uid: "5984"
+couchdb_gid: "5984"
+
+couchdb_admin_user: "{{ mash_playbook_service_identifier_prefix }}admin"
+couchdb_admin_passwd: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.couchdb', rounds=655555) | to_uuid }}"
+couchdb_config_uuid: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'uuid.couchdb', rounds=655555) | to_uuid }}"
+
+couchdb_config_couch_chttpd_auth_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.couchdb', rounds=655555) | to_uuid }}"
+
+
+########################################################################
+#                                                                      #
+# /couchdb                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:couchdb
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1704,7 +1704,6 @@ couchdb_config_uuid: "{{ '%s' | format(mash_playbook_generic_secret_key) | passw
 
 couchdb_config_couch_chttpd_auth_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.couchdb', rounds=655555) | to_uuid }}"
 
-
 ########################################################################
 #                                                                      #
 # /couchdb                                                             #

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -53,7 +53,7 @@
   name: collabora_online
   activation_prefix: collabora_online_
 - src: git+https://github.com/Bergruebe/ansible-role-couchdb.git
-  version: v3.3.3-0
+  version: v3.3.3-1
   name: couchdb
   activation_prefix: couchdb_
 - src: git+https://github.com/devture/com.devture.ansible.role.container_socket_proxy.git

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -52,6 +52,10 @@
   version: v24.04.3.1.1-0
   name: collabora_online
   activation_prefix: collabora_online_
+- src: git+https://github.com/Bergruebe/ansible-role-couchdb.git
+  version: v3.3.3-0
+  name: couchdb
+  activation_prefix: couchdb_
 - src: git+https://github.com/devture/com.devture.ansible.role.container_socket_proxy.git
   version: v0.1.2-1
   name: container_socket_proxy

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -139,6 +139,10 @@
     - role: galaxy/collabora_online
     # /role-specific:collabora_online
 
+    # role-specific:couchdb
+    - role: galaxy/couchdb
+    # /role-specific:couchdb
+
     # role-specific:docker_registry
     - role: galaxy/docker_registry
     # /role-specific:docker_registry


### PR DESCRIPTION
This PR adds support for [CouchDB](https://couchdb.apache.org) via the [ansible-role-couchdb](https://github.com/Bergruebe/ansible-role-couchdb).

Currently it doesn't support traefik automatically, because I'm not familiar with traefik. If someone else finds the time to add the support, I would be happy to accept a PR.