### PR TITLE
add Stirling PDF

### DIFF
--- a/docs/services/stirling-pdf.md
+++ b/docs/services/stirling-pdf.md
@@ -1,10 +1,13 @@
 # Stirling PDF
-Stirling PDF is a online PDF converter and editor with many functionalities. Visit the [official website](https://www.stirlingpdf.com) or [demo](https://stirlingpdf.io) to learn more.
+
+Stirling PDF is an online PDF converter and editor with many functionalities. Visit the [official website](https://www.stirlingpdf.com) or [demo](https://stirlingpdf.io) to learn more.
 
 ## Dependencies
-- traefik (optional)
+
+- a [Traefik](traefik.md) reverse-proxy server (optional)
 
 ## Configuration
+
 To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
 
 ```yaml
@@ -15,6 +18,7 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ########################################################################
 
 stirling_pdf_enabled: true
+
 stirling_pdf_hostname: stirlingpdf.example.com
 
 # The path at which stirling_pdf is served.
@@ -30,8 +34,10 @@ stirling_pdf_install_calibre: false
 #                                                                      #
 ########################################################################
 ```
+
 ### Optional Configuration
-you can decide if you want to configure via environment variables or a configuration file. Environment variables outrank the configuration file.
+
+You can decide if you want to configure via environment variables or a configuration file. Environment variables outrank the configuration file.
 
 To set addition environment variables use `stirling_pdf_environment_variables_extensions` in your `vars.yml` file.
 To use the configuration file, use `stirling_pdf_extra_config` in your `vars.yml` file.
@@ -49,4 +55,4 @@ stirling_pdf_environment_variables_extensions: |
 
 Find all possible arguments in the [official documentation](https://docs.stirlingpdf.com/Advanced%20Configuration/How%20to%20add%20configurations).
 
-All possible variables to configure the ansible-role can be found in the [defaults/main.yml](https://github.com/Bergruebe/ansible-role-stirling-pdf/blob/main/defaults/main.yml) file.
+All possible variables to configure the ansible-role can be found in its [defaults/main.yml](https://github.com/Bergruebe/ansible-role-stirling-pdf/blob/main/defaults/main.yml) file.

--- a/docs/services/stirling-pdf.md
+++ b/docs/services/stirling-pdf.md
@@ -1,0 +1,52 @@
+# Stirling PDF
+Stirling PDF is a online PDF converter and editor with many functionalities. Visit the [official website](https://www.stirlingpdf.com) or [demo](https://stirlingpdf.io) to learn more.
+
+## Dependencies
+- traefik (optional)
+
+## Configuration
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# stirling-pdf                                                         #
+#                                                                      #
+########################################################################
+
+stirling_pdf_enabled: true
+stirling_pdf_hostname: stirlingpdf.example.com
+
+# The path at which stirling_pdf is served.
+# This value must either be `/` or not end with a slash (e.g. `/pdf`).
+stirling_pdf_path_prefix: /
+
+# Set to true to download calibre onto stirling-pdf enabling pdf to/from book and advanced html conversion | default false
+stirling_pdf_install_calibre: false
+
+########################################################################
+#                                                                      #
+# /stirling-pdf                                                        #
+#                                                                      #
+########################################################################
+```
+### Optional Configuration
+you can decide if you want to configure via environment variables or a configuration file. Environment variables outrank the configuration file.
+
+To set addition environment variables use `stirling_pdf_environment_variables_extensions` in your `vars.yml` file.
+To use the configuration file, use `stirling_pdf_extra_config` in your `vars.yml` file.
+
+```yaml
+stirling_pdf_extra_config: |
+  	system:
+    	defaultLocale: 'de-DE'
+
+# OR
+
+stirling_pdf_environment_variables_extensions: |
+	SYSTEM_DEFAULTLOCALE=de-DE
+```
+
+Find all possible arguments in the [official documentation](https://docs.stirlingpdf.com/Advanced%20Configuration/How%20to%20add%20configurations).
+
+All possible variables to configure the ansible-role can be found in the [defaults/main.yml](https://github.com/Bergruebe/ansible-role-stirling-pdf/blob/main/defaults/main.yml) file.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -78,6 +78,7 @@
 | [rumqttd](https://github.com/bytebeamio/rumqtt) | A high performance, embeddable [MQTT](https://en.wikipedia.org/wiki/MQTT) broker | [Link](services/rumqttd.md) |
 | [Ansible Semaphore](https://www.ansible-semaphore.com/) | A responsive web UI for running Ansible playbooks  | [Link](services/semaphore.md) |
 | [Soft Serve](https://github.com/charmbracelet/soft-serve) | A tasty, self-hostable [Git](https://git-scm.com/) server for the command line | [Link](services/soft-serve.md) |
+| [Stirling PDF](https://github.com/Stirling-Tools/Stirling-PDF) | A self-hosted PDF converter | [Link](services/stirling-pdf.md) |
 | [Syncthing](https://syncthing.net/) | A continuous file synchronization program which synchronizes files between two or more computers in real time | [Link](services/syncthing.md) |
 | [Tandoor](https://docs.tandoor.dev/) | The recipe manager that allows you to manage your ever growing collection of digital recipes.| [Link](services/tandoor.md)
 | [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) | An open source server agent to help you collect metrics from your stacks, sensors, and systems. | [Link](services/telegraf.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -597,6 +597,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (soft_serve_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'soft-serve']} if soft_serve_enabled else omit) }}
   # /role-specific:soft_serve
 
+  # role-specific:stirling_pdf
+  - |-
+    {{ ({'name': (stirling_pdf_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'stirling_pdf']} if stirling_pdf_enabled else omit) }}
+  # /role-specific:stirling_pdf
+
   # role-specific:syncthing
   - |-
     {{ ({'name': (syncthing_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'syncthing']} if syncthing_enabled else omit) }}
@@ -5139,6 +5144,41 @@ soft_serve_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 #                                                                      #
 ########################################################################
 # /role-specific:soft_serve
+
+
+
+# role-specific:stirling-pdf
+########################################################################
+#                                                                      #
+# stirling-pdf                                                         #
+#                                                                      #
+########################################################################
+
+stirling_pdf_enabled: false
+
+stirling_pdf_identifier: "{{ mash_playbook_service_identifier_prefix }}stirling-pdf"
+
+stirling_pdf_uid: "{{ mash_playbook_uid }}"
+stirling_pdf_gid: "{{ mash_playbook_gid }}"
+
+stirling_pdf_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}stirling-pdf"
+
+stirling_pdf_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+stirling_pdf_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+stirling_pdf_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+stirling_pdf_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
+stirling_pdf_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"
+
+########################################################################
+#                                                                      #
+# /stirling-pdf                                                        #
+#                                                                      #
+########################################################################
+# /role-specific:stirling-pdf
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -343,6 +343,10 @@
   version: 13440992374e0fef8f6360a0856b78b37a1fd831
   name: ssh
   activation_prefix: system_security_ssh_
+- src: git+https://github.com/Bergruebe/ansible-role-stirling-pdf.git
+  version: v0.28.3-fat
+  name: stirling_pdf
+  activation_prefix: stirling_pdf_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-swap.git
   version: abfb18b6862108bbf24347500446203170324d7f
   name: swap

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -354,7 +354,7 @@
     # role-specific:radicale
     - role: galaxy/radicale
     # /role-specific:radicale
-    
+
     # role-specific:readeck
     - role: galaxy/readeck
     # /role-specific:readeck
@@ -378,6 +378,10 @@
     # role-specific:soft_serve
     - role: galaxy/soft_serve
     # /role-specific:soft_serve
+
+    # role-specific:stirling_pdf
+    - role: galaxy/stirling_pdf
+    # /role-specific:stirling_pdf
 
     # role-specific:syncthing
     - role: galaxy/syncthing


### PR DESCRIPTION
This PR adds [Stirling PDF](https://www.stirlingpdf.com), a tool to edit and convert PDFs.

The ansible role can be found [here](https://github.com/Bergruebe/ansible-role-stirling-pdf).