### PR TITLE
feat: make use of _auto for backup of postgres databases via borg

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1581,7 +1581,7 @@ backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if p
 backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
 backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
 backup_borg_postgresql_databases_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
-backup_borg_postgresql_databases: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
+backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
 # /role-specific:postgres
 
 # role-specific:mariadb


### PR DESCRIPTION
Must not be merged before https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg/pull/12 is available