### PR TITLE
Add SearXNG service

### DIFF
--- a/docs/services/searxng.md
+++ b/docs/services/searxng.md
@@ -1,0 +1,147 @@
+# SearXNG
+
+[SearXNG](https://github.com/searxng/searxng/) is a privacy-respecting, hackable [metasearch engine](https://en.wikipedia.org/wiki/Metasearch_engine).
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Traefik](traefik.md) reverse-proxy server
+
+If rate-limiting is enabled, then it also requires:
+
+- a [Valkey](valkey.md) database
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# searxng                                                              #
+#                                                                      #
+########################################################################
+
+searxng_enabled: true
+
+searxng_instance_name: My Example Instance Name'
+
+searxng_hostname: searxng.example.com
+
+# If you want to server SearXNG under a subpath, you can specify it here.
+#searxng_path_prefix: '/'
+
+# Generate the secret key with "openssl rand -hex 32".
+searxng_secret_key: 'MY_SECRET_KEY'
+
+########################################################################
+#                                                                      #
+# /searxng                                                             #
+#                                                                      #
+########################################################################
+```
+
+In the example configuration above, we configure the service to be hosted at `https://searxng.example.com`.
+
+It is possible to host SearXNG under a subpath (by configuring the `searxng_path_prefix` variable).
+
+### Configuring rate-limiting
+
+If you want to enable rate-limiting, you will also need to enable Valkey.  As described on the [Valkey](valkey.md) documentation page, if you're hosting additional services which require Valkey on the same server, you'd better go for installing a separate Valkey instance for each service. See [Creating a Valkey instance dedicated to SearXNG](...).
+
+You will also need to enable rate-limiting for SearXNG by setting:
+
+```yaml
+searxng_enable_rate_limiter: true
+```
+
+#### Creating a Valkey instance dedicated to SearXNG
+
+The following instructions are based on the [Running multiple instances of the same service on the same host](running-multiple-instances.md#re-do-your-inventory-to-add-supplementary-hosts) documentation.
+
+Adjust your `inventory/hosts` file as described in [Re-do your inventory to add supplementary hosts](../running-multiple-instances.md#re-do-your-inventory-to-add-supplementary-hosts), adding a new supplementary host (e.g. if `searxng.example.com` is your main one, create `searxng.example.com-deps`).
+
+Then, create a new `vars.yml` file for the `inventory/host_vars/searxng.example.com-deps/vars.yml`:
+
+```yaml
+---
+
+########################################################################
+#                                                                      #
+# Playbook                                                             #
+#                                                                      #
+########################################################################
+
+# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
+# Various other secrets will be derived from this secret automatically.
+mash_playbook_generic_secret_key: ''
+
+# Override service names and directory path prefixes
+mash_playbook_service_identifier_prefix: 'mash-searxng-'
+mash_playbook_service_base_directory_name_prefix: 'searxng-'
+
+########################################################################
+#                                                                      #
+# /Playbook                                                            #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# valkey                                                               #
+#                                                                      #
+########################################################################
+
+valkey_enabled: true
+
+########################################################################
+#                                                                      #
+# /valkey                                                              #
+#                                                                      #
+########################################################################
+```
+
+This will create a `mash-searxng-valkey` instance on this host with its data in `/mash/searxng-valkey`.
+
+Then, adjust your main inventory host's variables file (`inventory/host_vars/searxng.example.com/vars.yml`) like this:
+
+```yaml
+########################################################################
+#                                                                      #
+# searxng                                                              #
+#                                                                      #
+########################################################################
+
+# Base configuration as shown above
+
+# Point Searxng to its dedicated Valkey instance
+searxng_rate_limiter_config_valkey_hostname: mash-searxng-valkey
+
+# Make sure the Searxng service (mash-searxng.service) starts after its dedicated KeyDB service (mash-searxng-valkey.service)
+searxng_systemd_required_services_list_custom:
+  - "mash-searxng-valkey.service"
+
+# Make sure the Searxng container is connected to the container network of its dedicated KeyDB service (mash-searxng-valkey)
+searxng_container_additional_networks_custom:
+  - "mash-searxng-valkey"
+
+########################################################################
+#                                                                      #
+# /searxng                                                             #
+#                                                                      #
+########################################################################
+```
+
+### Configuring basic authentication
+
+If you are running a private instance, you might want to protect it with so that only authorized people can use it.  An easy option is to choose a non-trivial subpath by modifying the `searxng_path_prefix`.  Another, more complete option is to enable basic authentication for the instance.
+
+To do the latter, you need to set the following variables:
+
+```yaml
+searxng_basic_auth_enabled: true
+searxng_basic_auth_username: 'my_username'
+searxng_basic_auth_password: 'my_password'
+```

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -78,6 +78,7 @@
 | [Redis](https://redis.io/) | An in-memory data store used by millions of developers as a database, cache, streaming engine, and message broker. | [Link](services/redis.md) |
 | [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | [rumqttd](https://github.com/bytebeamio/rumqtt) | A high performance, embeddable [MQTT](https://en.wikipedia.org/wiki/MQTT) broker | [Link](services/rumqttd.md) |
+| [SearXNG](https://github.com/searxng/searxng) | A privacy-respecting, hackable [metasearch engine](https://en.wikipedia.org/wiki/Metasearch_engine) | [Link](services/searxng.md) |
 | [Ansible Semaphore](https://www.ansible-semaphore.com/) | A responsive web UI for running Ansible playbooks  | [Link](services/semaphore.md) |
 | [Soft Serve](https://github.com/charmbracelet/soft-serve) | A tasty, self-hostable [Git](https://git-scm.com/) server for the command line | [Link](services/soft-serve.md) |
 | [Stirling PDF](https://github.com/Stirling-Tools/Stirling-PDF) | A self-hosted PDF converter | [Link](services/stirling-pdf.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -596,6 +596,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (rumqttd_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'rumqttd']} if rumqttd_enabled else omit) }}
   # /role-specific:rumqttd
 
+  # role-specific:searxng
+  - |-
+    {{ ({'name': (searxng_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'searxng']} if searxng_enabled else omit) }}
+  # /role-specific:searxng
+
   # role-specific:semaphore
   - |-
     {{ ({'name': (semaphore_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'semaphore']} if semaphore_enabled else omit) }}
@@ -5179,6 +5184,46 @@ rumqttd_gid: "{{ mash_playbook_gid }}"
 #                                                                      #
 ########################################################################
 # /role-specific:rumqttd
+
+
+
+# role-specific:searxng
+########################################################################
+#                                                                      #
+# searxng                                                              #
+#                                                                      #
+########################################################################
+
+searxng_enabled: false
+
+searxng_identifier: "{{ mash_playbook_service_identifier_prefix }}searxng"
+
+searxng_uid: "{{ mash_playbook_uid }}"
+searxng_gid: "{{ mash_playbook_gid }}"
+
+searxng_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}searxng"
+
+searxng_systemd_required_systemd_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+  }}
+
+searxng_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+searxng_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+searxng_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+searxng_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+
+searxng_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /searxng                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:searxng
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -343,6 +343,10 @@
   version: v0.21.0-0
   name: rumqttd
   activation_prefix: rumqttd_
+- src: git+https://git.sergiodj.net/sergiodj/ansible-role-searxng.git
+  version: v1.0-0
+  name: searxng
+  activation_prefix: searxng_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-semaphore.git
   version: v2.9.56-0
   name: semaphore

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -375,6 +375,10 @@
     - role: galaxy/rumqttd
     # /role-specific:rumqttd
 
+    # role-specific:searxng
+    - role: galaxy/searxng
+    # /role-specific:searxng
+
     # role-specific:semaphore
     - role: galaxy/semaphore
     # /role-specific:semaphore


### PR DESCRIPTION
This PR adds a new service for SearXNG.

Unfortunately, upstream doesn't version their images (and it seems like they've stopped versioning their regular software releases as well), so I decided to make the service always pull the `latest` tag.  I realize this is not ideal and am open to suggestions on how to approach this problem.