### PR TITLE
Fix Forgejo additional container network template

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5391,7 +5391,7 @@ forgejo_systemd_required_systemd_services_list: |
     ([devture_postgres_identifier ~ '.service'] if devture_postgres_enabled and forgejo_config_database_hostname == devture_postgres_identifier else [])
   }}
 
-forgejo_container_additional_networks: |
+forgejo_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +


### PR DESCRIPTION
Forgejo should use forgejo_container_additional_networks_auto instead
of forgejo_container_additional_networks otherwise the role will
overwrite custom networks added by the user.