### PR TITLE
Update requirements.yml - Calibre-Web

### DIFF
--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -33,7 +33,7 @@
   name: backup_borg
   activation_prefix: backup_borg_
 - src: git+https://github.com/lingawakad/ansible-role-calibre-web.git
-  version: v0.6.22-0
+  version: v0.6.23-0
   name: calibre-web
   activation_prefix: calibre-web_
 - src: git+https://github.com/nielscil/ansible-role-changedetection.git


### PR DESCRIPTION
point to ansible-role-calibre-web v.0.6.23-0

There is a bug affecting eBook conversion, but it does not seem to be limited to this new version of Calibre-Web (v.0.6.23) - it seems to be related to the LSIO mod, not the service; https://github.com/linuxserver/docker-calibre-web/issues/307 - so i'll go ahead and bump the requirement.