### PR TITLE
Add docs/just.md and docs/playbook-tags.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -17,6 +18,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 - [Configuring interoperability with other services](interoperability.md)
 
 - [Installing](installing.md)
+
+- [Playbook tags](playbook-tags.md)
 
 - [Importing an existing Postgres database (from another installation)](services/postgres.md#importing) (optional)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Table of Contents
 
 - [Prerequisites](prerequisites.md) - go here to a guided installation using this Ansible playbook

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 - [Maintenance and Troubleshooting](maintenance-and-troubleshooting.md)
 
+- [Running `just` commands](just.md)
+
 - [Uninstalling](uninstalling.md)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
 SPDX-FileCopyrightText: 2024 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -18,8 +19,7 @@ We recommend installing and using using `just` - otherwise, you'll need to do mo
 
 - update the Ansible roles in this playbook by either running `just update` or `git pull && just roles`. `just update` is a shortcut that calls `git pull` and `just roles` with a single command, while `just roles` is a shortcut which ultimately runs either [agru](https://github.com/etkecc/agru) or [ansible-galaxy](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html) to download Ansible roles defined in the `requirements.yml` file. If you don't have `just`, you can also manually run the `roles` commands seen in the [`justfile`](../justfile).
 
-
-## Playbook tags introduction
+## Installing services
 
 The Ansible playbook's tasks are tagged, so that certain parts of the Ansible playbook can be run without running all other tasks.
 
@@ -29,36 +29,7 @@ The general command syntax is:
 
 - when not using `just`: `ansible-playbook -i inventory/hosts setup.yml --tags=COMMA_SEPARATED_TAGS_GO_HERE`
 
-Here are some playbook tags that you should be familiar with:
-
-- `setup-all` - runs all setup tasks (installation and uninstallation) for all components, but does not start/restart services
-
-- `install-all` - like `setup-all`, but skips uninstallation tasks. Useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove components, you'd need to run `setup-all` though, or these components will still remain installed
-
-- `setup-SERVICE` (e.g. `setup-miniflux`) - runs the setup tasks only for a given role ([Miniflux](services/miniflux.md) in this example), but does not start/restart services. You can discover these additional tags in each role (`roles/**/tasks/main.yml`). Running per-component setup tasks is **not recommended**, as components sometimes depend on each other and running just the setup tasks for a given component may not be enough. For example, for setting up the [Miniflux](services/miniflux.md) service, in addition to the `setup-miniflux` tag, changes to the database are also necessary (the `setup-postgres` tag).
-
-- `install-SERVICE` (e.g. `install-miniflux`) - like `setup-SERVICE`, but skips uninstallation tasks. See `install-all` above for additional information.
-
-- `start` - starts all systemd services and makes them start automatically in the future
-
-- `stop` - stops all systemd services
-
-`setup-*` tags and `install-*` tags **do not start services** automatically, because you may wish to do things before starting services, such as importing a database dump, restoring data from another server, etc.
-
-When using `just`, there are also helpful shortcuts you can use:
-
-- `just install-all`: runs all installation tasks and starts/restarts the services
-
-- `just setup-all`: runs all installation tasks and also uninstallation tasks that clean up after services you have removed from your `vars.yml` file. This task also starts/restarts all services.
-
-- `just install-service SERVICE_NAME`: runs the installation tasks only for the `SERVICE_NAME` service and starts/restarts the service. As mentioned above, this is not usually recommended, as installing a service may require running installation tasks for other (dependent) roles to prepare a database, etc.
-
-- `just stop-all`: stops all services
-
-- `just start-all`: starts all services
-
-
-## 1. Installing services
+It is recommended to get yourself familiar with the [playbook tags](playbook-tags.md) before proceeding.
 
 If you **don't** use SSH keys for authentication, but rather a regular password, you may need to add `--ask-pass` to the all Ansible (or `just`) commands
 
@@ -121,7 +92,7 @@ Proceed to [Maintaining your setup in the future](#2-maintaining-your-setup-in-t
 
 Feel free to **re-run the setup command any time** you think something is off with the server configuration. Ansible will take your configuration and update your server to match.
 
-Note that if you remove components from `vars.yml`, or if we switch some component from being installed by default to not being installed by default anymore, you'd need to use `setup-all` instead of `install-all`. See [Playbook tags introduction](#playbook-tags-introduction)
+Note that if you remove components from `vars.yml`, or if we switch some component from being installed by default to not being installed by default anymore, you'd need to use `setup-all` instead of `install-all`. See [this page on the playbook tags](playbook-tags.md) for more information.
 
 To do it with `just`:
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -24,9 +24,7 @@ We recommend installing and using using `just` - otherwise, you'll need to do mo
 The Ansible playbook's tasks are tagged, so that certain parts of the Ansible playbook can be run without running all other tasks.
 
 The general command syntax is:
-
 - (**recommended**) when using `just`: `just run-tags COMMA_SEPARATED_TAGS_GO_HERE`
-
 - when not using `just`: `ansible-playbook -i inventory/hosts setup.yml --tags=COMMA_SEPARATED_TAGS_GO_HERE`
 
 It is recommended to get yourself familiar with the [playbook tags](playbook-tags.md) before proceeding.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Installing
 
 If you've [configured the playbook](configuring-playbook.md) and have prepared the required domains (DNS records) depending on the services you've enabled, you can start the installation procedure.

--- a/docs/just.md
+++ b/docs/just.md
@@ -7,11 +7,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Running `just` commands
 
-We have previously used [make](https://www.gnu.org/software/make/) for easily running some playbook commands (e.g. `make roles` which triggers [`ansible-galaxy`](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html)). Our [`Makefile`](../Makefile) is still around, and you can still run these commands.
+This playbook supports running playbook commands via [`just`](https://github.com/casey/just) — a more modern command-runner alternative to `make`. It can be used to invoke `ansible-playbook` commands with less typing.
 
-In addition, we have added support for running commands via [`just`](https://github.com/casey/just) — a more modern command-runner alternative to `make`. It can be used to invoke `ansible-playbook` commands with less typing.
-
-The `just` utility executes shortcut commands (called as "recipes"), which invoke `ansible-playbook`, `ansible-galaxy` or [`agru`](https://github.com/etkecc/agru) (depending on what is available in your system). The targets of the recipes are defined in [`justfile`](../justfile). Most of the just recipes have no corresponding `Makefile` targets.
+The `just` utility executes shortcut commands (called as "recipes"), which invoke `ansible-playbook`, [`ansible-galaxy`](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html) or [`agru`](https://github.com/etkecc/agru) (depending on what is available in your system). The targets of the recipes are defined in [`justfile`](../justfile).
 
 For some recipes such as `just update`, our `justfile` recommends installing [`agru`](https://github.com/etkecc/agru) (a faster alternative to `ansible-galaxy`) to speed up the process.
 

--- a/docs/just.md
+++ b/docs/just.md
@@ -19,16 +19,15 @@ Here are some examples of shortcuts:
 
 | Shortcut                                       | Result                                                                                                         |
 |------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `just roles`                                   | Install the necessary Ansible roles pinned in [`requirements.yml`](../requirements.yml)                        |
+| `just roles`                                   | Install the necessary Ansible roles pinned in [`requirements.yml`](../templates/requirements.yml)              |
 | `just update`                                  | Run `git pull` (to update the playbook) and install the Ansible roles                                          |
-| `just install-all`                             | Run `ansible-playbook -i inventory/hosts setup.yml --tags=install-all,ensure-matrix-users-created,start`       |
-| `just setup-all`                               | Run `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start`         |
+| `just install-all`                             | Run `ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start`                                   |
+| `just setup-all`                               | Run `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`                                     |
 | `just install-all --ask-vault-pass`            | Run commands with additional arguments (`--ask-vault-pass` will be appended to the above installation command) |
-| `just run-tags install-mautrix-slack,start`    | Run specific playbook tags (here `install-mautrix-slack` and `start`)                                          |
-| `just install-service mautrix-slack`           | Run `just run-tags install-mautrix-slack,start` with even less typing                                          |
+| `just run-tags install-miniflux,start`         | Run specific playbook tags (here `install-miniflux` and `start`)                                               |
+| `just install-service miniflux`                | Run `just run-tags install-miniflux,start` with even less typing                                               |
 | `just start-all`                               | (Re-)starts all services                                                                                       |
 | `just stop-group postgres`                     | Stop only the Postgres service                                                                                 |
-| `just register-user alice secret-password yes` | Registers an `alice` user with the `secret-password` password and admin access (admin = `yes`)                 |
 
 While [our documentation on prerequisites](prerequisites.md) lists `just` as one of the requirements for installation, using `just` is optional. If you find it difficult to install it, do not find it useful, or want to prefer raw `ansible-playbook` commands for some reason, feel free to run all commands manually. For example, you can run `ansible-galaxy` directly to install the Ansible roles: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`.
 
@@ -40,6 +39,6 @@ For example, these two commands are different:
 - `just install-all`
 - `ansible-playbook -i inventory/hosts setup.yml --tags=install-all`
 
-The just recipe runs `ensure-matrix-users-created` and `start` tags after `install-all`, while the latter runs only `install-all` tag. The correct shortcut of the latter is `just run-tags install-all`.
+The just recipe runs `start` tag after `install-all`, while the latter runs only `install-all` tag. The correct shortcut of the latter is `just run-tags install-all`.
 
-Such kind of difference sometimes matters. For example, when you install a Matrix server into which you will import old data (see [here](installing.md#installing-a-server-into-which-youll-import-old-data)), you are not supposed to run `just install-all` or `just setup-all`, because these commands start services immediately after installing components, which may prevent you from importing the data.
+Such kind of difference sometimes matters. For example, when you install a server into which you will import old data (see [here](installing.md#installing-a-server-into-which-youll-import-old-data)), you are not supposed to run `just install-all` or `just setup-all`, because these commands start services immediately after installing components, which may prevent you from importing the data.

--- a/docs/just.md
+++ b/docs/just.md
@@ -1,0 +1,45 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Running `just` commands
+
+We have previously used [make](https://www.gnu.org/software/make/) for easily running some playbook commands (e.g. `make roles` which triggers [`ansible-galaxy`](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html)). Our [`Makefile`](../Makefile) is still around, and you can still run these commands.
+
+In addition, we have added support for running commands via [`just`](https://github.com/casey/just) — a more modern command-runner alternative to `make`. It can be used to invoke `ansible-playbook` commands with less typing.
+
+The `just` utility executes shortcut commands (called as "recipes"), which invoke `ansible-playbook`, `ansible-galaxy` or [`agru`](https://github.com/etkecc/agru) (depending on what is available in your system). The targets of the recipes are defined in [`justfile`](../justfile). Most of the just recipes have no corresponding `Makefile` targets.
+
+For some recipes such as `just update`, our `justfile` recommends installing [`agru`](https://github.com/etkecc/agru) (a faster alternative to `ansible-galaxy`) to speed up the process.
+
+Here are some examples of shortcuts:
+
+| Shortcut                                       | Result                                                                                                         |
+|------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `just roles`                                   | Install the necessary Ansible roles pinned in [`requirements.yml`](../requirements.yml)                        |
+| `just update`                                  | Run `git pull` (to update the playbook) and install the Ansible roles                                          |
+| `just install-all`                             | Run `ansible-playbook -i inventory/hosts setup.yml --tags=install-all,ensure-matrix-users-created,start`       |
+| `just setup-all`                               | Run `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start`         |
+| `just install-all --ask-vault-pass`            | Run commands with additional arguments (`--ask-vault-pass` will be appended to the above installation command) |
+| `just run-tags install-mautrix-slack,start`    | Run specific playbook tags (here `install-mautrix-slack` and `start`)                                          |
+| `just install-service mautrix-slack`           | Run `just run-tags install-mautrix-slack,start` with even less typing                                          |
+| `just start-all`                               | (Re-)starts all services                                                                                       |
+| `just stop-group postgres`                     | Stop only the Postgres service                                                                                 |
+| `just register-user alice secret-password yes` | Registers an `alice` user with the `secret-password` password and admin access (admin = `yes`)                 |
+
+While [our documentation on prerequisites](prerequisites.md) lists `just` as one of the requirements for installation, using `just` is optional. If you find it difficult to install it, do not find it useful, or want to prefer raw `ansible-playbook` commands for some reason, feel free to run all commands manually. For example, you can run `ansible-galaxy` directly to install the Ansible roles: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`.
+
+## Difference between playbook tags and shortcuts
+
+It is worth noting that `just` "recipes" are different from [playbook tags](playbook-tags.md). The recipes are shortcuts of commands defined in `justfile` and can be executed by the `just` program only, while the playbook tags are available for the raw `ansible-playbook` commands as well. Please be careful not to confuse them.
+
+For example, these two commands are different:
+- `just install-all`
+- `ansible-playbook -i inventory/hosts setup.yml --tags=install-all`
+
+The just recipe runs `ensure-matrix-users-created` and `start` tags after `install-all`, while the latter runs only `install-all` tag. The correct shortcut of the latter is `just run-tags install-all`.
+
+Such kind of difference sometimes matters. For example, when you install a Matrix server into which you will import old data (see [here](installing.md#installing-a-server-into-which-youll-import-old-data)), you are not supposed to run `just install-all` or `just setup-all`, because these commands start services immediately after installing components, which may prevent you from importing the data.

--- a/docs/just.md
+++ b/docs/just.md
@@ -11,7 +11,7 @@ This playbook supports running playbook commands via [`just`](https://github.com
 
 The `just` utility executes shortcut commands (called as "recipes"), which invoke `ansible-playbook`, [`ansible-galaxy`](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html) or [`agru`](https://github.com/etkecc/agru) (depending on what is available in your system). The targets of the recipes are defined in [`justfile`](../justfile).
 
-For some recipes such as `just update`, our `justfile` recommends installing [`agru`](https://github.com/etkecc/agru) (a faster alternative to `ansible-galaxy`) to speed up the process.
+For some recipes such as `just update`, our `justfile` recommends installing `agru` (a faster alternative to `ansible-galaxy`) to speed up the process.
 
 Here are some examples of shortcuts:
 

--- a/docs/playbook-tags.md
+++ b/docs/playbook-tags.md
@@ -1,0 +1,32 @@
+<!--
+SPDX-FileCopyrightText: 2018 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Playbook tags
+
+The Ansible playbook's tasks are tagged, so that certain parts of the Ansible playbook can be run without running all other tasks.
+
+The general command syntax is: `ansible-playbook -i inventory/hosts setup.yml --tags=COMMA_SEPARATED_TAGS_GO_HERE`
+
+Here are some playbook tags that you should be familiar with:
+
+- `setup-all` — runs all setup tasks (installation and uninstallation) for all components, but does not start/restart services
+
+- `install-all` — like `setup-all`, but skips uninstallation tasks. Useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove components, you'd need to run `setup-all` though, or these components will still remain installed
+
+- `setup-SERVICE` (e.g. `setup-postmoogle`) — runs the setup tasks only for a given role, but does not start/restart services. You can discover these additional tags in each role (`roles/**/tasks/main.yml`). Running per-component setup tasks is **not recommended**, as components sometimes depend on each other and running just the setup tasks for a given component may not be enough. For example, setting up the [mautrix-telegram bridge](configuring-playbook-bridge-mautrix-telegram.md), in addition to the `setup-mautrix-telegram` tag, requires database changes (the `setup-postgres` tag) as well as reverse-proxy changes (the `setup-nginx-proxy` tag).
+
+- `install-SERVICE` (e.g. `install-postmoogle`) — like `setup-SERVICE`, but skips uninstallation tasks. See `install-all` above for additional information.
+
+- `start` — starts all systemd services and makes them start automatically in the future
+
+- `stop` — stops all systemd services
+
+- `ensure-matrix-users-created` — a special tag which ensures that all special users needed by the playbook (for bots, etc.) are created
+
+**Notes**:
+- `setup-*` tags and `install-*` tags **do not start services** automatically, because you may wish to do things before starting services, such as importing a database dump, restoring data from another server, etc.
+- Please be careful not to confuse the playbook tags with the `just` shortcut commands ("recipes"). For details about `just` commands, see: [Running `just` commands](just.md)

--- a/docs/playbook-tags.md
+++ b/docs/playbook-tags.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2018 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2018 - 2023 Slavi Pantaleev
 SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -9,7 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 The Ansible playbook's tasks are tagged, so that certain parts of the Ansible playbook can be run without running all other tasks.
 
-The general command syntax is: `ansible-playbook -i inventory/hosts setup.yml --tags=COMMA_SEPARATED_TAGS_GO_HERE`
+The general command syntax is:
+- (**recommended**) when using `just`: `just run-tags COMMA_SEPARATED_TAGS_GO_HERE`
+- when not using `just`: `ansible-playbook -i inventory/hosts setup.yml --tags=COMMA_SEPARATED_TAGS_GO_HERE`
 
 Here are some playbook tags that you should be familiar with:
 
@@ -17,15 +19,13 @@ Here are some playbook tags that you should be familiar with:
 
 - `install-all` — like `setup-all`, but skips uninstallation tasks. Useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove components, you'd need to run `setup-all` though, or these components will still remain installed
 
-- `setup-SERVICE` (e.g. `setup-postmoogle`) — runs the setup tasks only for a given role, but does not start/restart services. You can discover these additional tags in each role (`roles/**/tasks/main.yml`). Running per-component setup tasks is **not recommended**, as components sometimes depend on each other and running just the setup tasks for a given component may not be enough. For example, setting up the [mautrix-telegram bridge](configuring-playbook-bridge-mautrix-telegram.md), in addition to the `setup-mautrix-telegram` tag, requires database changes (the `setup-postgres` tag) as well as reverse-proxy changes (the `setup-nginx-proxy` tag).
+- `setup-SERVICE` (e.g. `setup-miniflux`) — runs the setup tasks only for a given role, but does not start/restart services. You can discover these additional tags in each role (`roles/**/tasks/main.yml`). Running per-component setup tasks is **not recommended**, as components sometimes depend on each other and running just the setup tasks for a given component may not be enough. For example, setting up the [Miniflux](services/miniflux.md) service, in addition to the `setup-miniflux` tag, requires database changes (the `setup-postgres` tag) as well.
 
-- `install-SERVICE` (e.g. `install-postmoogle`) — like `setup-SERVICE`, but skips uninstallation tasks. See `install-all` above for additional information.
+- `install-SERVICE` (e.g. `install-miniflux`) — like `setup-SERVICE`, but skips uninstallation tasks. See `install-all` above for additional information.
 
 - `start` — starts all systemd services and makes them start automatically in the future
 
 - `stop` — stops all systemd services
-
-- `ensure-matrix-users-created` — a special tag which ensures that all special users needed by the playbook (for bots, etc.) are created
 
 **Notes**:
 - `setup-*` tags and `install-*` tags **do not start services** automatically, because you may wish to do things before starting services, such as importing a database dump, restoring data from another server, etc.


### PR DESCRIPTION
This PR intends to add docs/just.md and docs/playbook-tags.md by copying them from the MDAD project and edit them for the MASH project. I tried to be careful here not to mix up stuff related to Matrix, but it would be appreciated if the changes are reviewed, especially on be6bd0c8a03fb1920ec17b3169052052a5b35556 and f4cc701b041bf59a285dbbb2ccdbdfac79091d16. 51c3da3a47cf75cc842444c3f15616a49097bd1c should be fine.