### PR TITLE
Add Forgejo Runner service

### DIFF
--- a/docs/services/forgejo-runner.md
+++ b/docs/services/forgejo-runner.md
@@ -1,0 +1,57 @@
+# Forgejo Runner
+
+[Forgejo Runner](https://code.forgejo.org/forgejo/runner) is a runner to use with [Forgejo Actions](https://forgejo.org/docs/latest/admin/actions/).  It provides a way to perform CI using Forgejo.  You might also be interested in [Woodpecker CI](https://woodpecker-ci.org/) (that this playbook also [supports](woodpecker-ci.md)).
+
+> [!WARNING]
+> Upstream considers this software as being an **alpha release**, and says it should **not** be considered secure enough to deploy in production.  Use at your own risk.
+
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# forgejo-runner                                                       #
+#                                                                      #
+########################################################################
+
+forgejo_runner_enabled: true
+
+forgejo_runner_runner_name: "Your Runner Name Here"
+
+# The instance URL.
+forgejo_runner_instance_url: "https://example.com"
+
+# The registration token.
+#
+# Should be obtained via the web interface, by going to:
+#
+#   Site Administration -> Actions -> Runners -> Create new runner
+forgejo_runner_registration_token: "TOKEN_HERE"
+
+# The capacity of the runner, i.e., how many concurrent tasks it can run.
+forgejo_runner_capacity: 1
+
+# The labels associated with this runner.
+forgejo_runner_labels:
+  - ubuntu-22.04:docker://node:20-bullseye
+
+########################################################################
+#                                                                      #
+# /forgejo-runner                                                      #
+#                                                                      #
+########################################################################
+```
+
+As mentioned in the example above, the registration token should be obtained via Forgejo's web interface, by going to `Site Administration -> Actions -> Runners -> Create new runner`.
+
+Labels are an important aspect of the runner, and as such should be carefully chosen.  Read [the official documentation](https://forgejo.org/docs/latest/admin/actions/#labels-and-runs-on) for more information.
+
+
+## Usage
+
+After the installation, the runner will register with the Forgejo instance (provided via the `forgejo_runner_instance_url` variable) and generate a `.runner` file inside its configuration path.  This file should not be modified manually.  If for some reason you wish to force the registration to run again, you can delete the `.runner` file and restart the service.
+
+If you with to change the labels associated with the runner, you can simply modify the `forgejo_runner_labels` variable and run the playbook again.  There is no need to delete the `.runner` file and run the registration again.

--- a/docs/services/forgejo.md
+++ b/docs/services/forgejo.md
@@ -56,7 +56,7 @@ Going there, you'll be taken to the initial setup wizard, which will let you ass
 
 ## Recommended other services
 
-You may also wish to look into [Woodpecker CI](woodpecker-ci.md), which can integrate nicely with Forgejo.
+You may also wish to look into [Woodpecker CI](woodpecker-ci.md) and [Forgejo Runner](forgejo-runner.md), which can integrate nicely with Forgejo.
 
 
 ## Integration with Woodpecker CI

--- a/docs/services/woodpecker-ci.md
+++ b/docs/services/woodpecker-ci.md
@@ -1,6 +1,6 @@
 # Woodpecker CI
 
-This playbook can install and configure [Woodpecker CI](https://woodpecker-ci.org/) for you.
+This playbook can install and configure [Woodpecker CI](https://woodpecker-ci.org/) for you.  If you are using Forgejo, you might also be interested in [Forgejo Runner](https://code.forgejo.org/forgejo/runner) (that this playbook also [supports](forgejo-runner.md)).
 
 Woodpecker CI is a [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) engine which can build and deploy your code automatically after pushing to a Gitea repository.
 

--- a/docs/services/woodpecker-ci.md
+++ b/docs/services/woodpecker-ci.md
@@ -1,8 +1,9 @@
 # Woodpecker CI
 
-This playbook can install and configure [Woodpecker CI](https://woodpecker-ci.org/) for you.  If you are using Forgejo, you might also be interested in [Forgejo Runner](https://code.forgejo.org/forgejo/runner) (that this playbook also [supports](forgejo-runner.md)).
+This playbook can install and configure [Woodpecker CI](https://woodpecker-ci.org/) for you.
 
-Woodpecker CI is a [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) engine which can build and deploy your code automatically after pushing to a Gitea repository.
+Woodpecker CI is a [Continuous Integration](https://en.wikipedia.org/wiki/Continuous_integration) engine which can build and deploy your code automatically after pushing to a [Gitea](./gitea.md) or [Forgejo](./forgejo.md) repository.
+If you are using [Forgejo](./forgejo.md), you might also be interested in [Forgejo Runner](https://code.forgejo.org/forgejo/runner) (that this playbook also [supports](forgejo-runner.md)).
 
 A Woodpecker CI installation contains 2 components:
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -87,6 +87,7 @@
 | [Wetty](https://github.com/butlerx/wetty) | An SSH terminal over HTTP/HTTPS | [Link](services/wetty.md) |
 | [WireGuard Easy](https://github.com/wg-easy/wg-easy) | The easiest way to run [WireGuard](https://www.wireguard.com/) VPN + Web-based Admin UI. | [Link](services/wg-easy.md) |
 | [Forgejo](https://forgejo.org/) | An alternative fork of Gitea. Easy and painless self-hosted git server. | [Link](services/forgejo.md) |
+| [Forgejo Runner](https://code.forgejo.org/forgejo/runner) | A runner to use with Forgejo Actions | [Link](services/forgejo-runner.md) |
 | [Woodpecker CI](https://woodpecker-ci.org/) | A simple Continuous Integration (CI) engine with great extensibility. | [Link](services/woodpecker-ci.md) |
 | [WordPress](https://wordpress.org/) | A widley used open source web content management system | [Link](services/wordpress.md) |
 | [Writefreely](https://writefreely.org) | A clean, minimalist publishing platform made for writers with optional federation via ActivityPub. | [Link](services/writefreely.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -639,6 +639,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (forgejo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo', 'forgejo-server']} if forgejo_enabled else omit) }}
   # /role-specific:forgejo
 
+  # role-specific:forgejo_runner
+  - |-
+    {{ ({'name': (forgejo_runner_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo-runner']} if forgejo_runner_enabled else omit) }}
+  # /role-specific:forgejo_runner
+
   # role-specific:writefreely
   - |-
     {{ ({'name': (writefreely_identifier  + '.service'), 'priority': 2000, 'groups': ['mash', 'writefreely']} if writefreely_enabled else omit) }}
@@ -5454,6 +5459,36 @@ forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret
 #                                                                      #
 ########################################################################
 # /role-specific:forgejo
+
+
+
+# role-specific:forgejo_runner
+########################################################################
+#                                                                      #
+# forgejo_runner                                                       #
+#                                                                      #
+########################################################################
+
+forgejo_runner_enabled: false
+
+forgejo_runner_uid: "0"
+forgejo_runner_gid: "0"
+
+forgejo_runner_identifier: "{{ mash_playbook_service_identifier_prefix }}forgejo-runner"
+
+forgejo_runner_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}forgejo-runner"
+
+forgejo_runner_systemd_required_systemd_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /forgejo_runner                                                      #
+#                                                                      #
+########################################################################
+# /role-specific:forgejo_runner
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -116,6 +116,10 @@
   version: v8.0.3-0
   name: forgejo
   activation_prefix: forgejo_
+- src: git+https://git.sergiodj.net/sergiodj/ansible-role-forgejo-runner.git
+  version: v3.5.1-0
+  name: forgejo_runner
+  activation_prefix: forgejo_runner_
 - src: git+https://github.com/kinduff/ansible-docker-freshrss.git
   version: v2.4.0
   name: freshrss

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -407,6 +407,10 @@
     - role: galaxy/forgejo
     # /role-specific:forgejo
 
+    # role-specific:forgejo_runner
+    - role: galaxy/forgejo_runner
+    # /role-specific:forgejo_runner
+
     # role-specific:woodpecker_ci_server
     - role: galaxy/woodpecker_ci_server
     # /role-specific:woodpecker_ci_server


### PR DESCRIPTION
Add support for [Forgejo Runner](https://code.forgejo.org/forgejo/runner).

Caveats:

- The software is still alpha, and not considered secure enough to be deployed in production.  I left a warning on the documentation.

- Unfortunately it's necessary to run the container as `root`, because upstream's Dockerfile will forcefully set `1000:1000` as the `UID/GID` and we need access to `/var/run/docker.sock`.

- Maybe this should use `docker-socket-proxy`?  Not sure how to integrate both.

- The registration process is not as streamlined as with [Gitea's runner](https://gitea.com/gitea/act_runner).  I had to do some `ExecPreStart` dance in the systemd service.  Hopefully that's not too problematic.