### PR TITLE
Add role-specific annotations in group_vars for tandoor

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5309,7 +5309,7 @@ syncthing_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pr
 
 
 
-
+# role-specific:tandoor
 ########################################################################
 #                                                                      #
 # tandoor                                                              #
@@ -5372,7 +5372,7 @@ tandoor_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled 
 # /tandoor                                                             #
 #                                                                      #
 ########################################################################
-
+# /role-specific:tandoor
 
 
 


### PR DESCRIPTION
Before this change the tandoor variables would always be in the optimized group_vars file. This PR fixes the issue.