### PR TITLE
Add Readeck service

### DIFF
--- a/docs/services/readeck.md
+++ b/docs/services/readeck.md
@@ -1,0 +1,42 @@
+# Readeck
+
+[Readeck](https://readeck.org) is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever.
+See it as a bookmark manager and a read later tool.
+
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Traefik](traefik.md) reverse-proxy server
+
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# Readeck                                                              #
+#                                                                      #
+########################################################################
+
+readeck_enabled: true
+
+readeck_hostname: readeck.example.com
+
+########################################################################
+#                                                                      #
+# /calibre-web                                                           #
+#                                                                      #
+########################################################################
+```
+
+### URL
+
+In the example configuration above, we configure the service to be hosted at `https://readeck.example.com/`.
+
+## Usage
+
+After installation, you can go to the Readeck URL, as defined in `readeck_hostname`, and create a user. The User Documentation is embedded in Readeck so it's easy to access and always up-to-date.

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -191,6 +191,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (calibre_web_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'calibre-web']} if calibre_web_enabled else omit) }}
   # /role-specific:calibre-web
 
+  # role-specific:readeck
+  - |-
+    {{ ({'name': (readeck_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'readeck']} if readeck_enabled else omit) }}
+  # /role-specific:readeck
+
   # role-specific:changedetection
   - |-
     {{ ({'name': (changedetection_identifier + '.service'), 'priority': 2100, 'groups': ['mash', 'changedetection']} if changedetection_enabled else omit) }}
@@ -1649,6 +1654,41 @@ calibre_web_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certR
 #                                                                      #
 ########################################################################
 # /role-specific:calibre-web
+
+
+
+# role-specific:readeck
+########################################################################
+#                                                                      #
+# readeck                                                            #
+#                                                                      #
+########################################################################
+
+readeck_enabled: false
+
+readeck_identifier: "{{ mash_playbook_service_identifier_prefix }}readeck"
+
+readeck_uid: "{{ mash_playbook_uid }}"
+readeck_gid: "{{ mash_playbook_gid }}"
+
+readeck_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}readeck"
+
+readeck_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+readeck_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+readeck_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+readeck_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+readeck_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+########################################################################
+#                                                                      #
+# /readeck                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:readeck
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -311,6 +311,10 @@
   version: v3.2.3.0-0
   name: radicale
   activation_prefix: radicale_
+- src: git+https://github.com/lingawakad/ansible-role-readeck.git
+  version: v0.15.3-0
+  name: readeck
+  activation_prefix: readeck_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-redis.git
   version: v7.2.5-0
   name: redis

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -354,6 +354,10 @@
     # role-specific:radicale
     - role: galaxy/radicale
     # /role-specific:radicale
+    
+    # role-specific:readeck
+    - role: galaxy/readeck
+    # /role-specific:readeck
 
     # role-specific:redmine
     - role: galaxy/redmine


### PR DESCRIPTION
Readeck is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever.
See it as a bookmark manager and a read later tool.

https://readeck.org
https://codeberg.org/readeck/readeck

please let me know if there are any issues, i am also running ```matrix-docker-ansible-deploy``` but that shouldn't affect anything hopefully?