### PR TITLE
new service: TSDProxy

### DIFF
--- a/docs/services/tsdproxy.md
+++ b/docs/services/tsdproxy.md
@@ -1,17 +1,19 @@
 # TSDProxy
 
-It is mandatory to set following variables:
+It is mandatory to set the following variables:
 
 ```yaml
 tsdproxy_tailscale_authkey: '' # OR
 tsdproxy_tailscale_authkeyfile: '' # use this to load authkey from file. If this is defined, Authkey is ignored
 ```
+
 If [com.devture.ansible.role.container_socket_proxy](https://github.com/devture/com.devture.ansible.role.container_socket_proxy) is installed by the playbook (default), the container will use the proxy.
 If not, the container will mount the docker socket at `/var/run/docker.sock`, but you can change that by setting `tsdproxy_docker_socket` to something else. Don't forget to adjust the `tsdproxy_docker_endpoint_is_unix_socket` to false if you are using a tcp endpoint. 
 
 ## Add a new Service
-This proxy creates for each service a own machine in the Tailscale network, without creating each time a sidecar container.
-To add a new service, you have to make sure that the service and proxy are in a same docker network. You can do this by adding the proxy to the network of the service or the other way round.
+
+This proxy creates for each service a own machine in the Tailscale network, without creating a sidecar container each time.
+To add a new service, you have to make sure that the service and proxy are in a same container network. You can do this by adding the proxy to the network of the service or the other way round.
 ```yaml
 tsdproxy_container_additional_networks_custom:
   - YOUR-SERVICE-NETWORK
@@ -20,14 +22,18 @@ YOUR-SERVICE_container_additional_networks_custom:
   - "{{ tsdproxy_container_network }}"
 ```
 
-The next step is to add the service to the proxy. 
-### Via docker labels
+The next step is to add the service to the proxy.
+
+### Connecting a service to the proxy via container labels
+
 ```yaml
 YOUR-SERVICE_container_labels_additional_labels: |
 	tsdproxy.enable: "true"
 	tsdproxy.container_port: 8080
 ```
-Following labels are optional, please read the [official TSDProxy documentation](https://almeidapaulopt.github.io/tsdproxy/docs/docker/) for more information. 
+
+The following labels are optional, please read the [official TSDProxy documentation](https://almeidapaulopt.github.io/tsdproxy/docs/docker/) for more information.
+
 ```yaml	
 	tsdproxy.name: "my-service"
 	tsdproxy.autodetect: "false"
@@ -36,8 +42,11 @@ Following labels are optional, please read the [official TSDProxy documentation]
 	tsdproxy.funnel: "false"
 ```
 
-### Via Proxy list
+### Connecting a service to the proxy via a Proxy list
+
 An alternative way to add a service to the proxy is to use Proxy files.
+
 Please read the [official TSDProxy documentation](https://almeidapaulopt.github.io/tsdproxy/docs/files/) for more information.
+
 You will need to use the `tsdproxy_config_files` variable and add your proxy list file into the config folder, most likely `/mash/tsdproxy/config/`.
 This is possible manually or by using [AUX-Files](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/auxiliary.md).

--- a/docs/services/tsdproxy.md
+++ b/docs/services/tsdproxy.md
@@ -1,0 +1,43 @@
+# TSDProxy
+
+It is mandatory to set following variables:
+
+```yaml
+tsdproxy_tailscale_authkey: '' # OR
+tsdproxy_tailscale_authkeyfile: '' # use this to load authkey from file. If this is defined, Authkey is ignored
+```
+If [com.devture.ansible.role.container_socket_proxy](https://github.com/devture/com.devture.ansible.role.container_socket_proxy) is installed by the playbook (default), the container will use the proxy.
+If not, the container will mount the docker socket at `/var/run/docker.sock`, but you can change that by setting `tsdproxy_docker_socket` to something else. Don't forget to adjust the `tsdproxy_docker_endpoint_is_unix_socket` to false if you are using a tcp endpoint. 
+
+## Add a new Service
+This proxy creates for each service a own machine in the Tailscale network, without creating each time a sidecar container.
+To add a new service, you have to make sure that the service and proxy are in a same docker network. You can do this by adding the proxy to the network of the service or the other way round.
+```yaml
+tsdproxy_container_additional_networks_custom:
+  - YOUR-SERVICE-NETWORK
+# OR
+YOUR-SERVICE_container_additional_networks_custom:
+  - "{{ tsdproxy_container_network }}"
+```
+
+The next step is to add the service to the proxy. 
+### Via docker labels
+```yaml
+YOUR-SERVICE_container_labels_additional_labels: |
+	tsdproxy.enable: "true"
+	tsdproxy.container_port: 8080
+```
+Following labels are optional, please read the [official TSDProxy documentation](https://almeidapaulopt.github.io/tsdproxy/docs/docker/) for more information. 
+```yaml	
+	tsdproxy.name: "my-service"
+	tsdproxy.autodetect: "false"
+	tsdproxy.proxyprovider: "providername"
+	tsdproxy.ephemeral: "false"
+	tsdproxy.funnel: "false"
+```
+
+### Via Proxy list
+An alternative way to add a service to the proxy is to use Proxy files.
+Please read the [official TSDProxy documentation](https://almeidapaulopt.github.io/tsdproxy/docs/files/) for more information.
+You will need to use the `tsdproxy_config_files` variable and add your proxy list file into the config folder, most likely `/mash/tsdproxy/config/`.
+This is possible manually or by using [AUX-Files](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/auxiliary.md).

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -86,6 +86,7 @@
 | [Tandoor](https://docs.tandoor.dev/) | The recipe manager that allows you to manage your ever growing collection of digital recipes.| [Link](services/tandoor.md)
 | [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) | An open source server agent to help you collect metrics from your stacks, sensors, and systems. | [Link](services/telegraf.md) |
 | [Traefik](https://doc.traefik.io/traefik/) | A container-aware reverse-proxy server | [Link](services/traefik.md) |
+| [TSDProxy](https://almeidapaulopt.github.io/tsdproxy/) | A proxy for virtual services in Tailscale | [Link](services/tsdproxy.md) |
 | [Uptime-kuma](https://uptime.kuma.pet/) | A fancy self-hosted monitoring tool | [Link](services/uptime-kuma.md) |
 | [Valkey](https://valkey.io/) | A flexible distributed key-value datastore that is optimized for caching and other realtime workloads. | [Link](services/valkey.md) |
 | [Vaultwarden](https://github.com/dani-garcia/vaultwarden) | A lightweight unofficial and compatible implementation of the [Bitwarden](https://bitwarden.com/)password manager | [Link](services/vaultwarden.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -668,6 +668,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (forgejo_runner_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo-runner']} if forgejo_runner_enabled else omit) }}
   # /role-specific:forgejo_runner
 
+  # role-specific:tsdproxy
+  - |-
+    {{ ({'name': (tsdproxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'tsdproxy']} if tsdproxy_enabled else omit) }}
+  # /role-specific:tsdproxy
+
   # role-specific:writefreely
   - |-
     {{ ({'name': (writefreely_identifier  + '.service'), 'priority': 2000, 'groups': ['mash', 'writefreely']} if writefreely_enabled else omit) }}
@@ -5468,6 +5473,51 @@ telegraf_systemd_required_services_list: |
 #                                                                      #
 ########################################################################
 # /role-specific:telegraf
+
+
+
+# role-specific:tsdproxy
+########################################################################
+#                                                                      #
+# tsdproxy                                                             #
+#                                                                      #
+########################################################################
+
+tsdproxy_enabled: false
+
+tsdproxy_identifier: "{{ mash_playbook_service_identifier_prefix }}tsdproxy"
+
+tsdproxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}tsdproxy"
+
+tsdproxy_uid: "{{ mash_playbook_uid }}"
+tsdproxy_gid: "{{ mash_playbook_gid }}"
+
+# role-specific:container_socket_proxy
+tsdproxy_docker_endpoint_is_unix_socket: "{{ false if devture_container_socket_proxy_enabled else true }}"
+tsdproxy_docker_endpoint: "{{ devture_container_socket_proxy_endpoint if devture_container_socket_proxy_enabled == true and tsdproxy_enabled == true else 'unix:///var/run/docker.sock' }}"
+# TSDProxy needs access to the Docker Networks and images to work
+devture_container_socket_proxy_api_network_enabled: "{{ true if tsdproxy_docker_endpoint == devture_container_socket_proxy_endpoint else false }}"
+devture_container_socket_proxy_api_images_enabled: "{{ true if tsdproxy_docker_endpoint == devture_container_socket_proxy_endpoint else false }}"
+# /role-specific:container_socket_proxy
+
+tsdproxy_container_additional_networks_auto: |
+  {{
+    ([devture_container_socket_proxy_container_network] if devture_container_socket_proxy_enabled | default(false) else [])
+  }}
+
+tsdproxy_systemd_required_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+    +
+    ([devture_container_socket_proxy_identifier + '.service'] if devture_container_socket_proxy_enabled | default(false) else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /tsdproxy                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:tsdproxy
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -395,6 +395,10 @@
   version: v3.2.1-0
   name: traefik
   activation_prefix: traefik_
+- src: git+https://github.com/Bergruebe/ansible-role-tsdproxy.git
+  version: v1.2.0-1
+  name: tsdproxy
+  activation_prefix: tsdproxy_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-uptime_kuma.git
   version: v1.23.15-1
   name: uptime_kuma

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -403,6 +403,10 @@
     - role: galaxy/telegraf
     # /role-specific:telegraf
 
+    # role-specific:tsdproxy
+    - role: galaxy/tsdproxy
+    # /role-specific:tsdproxy
+
     # role-specific:valkey
     - role: galaxy/valkey
     # /role-specific:valkey


### PR DESCRIPTION
This PR adds support for [TSDProxy](https://almeidapaulopt.github.io/tsdproxy/). 
A special proxy, which publishes docker containers to your [Tailscale](tailscale.com) network (Tailnet).