### PR TITLE
Add Sonarr support

### DIFF
--- a/docs/services/sonarr.md
+++ b/docs/services/sonarr.md
@@ -1,0 +1,43 @@
+# Sonarr
+
+[Sonarr](https://sonarr.tv/) is a smart PVR for newsgroup and bittorrent users.
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Traefik](traefik.md) reverse-proxy server
+
+## Configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# sonarr                                                               #
+#                                                                      #
+########################################################################
+
+sonarr_enabled: true
+
+sonarr_hostname: sonarr.example.com
+
+########################################################################
+#                                                                      #
+# /sonarr                                                              #
+#                                                                      #
+########################################################################
+```
+
+### URL
+
+In the example configuration above, we configure the service to be hosted at `https://sonarr.example.com`.
+
+A `sonarr_path_prefix` variable can be adjusted to host under a subpath (e.g. `sonarr_path_prefix: /sonarr`), but this hasn't been tested yet.
+
+## Usage
+
+After [installation](../installing.md), you should be able to access your new Sonarr instance at the URL you've chosen.
+
+For additional configuration options, refer to [ansible-role-sonarr](https://github.com/spatterIight/ansible-role-sonarr)'s `defaults/main.yml` file.

--- a/docs/services/sonarr.md
+++ b/docs/services/sonarr.md
@@ -38,6 +38,6 @@ A `sonarr_path_prefix` variable can be adjusted to host under a subpath (e.g. `s
 
 ## Usage
 
-After [installation](../installing.md), you should be able to access your new Sonarr instance at the URL you've chosen.
+After [installation](../installing.md), you should access your new Sonarr instance at the URL you've chosen and configure a username and password. The recommended authenticaton method is `Forms (Login Page)`.
 
 For additional configuration options, refer to [ansible-role-sonarr](https://github.com/spatterIight/ansible-role-sonarr)'s `defaults/main.yml` file.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -80,8 +80,9 @@
 | [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | [rumqttd](https://github.com/bytebeamio/rumqtt) | A high performance, embeddable [MQTT](https://en.wikipedia.org/wiki/MQTT) broker | [Link](services/rumqttd.md) |
 | [SearXNG](https://github.com/searxng/searxng) | A privacy-respecting, hackable [metasearch engine](https://en.wikipedia.org/wiki/Metasearch_engine) | [Link](services/searxng.md) |
-| [Ansible Semaphore](https://www.ansible-semaphore.com/) | A responsive web UI for running Ansible playbooks  | [Link](services/semaphore.md) |
+| [Ansible Semaphore](https://www.ansible-semaphore.com/) | A responsive web UI for running Ansible playbooks | [Link](services/semaphore.md) |
 | [Soft Serve](https://github.com/charmbracelet/soft-serve) | A tasty, self-hostable [Git](https://git-scm.com/) server for the command line | [Link](services/soft-serve.md) |
+| [Sonarr](https://sonarr.tv/) | A smart PVR for newsgroup and bittorrent users | [Link](services/sonarr.md) |
 | [Stirling PDF](https://github.com/Stirling-Tools/Stirling-PDF) | A self-hosted PDF converter | [Link](services/stirling-pdf.md) |
 | [Syncthing](https://syncthing.net/) | A continuous file synchronization program which synchronizes files between two or more computers in real time | [Link](services/syncthing.md) |
 | [Tandoor](https://docs.tandoor.dev/) | The recipe manager that allows you to manage your ever growing collection of digital recipes.| [Link](services/tandoor.md)

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -616,6 +616,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (soft_serve_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'soft-serve']} if soft_serve_enabled else omit) }}
   # /role-specific:soft_serve
 
+  # role-specific:sonarr
+  - |-
+    {{ ({'name': (sonarr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'sonarr']} if sonarr_enabled else omit) }}
+  # /role-specific:sonarr
+
   # role-specific:stirling_pdf
   - |-
     {{ ({'name': (stirling_pdf_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'stirling_pdf']} if stirling_pdf_enabled else omit) }}
@@ -5343,6 +5348,44 @@ soft_serve_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 #                                                                      #
 ########################################################################
 # /role-specific:soft_serve
+
+
+
+# role-specific:sonarr
+########################################################################
+#                                                                      #
+# sonarr                                                            #
+#                                                                      #
+########################################################################
+
+sonarr_enabled: false
+
+sonarr_identifier: "{{ mash_playbook_service_identifier_prefix }}sonarr"
+
+sonarr_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}sonarr"
+
+sonarr_uid: "{{ mash_playbook_uid }}"
+sonarr_gid: "{{ mash_playbook_gid }}"
+
+sonarr_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+sonarr_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+sonarr_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+sonarr_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+sonarr_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /sonarr                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:sonarr
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -359,6 +359,10 @@
   version: v0.4.7-0
   name: soft_serve
   activation_prefix: soft_serve_
+- src: git+https://github.com/spatterIight/ansible-role-sonarr.git
+  version: v4.0.12-0
+  name: sonarr
+  activation_prefix: sonarr_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-ssh.git
   version: 13440992374e0fef8f6360a0856b78b37a1fd831
   name: ssh

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -391,6 +391,10 @@
     - role: galaxy/soft_serve
     # /role-specific:soft_serve
 
+    # role-specific:sonarr
+    - role: galaxy/sonarr
+    # /role-specific:sonarr
+
     # role-specific:stirling_pdf
     - role: galaxy/stirling_pdf
     # /role-specific:stirling_pdf


### PR DESCRIPTION
This PR adds Sonarr support. It has been tested as working. `sonarr_path_prefix` has not been tested.

https://github.com/spatterIight/ansible-role-sonarr/tree/main

#### Other information:

The role configures Sonarr with security in mind by doing the following:

1. Running the container as a non-root user
2. Making the filesystem read-only
3. Dropping most capabilities

Unfortunately, due to upstream requirements, some admissions had to be made:

1. Several capabilities related to permissions are added to the container
   - SETUID
   - SETGID
   - CHOWN
   - FOWNER
   - DAC_OVERRIDE
2. A `tmpfs` volume is mounted with `exec` permissions

You can read more about these upstream requirements in the documentation:

1. https://docs.linuxserver.io/misc/non-root/
2. https://docs.linuxserver.io/misc/read-only/