### PR TITLE
feat: use postgres_backup_databases_auto in order to allow setting postgres_backup_databases_custom

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1149,7 +1149,7 @@ postgres_backup_connection_password: "{{ postgres_connection_password if postgre
 
 postgres_backup_postgres_data_path: "{{ postgres_data_path if postgres_enabled else '' }}"
 
-postgres_backup_databases: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
+postgres_backup_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
 # /role-specific:postgres
 
 ########################################################################


### PR DESCRIPTION
Not to be merged before https://github.com/mother-of-all-self-hosting/ansible-role-postgres-backup/pull/6 is available in the playbook, will otherwise break.