### PR TITLE
Update docs: installation process based on MDAD project

### DIFF
--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -1,4 +1,5 @@
 <!--
+SPDX-FileCopyrightText: 2018 - 2024 MDAD project contributors
 SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
 SPDX-FileCopyrightText: 2023 Slavi Pantaleev
 
@@ -6,6 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Configuring DNS
+
+<sup>[Prerequisites](prerequisites.md) > Configuring your DNS settings > [Getting the playbook](getting-the-playbook.md) > [Configuring the playbook](configuring-playbook.md) > [Installing](installing.md)</sup>
 
 To reach your services, you'd need to do some DNS configuration.
 
@@ -42,4 +45,8 @@ accordingly in your `vars.yml`.
 
 Be mindful as to how long it will take for the DNS records to propagate.
 
-When you're done configuring DNS, proceed to [Configuring the playbook](configuring-playbook.md).
+**Note**: if you are using Cloudflare DNS, make sure to disable the proxy and set all records to "DNS only". Otherwise, fetching certificates will fail.
+
+---------------------------------------------
+
+[▶️](getting-the-playbook.md) When you're done with the DNS configuration and ready to proceed, continue with [Getting the playbook](getting-the-playbook.md).

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -2,6 +2,7 @@
 SPDX-FileCopyrightText: 2018 - 2024 MDAD project contributors
 SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
 SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -21,12 +22,14 @@ To reach your services, you'd need to do some DNS configuration.
 Some services (like [Uptime-kuma](services/uptime-kuma.md)) require being hosted at their own dedicated domain.
 Others, you can put on their own domain/subdomain or at subpaths on any domain you'd like.
 
-As an **example** setup, consider this one:
+## Example DNS settings
 
-| Service                    | Type  | Host                | Target              |
-|--------------------------- |-------|---------------------|---------------------|
-| Miniflux, Radicale, others | A     | `mash.example.com`  | `IP of your server` |
-| Nextcloud                  | CNAME | `cloud.example.com` | `mash.example.com`  |
+As an example setup, adjust DNS records as below.
+
+| Service                    | Type  | Host    | Priority | Weight | Port | Target             |
+|--------------------------- | ----- | ------- | -------- | ------ | ---- | -------------------|
+| Miniflux, Radicale, others | A     | `mash`  | -        | -      | -    | `mash-server-IP`   |
+| Nextcloud                  | CNAME | `cloud` | -        | -      | -    | `mash.example.com` |
 
 With such a setup, you could reach:
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -15,12 +15,11 @@ To reach your services, you'd need to do some DNS configuration.
 
 **We recommend** that you:
 
-- create at least one generic domain (e.g. `mash.DOMAIN`) for easily hosting various services at different subpaths (e.g. `mash.DOMAIN/miniflux`, `mash.DOMAIN/radicale`, etc.)
+- create at least one generic domain (e.g. `mash.example.com`) for easily hosting various services at different subpaths (e.g. `mash.example.com/miniflux`, `mash.example.com/radicale`, etc.)
 
 - create additional domains (`CNAME` DNS records pointing to the main generic domain) for large services or services that explicitly require their own dedicated domain
 
-Some services (like [Uptime-kuma](services/uptime-kuma.md)) require being hosted at their own dedicated domain.
-Others, you can put on their own domain/subdomain or at subpaths on any domain you'd like.
+Some services (like [Uptime-kuma](services/uptime-kuma.md)) require being hosted at their own dedicated domain. Others, you can put on their own domain/subdomain or at subpaths on any domain you'd like.
 
 ## Example DNS settings
 
@@ -33,18 +32,15 @@ As an example setup, adjust DNS records as below.
 
 With such a setup, you could reach:
 
-- the feedreader [Miniflux](services/miniflux.md) at `https://mash.example.com/miniflux` (if you set
-`miniflux_hostname: mash.example.com` and `miniflux_path_prefix: /miniflux` in your `vars.yml`)
+- the feedreader [Miniflux](services/miniflux.md) at `https://mash.example.com/miniflux` (if you set `miniflux_hostname: mash.example.com` and `miniflux_path_prefix: /miniflux` in your `vars.yml`)
 
-- the [Radicale](services/radicale.md) CalDAV/CardDAV sever at `https://mash.example.com/radicale` (if you set
-`radicale_hostname: mash.example.com` and `radicale_path_prefix: /radicale` in your `vars.yml`)
+- the [Radicale](services/radicale.md) CalDAV/CardDAV sever at `https://mash.example.com/radicale` (if you set `radicale_hostname: mash.example.com` and `radicale_path_prefix: /radicale` in your `vars.yml`)
 
 - Nextcloud at its own dedicated domain, at `https://cloud.example.com`
 
 Hosting services at subpaths is more convenient, because it doesn't require you to create additional DNS records and no new SSL certificates need to be retrieved.
 
-Still, if you'd like each service to have its own dedicated domain (or subdomain), feel free to configure services that way by making sure that you set `<service>_hostname` and `<service>_path_prefix`
-accordingly in your `vars.yml`.
+Still, if you'd like each service to have its own dedicated domain (or subdomain), feel free to configure services that way by making sure that you set `<service>_hostname` and `<service>_path_prefix` accordingly in your `vars.yml`.
 
 Be mindful as to how long it will take for the DNS records to propagate.
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Configuring DNS
 
 To reach your services, you'd need to do some DNS configuration.
@@ -28,7 +35,7 @@ With such a setup, you could reach:
 
 - Nextcloud at its own dedicated domain, at `https://cloud.example.com`
 
-Hosting services at subpaths is more convenient, because it doesn't require you to create additional DNS records and no new SSL certificates need to be retrieved. 
+Hosting services at subpaths is more convenient, because it doesn't require you to create additional DNS records and no new SSL certificates need to be retrieved.
 
 Still, if you'd like each service to have its own dedicated domain (or subdomain), feel free to configure services that way by making sure that you set `<service>_hostname` and `<service>_path_prefix`
 accordingly in your `vars.yml`.

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -1,20 +1,26 @@
 <!--
-SPDX-FileCopyrightText: 2023 Slavi Pantaleev
-SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2018 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2018 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 Sabine Laszakovits
+SPDX-FileCopyrightText: 2021 Cody Neiman
+SPDX-FileCopyrightText: 2021 Matthew Cengia
+SPDX-FileCopyrightText: 2021 Toni Spets
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+SPDX-FileCopyrightText: 2022 - 2023 Julian-Samuel Gebühr
 SPDX-FileCopyrightText: 2023 MASH project contributors
+SPDX-FileCopyrightText: 2023 Shreyas Ajjarapu
 SPDX-FileCopyrightText: 2023 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Configuring the Ansible playbook
+# Configuring the playbook
 
-To configure the playbook, you need to have done the following things:
+<sup>[Prerequisites](prerequisites.md) > [Configuring your DNS settings](configuring-dns.md) > [Getting the playbook](getting-the-playbook.md) > Configuring the playbook > [Installing](installing.md)</sup>
 
-- have a server where services will run
-- [retrieved the playbook's source code](getting-the-playbook.md) to your computer
-
-You can then follow these steps inside the playbook directory:
+If you've configured your DNS records and retrieved the playbook's source code to your computer, you can start configuring the playbook. To do so, follow these steps inside the playbook directory:
 
 1. create a directory to hold your configuration (`mkdir -p inventory/host_vars/<your-domain>`)
 

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -22,16 +22,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 If you've configured your DNS records and retrieved the playbook's source code to your computer, you can start configuring the playbook. To do so, follow these steps inside the playbook directory:
 
-1. create a directory to hold your configuration (`mkdir -p inventory/host_vars/<your-domain>`)
+1. create a directory to hold your configuration (`mkdir -p inventory/host_vars/mash.example.com`)
 
-2. copy the sample configuration file (`cp examples/vars.yml inventory/host_vars/<your-domain>/vars.yml`)
+2. copy the sample configuration file (`cp examples/vars.yml inventory/host_vars/mash.example.com/vars.yml`)
 
-3. edit the configuration file (`inventory/host_vars/<your-domain>/vars.yml`) to your liking. You should [enable one or more services](supported-services.md) in your `vars.yml` file. You may also take a look at the various `roles/**/ROLE_NAME_HERE/defaults/main.yml` files (after importing external roles with `just update` into `roles/galaxy`) and see if there's something you'd like to copy over and override in your `vars.yml` configuration file.
+3. edit the configuration file (`inventory/host_vars/mash.example.com/vars.yml`) to your liking. You should [enable one or more services](supported-services.md) in your `vars.yml` file. You may also take a look at the various `roles/*/ROLE_NAME_HERE/defaults/main.yml` files (after importing external roles with `just update` into `roles/galaxy`) and see if there's something you'd like to copy over and override in your `vars.yml` configuration file.
 
 4. copy the sample inventory hosts file (`cp examples/hosts inventory/hosts`)
 
 5. edit the inventory hosts file (`inventory/hosts`) to your liking
 
+6. (optional, advanced) you may wish to keep your `inventory` directory under version control with [git](https://git-scm.com/) or any other version-control system.
+
+For a basic installation, that's all you need.
+
 If you're installing services on the same server using another playbook (like [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy)) or you already have [Traefik](./services/traefik.md) or [Docker](./services/docker.md) installed on the server, consult our [Interoperability](./interoperability.md) documentation.
 
-When you're done with all the configuration you'd like to do, continue with [Installing](installing.md).
+---------------------------------------------
+
+[▶️](installing.md) When you're done with all the configuration you'd like to do, continue with [Installing](installing.md).

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 MASH project contributors
+SPDX-FileCopyrightText: 2023 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Configuring the Ansible playbook
 
 To configure the playbook, you need to have done the following things:

--- a/docs/getting-the-playbook.md
+++ b/docs/getting-the-playbook.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
-SPDX-FileCopyrightText: 2024 Suguru Hirahara
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <sup>[Prerequisites](prerequisites.md) > [Configuring your DNS settings](configuring-dns.md) > Getting the playbook > [Configuring the playbook](configuring-playbook.md) > [Installing](installing.md)</sup>
 
-This Ansible playbook is meant to be executed on your own computer (not the Matrix server).
+This Ansible playbook is meant to be executed on your own computer (not on the server).
 
 In special cases (if your computer cannot run Ansible, etc.) you may put the playbook on the server as well.
 
@@ -24,18 +24,18 @@ We recommend using the [git](https://git-scm.com/) tool to get the playbook's so
 Once you've installed git on your computer, you can go to any directory of your choosing and run the following command to retrieve the playbook's source code:
 
 ```sh
-git clone https://github.com/spantaleev/matrix-docker-ansible-deploy.git
+git clone https://github.com/mother-of-all-self-hosting/mash-playbook.git
 ```
 
-This will create a new `matrix-docker-ansible-deploy` directory. You're supposed to execute all other installation commands inside that directory.
+This will create a new `mash-playbook` directory. You're supposed to execute all other installation commands inside that directory.
 
 ## Downloading the playbook as a ZIP archive
 
 Alternatively, you can download the playbook as a ZIP archive. This is not recommended, as it's not easy to keep up to date with future updates. We suggest you [use git](#using-git-to-get-the-playbook) instead.
 
-The latest version is always at the following URL: https://github.com/spantaleev/matrix-docker-ansible-deploy/archive/master.zip
+The latest version is always at the following URL: https://github.com/mother-of-all-self-hosting/mash-playbook/archive/master.zip
 
-You can extract this archive anywhere. You'll get a directory called `matrix-docker-ansible-deploy-master`. You're supposed to execute all other installation commands inside that directory.
+You can extract this archive anywhere. You'll get a directory called `mash-playbook-master`. You're supposed to execute all other installation commands inside that directory.
 
 ---------------------------------------------
 

--- a/docs/getting-the-playbook.md
+++ b/docs/getting-the-playbook.md
@@ -1,21 +1,21 @@
 <!--
-SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Getting the playbook
 
-This Ansible playbook is meant to be executed on your own computer (not on the server).
+<sup>[Prerequisites](prerequisites.md) > [Configuring your DNS settings](configuring-dns.md) > Getting the playbook > [Configuring the playbook](configuring-playbook.md) > [Installing](installing.md)</sup>
+
+This Ansible playbook is meant to be executed on your own computer (not the Matrix server).
 
 In special cases (if your computer cannot run Ansible, etc.) you may put the playbook on the server as well.
 
 You can retrieve the playbook's source code by:
-
 - [Using git to get the playbook](#using-git-to-get-the-playbook) (recommended)
-
 - [Downloading the playbook as a ZIP archive](#downloading-the-playbook-as-a-zip-archive) (not recommended)
-
 
 ## Using git to get the playbook
 
@@ -23,25 +23,20 @@ We recommend using the [git](https://git-scm.com/) tool to get the playbook's so
 
 Once you've installed git on your computer, you can go to any directory of your choosing and run the following command to retrieve the playbook's source code:
 
-```bash
-git clone https://github.com/mother-of-all-self-hosting/mash-playbook.git
+```sh
+git clone https://github.com/spantaleev/matrix-docker-ansible-deploy.git
 ```
 
-This will create a new `mash-playbook` directory.
-You're supposed to execute all other installation commands inside that directory.
-
+This will create a new `matrix-docker-ansible-deploy` directory. You're supposed to execute all other installation commands inside that directory.
 
 ## Downloading the playbook as a ZIP archive
 
-Alternatively, you can download the playbook as a ZIP archive.
-This is not recommended, as it's not easy to keep up to date with future updates. We suggest you [use git](#using-git-to-get-the-playbook) instead.
+Alternatively, you can download the playbook as a ZIP archive. This is not recommended, as it's not easy to keep up to date with future updates. We suggest you [use git](#using-git-to-get-the-playbook) instead.
 
-The latest version is always at the following URL: https://github.com/mother-of-all-self-hosting/mash-playbook/archive/master.zip
+The latest version is always at the following URL: https://github.com/spantaleev/matrix-docker-ansible-deploy/archive/master.zip
 
-You can extract this archive anywhere. You'll get a directory called `mash-playbook-master`.
-You're supposed to execute all other installation commands inside that directory.
-
+You can extract this archive anywhere. You'll get a directory called `matrix-docker-ansible-deploy-master`. You're supposed to execute all other installation commands inside that directory.
 
 ---------------------------------------------
 
-No matter which method you've used to download the playbook, you can proceed by [Configuring the playbook](configuring-playbook.md).
+[▶️](configuring-playbook.md) No matter which method you've used to download the playbook, you can proceed by [Configuring the playbook](configuring-playbook.md).

--- a/docs/getting-the-playbook.md
+++ b/docs/getting-the-playbook.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Getting the playbook
 
 This Ansible playbook is meant to be executed on your own computer (not on the server).

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -105,13 +105,17 @@ After you have started the services, you can:
 - or come say Hi in our [Matrix](https://matrix.org) support room - [#mash-playbook:devture.com](https://matrix.to/#/#mash-playbook:devture.com). You might learn something or get to help someone else new to hosting services with this playbook.
 - or help make this playbook better by contributing (code, documentation, or [coffee/beer](https://liberapay.com/mother-of-all-self-hosting/donate))
 
-## 2. Maintaining your setup in the future
+### ⚠️ Keep the playbook and services up-to-date
 
-Feel free to **re-run the setup command any time** you think something is off with the server configuration. Ansible will take your configuration and update your server to match.
+While this playbook helps you to set up Matrix services and maintain them, it will **not** automatically run the maintenance task for you. You will need to update the playbook and re-run it **manually**.
 
-Note that if you remove components from `vars.yml`, or if we switch some component from being installed by default to not being installed by default anymore, you'd need to use `setup-all` instead of `install-all`. See [this page on the playbook tags](playbook-tags.md) for more information.
+The upstream projects, which this playbook makes use of, occasionally if not often suffer from security vulnerabilities.
 
-To do it with `just`:
+Since it is unsafe to keep outdated services running on the server connected to the internet, please consider to update the playbook and re-run it periodically, in order to keep the services up-to-date.
+
+For more information about upgrading or maintaining services with the playbook, take at look at this page: [Upgrading the Matrix services](maintenance-upgrading-services.md)
+
+Feel free to **re-run the setup command any time** you think something is wrong with the server configuration. Ansible will take your configuration and update your server to match.
 
 ```sh
 just install-all
@@ -128,3 +132,5 @@ ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start
 # Or, to run potential uninstallation tasks too:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+**Note**: see [this page on the playbook tags](playbook-tags.md) for more information about those tags.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -65,7 +65,7 @@ This will do a full installation and start all services.
 
 ### Installing a server into which you'll import old data
 
-If you will be importing data into your newly created Matrix server, install it, but **do not** start its services just yet. Starting its services or messing with its database now will affect your data import later on.
+If you will be importing data into your newly created server, install it, but **do not** start its services just yet. Starting its services or messing with its database now will affect your data import later on.
 
 To do the installation **without** starting services, run only the `install-all` tag:
 
@@ -107,13 +107,13 @@ After you have started the services, you can:
 
 ### ⚠️ Keep the playbook and services up-to-date
 
-While this playbook helps you to set up Matrix services and maintain them, it will **not** automatically run the maintenance task for you. You will need to update the playbook and re-run it **manually**.
+While this playbook helps you to set up services and maintain them, it will **not** automatically run the maintenance task for you. You will need to update the playbook and re-run it **manually**.
 
 The upstream projects, which this playbook makes use of, occasionally if not often suffer from security vulnerabilities.
 
 Since it is unsafe to keep outdated services running on the server connected to the internet, please consider to update the playbook and re-run it periodically, in order to keep the services up-to-date.
 
-For more information about upgrading or maintaining services with the playbook, take at look at this page: [Upgrading the Matrix services](maintenance-upgrading-services.md)
+For more information about upgrading or maintaining services with the playbook, take at look at this page: [Upgrading services](maintenance-upgrading-services.md)
 
 Feel free to **re-run the setup command any time** you think something is wrong with the server configuration. Ansible will take your configuration and update your server to match.
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -95,6 +95,8 @@ just start-all
 # ansible-playbook -i inventory/hosts setup.yml --tags=start
 ```
 
+Regardless of the installation way you have chosen, **if an error is not returned, the installation has completed and the services have been started successfully**🎉
+
 ## Things to do next
 
 After you have started the services, you can:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -95,6 +95,16 @@ just start-all
 # ansible-playbook -i inventory/hosts setup.yml --tags=start
 ```
 
+## Things to do next
+
+After you have started the services, you can:
+
+- start using the configured services
+- or set up additional services
+- or learn how to [upgrade services when new versions are released](maintenance-upgrading-services.md)
+- or come say Hi in our [Matrix](https://matrix.org) support room - [#mash-playbook:devture.com](https://matrix.to/#/#mash-playbook:devture.com). You might learn something or get to help someone else new to hosting services with this playbook.
+- or help make this playbook better by contributing (code, documentation, or [coffee/beer](https://liberapay.com/mother-of-all-self-hosting/donate))
+
 ## 2. Maintaining your setup in the future
 
 Feel free to **re-run the setup command any time** you think something is off with the server configuration. Ansible will take your configuration and update your server to match.
@@ -118,14 +128,3 @@ ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start
 # Or, to run potential uninstallation tasks too:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
-
-
-## 3. Things to do next
-
-After you have started the services, you can:
-
-- start using the configured services
-- or set up additional services
-- or learn how to [upgrade services when new versions are released](maintenance-upgrading-services.md)
-- or come say Hi in our [Matrix](https://matrix.org) support room - [#mash-playbook:devture.com](https://matrix.to/#/#mash-playbook:devture.com). You might learn something or get to help someone else new to hosting services with this playbook.
-- or help make this playbook better by contributing (code, documentation, or [coffee/beer](https://liberapay.com/mother-of-all-self-hosting/donate))

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -25,9 +25,9 @@ Before installing, you need to update the Ansible roles that this playbook uses 
 To update your playbook directory and all upstream Ansible roles (defined in the `requirements.yml` file), run:
 
 - either: `just update`
-- or: a combination of `git pull` and `just roles` (or `make roles` if you have `make` program on your computer instead of `just`)
+- or: a combination of `git pull` and `just roles`
 
-If you don't have either `just` tool or `make` program, you can run the `ansible-galaxy` tool directly: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`
+If you don't have either `just` tool, you can run the `ansible-galaxy` tool directly: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`
 
 For details about `just` commands, take a look at: [Running `just` commands](just.md).
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,6 +1,12 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2018 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2018 Aaron Raimist
+SPDX-FileCopyrightText: 2018 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2019 Edgars Voroboks
+SPDX-FileCopyrightText: 2019 Michael Haak
+SPDX-FileCopyrightText: 2020 Kevin Lanni
 SPDX-FileCopyrightText: 2024 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 Mitja Jež
 SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -8,16 +14,22 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Installing
 
-If you've [configured the playbook](configuring-playbook.md) and have prepared the required domains (DNS records) depending on the services you've enabled, you can start the installation procedure.
+<sup>[Prerequisites](prerequisites.md) > [Configuring your DNS settings](configuring-dns.md) > [Getting the playbook](getting-the-playbook.md) > [Configuring the playbook](configuring-playbook.md) > Installing</sup>
 
-This playbook makes use of the [`just`](https://github.com/casey/just) utility to make it easier to run playbook-related commands defined in the [`justfile`](../justfile).
-We recommend installing and using using `just` - otherwise, you'll need to do more manual work.
+If you've configured your DNS records and the playbook, you can start the installation procedure.
 
-**Before installing** and each time you update the playbook in the future, you will need to:
+## Update Ansible roles
 
-- (only if you're not using the [`just`](https://github.com/casey/just) utility): create `setup.yml`, `requirements.yml` and `group_vars/mash_servers` based on the up-to-date templates found in the [`templates/` directory](../templates). If you are using `just`, these files are created and maintained up-to-date automatically.
+Before installing, you need to update the Ansible roles that this playbook uses and fetches from outside.
 
-- update the Ansible roles in this playbook by either running `just update` or `git pull && just roles`. `just update` is a shortcut that calls `git pull` and `just roles` with a single command, while `just roles` is a shortcut which ultimately runs either [agru](https://github.com/etkecc/agru) or [ansible-galaxy](https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html) to download Ansible roles defined in the `requirements.yml` file. If you don't have `just`, you can also manually run the `roles` commands seen in the [`justfile`](../justfile).
+To update your playbook directory and all upstream Ansible roles (defined in the `requirements.yml` file), run:
+
+- either: `just update`
+- or: a combination of `git pull` and `just roles` (or `make roles` if you have `make` program on your computer instead of `just`)
+
+If you don't have either `just` tool or `make` program, you can run the `ansible-galaxy` tool directly: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`
+
+For details about `just` commands, take a look at: [Running `just` commands](just.md).
 
 ## Installing services
 
@@ -29,12 +41,11 @@ The general command syntax is:
 
 It is recommended to get yourself familiar with the [playbook tags](playbook-tags.md) before proceeding.
 
-If you **don't** use SSH keys for authentication, but rather a regular password, you may need to add `--ask-pass` to the all Ansible (or `just`) commands
+If you **don't** use SSH keys for authentication, but rather a regular password, you may need to add `--ask-pass` to the all Ansible (or `just`) commands.
 
-If you **do** use SSH keys for authentication, **and** use a non-root user to *become* root (sudo), you may need to add `-K` (`--ask-become-pass`) to all Ansible commands
+If you **do** use SSH keys for authentication, **and** use a non-root user to *become* root (sudo), you may need to add `-K` (`--ask-become-pass`) to all Ansible commands.
 
-There 2 ways to start the installation process - depending on whether you're [Installing a brand new server (without importing data)](#installing-a-brand-new-server-without-importing-data) or [Installing a server into which you'll import old data](#installing-a-server-into-which-youll-import-old-data).
-
+There 2 ways to start the installation process — depending on whether you're [Installing a brand new server (without importing data)](#installing-a-brand-new-server-without-importing-data) or [Installing a server into which you'll import old data](#installing-a-server-into-which-youll-import-old-data).
 
 ### Installing a brand new server (without importing data)
 
@@ -50,13 +61,11 @@ just install-all
 
 This will do a full installation and start all services.
 
-Proceed to [Maintaining your setup in the future](#2-maintaining-your-setup-in-the-future).
-
+**Note**: if the command does not work as expected, make sure that you have properly installed and configured software required to run the playbook, as described on [Prerequisites](prerequisites.md).
 
 ### Installing a server into which you'll import old data
 
-If you will be importing data into your newly created server, install it, but **do not** start its services just yet.
-Starting its services or messing with its database now will affect your data import later on.
+If you will be importing data into your newly created Matrix server, install it, but **do not** start its services just yet. Starting its services or messing with its database now will affect your data import later on.
 
 To do the installation **without** starting services, run only the `install-all` tag:
 
@@ -67,13 +76,16 @@ just run-tags install-all
 # ansible-playbook -i inventory/hosts setup.yml --tags=install-all
 ```
 
-When this command completes, **services won't be running yet**.
+> [!WARNING]
+> Do not run the just "recipe" `just install-all` instead, because it automatically starts services at the end of execution. See: [Difference between playbook tags and shortcuts](just.md#difference-between-playbook-tags-and-shortcuts)
+
+When this command completes, services won't be running yet.
 
 You can now:
 
 - [Importing an existing Postgres database (from another installation)](services/postgres.md#importing) (optional)
 
-.. and then proceed to starting all services:
+… and then proceed to starting all services:
 
 ```sh
 # This is equivalent to: just run-tags start (or: just run-tags start-all)
@@ -82,9 +94,6 @@ just start-all
 # Or, when not using just, you can use this instead:
 # ansible-playbook -i inventory/hosts setup.yml --tags=start
 ```
-
-Proceed to [Maintaining your setup in the future](#2-maintaining-your-setup-in-the-future).
-
 
 ## 2. Maintaining your setup in the future
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,14 +1,22 @@
 <!--
-SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2018 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 - 2022 Aaron Raimist
+SPDX-FileCopyrightText: 2019 - 2023 MDAD project contributors
 SPDX-FileCopyrightText: 2023 QEDeD
 SPDX-FileCopyrightText: 2024 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 Fabio Bonelli
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 # Prerequisites
 
-To install services using this Ansible playbook, you need:
+<sup>Prerequisites > [Configuring your DNS settings](configuring-dns.md) > [Getting the playbook](getting-the-playbook.md) > [Configuring the playbook](configuring-playbook.md) > [Installing](installing.md)</sup>
+
+To install services using this Ansible playbook, you need to prepare several requirements both on your local computer (where you will run the playbook to configure the server) and the server (where the playbook will install the services for you). **These requirements need to be set up manually** before proceeding to the next step.
+
+We will be using `example.com` as the domain in the following instruction. Please remember to replace it with your own domain before running any commands.
 
 - (Recommended) An **x86-64** (`amd64`) or **arm64** server running one of these operating systems:
   - **Red Hat Enterprise Linux** or derivative distros, e.g. Rocky Linux (Major version 7 or newer)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 QEDeD
+SPDX-FileCopyrightText: 2024 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Prerequisites
 
 To install services using this Ansible playbook, you need:

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -30,17 +30,19 @@ We will be using `example.com` as the domain in the following instruction. Pleas
 
 - Strong password (random strings) generator. The playbook often requires you to create a strong password and use it for settings on `vars.yml`, components, etc. As any tools should be fine, this playbook has adopted [`pwgen`](https://linux.die.net/man/1/pwgen) (running `pwgen -s 64 1`). [Password Tech](https://pwgen-win.sourceforge.io/), formerly known as "PWGen for Windows", is available as free and open source password generator for Windows. Generally, using a random generator available on the internet is not recommended.
 
-- (Recommended) An **x86-64** (`amd64`) or **arm64** server running one of these operating systems:
-  - **Red Hat Enterprise Linux** or derivative distros, e.g. Rocky Linux (Major version 7 or newer)
-  - **Debian** (10/Buster or newer)
-  - **Ubuntu** (18.04 or newer, although [20.04 may be problematic](ansible.md#supported-ansible-versions))
+## Server
+
+- (Recommended) An **x86** server running one of these operating systems that make use of [systemd](https://systemd.io/):
   - **Archlinux**
+  - **CentOS**, **Rocky Linux**, **AlmaLinux**, or possibly other RHEL alternatives (although your mileage may vary)
+  - **Debian** (10/Buster or newer)
+  - **Ubuntu** (18.04 or newer, although [20.04 may be problematic](ansible.md#supported-ansible-versions) if you run the Ansible playbook on it)
 
-Generally, newer is better. We only strive to support released stable versions of distributions, not betas or pre-releases. This playbook can take over your whole server or co-exist with other services that you have there.
+  Generally, newer is better. We only strive to support released stable versions of distributions, not betas or pre-releases. The playbook can take over your whole server or co-exist with other services that you have there.
 
-This playbook somewhat supports running on non-`amd64` architectures like ARM. See [Alternative Architectures](alternative-architectures.md).
+  This playbook somewhat supports running on non-`amd64` architectures like ARM. See [Alternative Architectures](alternative-architectures.md).
 
-If your distro runs within an [LXC container](https://linuxcontainers.org/), you may hit [this issue](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/703). It can be worked around, if absolutely necessary, but we suggest that you avoid running from within an LXC container.
+  If your distro runs within an [LXC container](https://linuxcontainers.org/), you may hit [this issue](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/703). It can be worked around, if absolutely necessary, but we suggest that you avoid running from within an LXC container.
 
 - `root` access to your server (or a user capable of elevating to `root` via `sudo`).
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -18,6 +18,18 @@ To install services using this Ansible playbook, you need to prepare several req
 
 We will be using `example.com` as the domain in the following instruction. Please remember to replace it with your own domain before running any commands.
 
+## Your local computer
+
+- [Ansible](http://ansible.com/) program. It's used to run this playbook and configures your server for you. Take a look at [our guide about Ansible](ansible.md) for more information, as well as [version requirements](ansible.md#supported-ansible-versions) and alternative ways to run Ansible.
+
+- [passlib](https://passlib.readthedocs.io/en/stable/index.html) Python library. See [this official documentation](https://passlib.readthedocs.io/en/stable/install.html#installation-instructions) for an instruction to install it. On most distros, you need to install some `python-passlib` or `py3-passlib` package, etc.
+
+- [`git`](https://git-scm.com/) as the recommended way to download the playbook. `git` may also be required on the server if you will be [self-building](self-building.md) components.
+
+- [`just`](https://github.com/casey/just) for running `just roles`, `just update`, etc. (see [`justfile`](../justfile)), although you can also run these commands manually. Take at look at this documentation for more information: [Running `just` commands](just.md).
+
+- Strong password (random strings) generator. The playbook often requires you to create a strong password and use it for settings on `vars.yml`, components, etc. As any tools should be fine, this playbook has adopted [`pwgen`](https://linux.die.net/man/1/pwgen) (running `pwgen -s 64 1`). [Password Tech](https://pwgen-win.sourceforge.io/), formerly known as "PWGen for Windows", is available as free and open source password generator for Windows. Generally, using a random generator available on the internet is not recommended.
+
 - (Recommended) An **x86-64** (`amd64`) or **arm64** server running one of these operating systems:
   - **Red Hat Enterprise Linux** or derivative distros, e.g. Rocky Linux (Major version 7 or newer)
   - **Debian** (10/Buster or newer)
@@ -35,14 +47,6 @@ If your distro runs within an [LXC container](https://linuxcontainers.org/), you
 - [Python](https://www.python.org/) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python3`). On some distros, Ansible may incorrectly [detect the Python version](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) (2 vs 3) and you may need to explicitly specify the interpreter path in `inventory/hosts` during installation (e.g. `ansible_python_interpreter=/usr/bin/python3`)
 
 - [sudo](https://www.sudo.ws/) being installed on the server, even when you've configured Ansible to log in as `root`. Some distributions, like a minimal Debian net install, do not include the `sudo` package by default.
-
-- The [Ansible](http://ansible.com/) program being installed on your own computer. It's used to run this playbook and configures your server for you. Take a look at [our guide about Ansible](ansible.md) for more information, as well as [version requirements](ansible.md#supported-ansible-versions) and alternative ways to run Ansible.
-
-- the [passlib](https://passlib.readthedocs.io/en/stable/index.html) Python library installed on the computer you run Ansible. On most distros, you need to install some `python-passlib` or `py3-passlib` package, etc.
-
-- [git](https://git-scm.com/) is the recommended way to download the playbook to your computer. `git` may also be required on the server if you will be [self-building](self-building.md) components.
-
-- [just](https://github.com/casey/just) for running `just update` and playbook installation commands, etc. (see [`justfile`](../justfile)). You can get by without `just` (by running `ansible-galaxy`, `ansible-playbook` commands manually), but maintaining your playbook setup will require more manual work. `just` (thanks to the commands defined in the `justfile`) keeps various files (`setup.yml`, `requirements.yml`, `group_vars/mash_servers`) up-to-date with the templates in [the `templates/` directory](../templates/) automatically.
 
 - at least one domain name you can use
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -46,11 +46,11 @@ We will be using `example.com` as the domain in the following instruction. Pleas
 
 - `root` access to your server (or a user capable of elevating to `root` via `sudo`).
 
-- [Python](https://www.python.org/) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python3`). On some distros, Ansible may incorrectly [detect the Python version](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) (2 vs 3) and you may need to explicitly specify the interpreter path in `inventory/hosts` during installation (e.g. `ansible_python_interpreter=/usr/bin/python3`)
+- [Python](https://www.python.org/). Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python3`). On some distros, Ansible may incorrectly [detect the Python version](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) (2 vs 3) and you may need to explicitly specify the interpreter path in `inventory/hosts` during installation (e.g. `ansible_python_interpreter=/usr/bin/python3`)
 
-- [sudo](https://www.sudo.ws/) being installed on the server, even when you've configured Ansible to log in as `root`. Some distributions, like a minimal Debian net install, do not include the `sudo` package by default.
+- [sudo](https://www.sudo.ws/), even when you've configured Ansible to log in as `root`. Some distributions, like a minimal Debian net install, do not include the `sudo` package by default.
 
-- at least one domain name you can use
+- Properly configured DNS records for `example.com` (details in [Configuring DNS](configuring-dns.md)).
 
 - Some TCP/UDP ports open. This playbook (actually [Docker itself](https://docs.docker.com/network/iptables/)) configures the server's internal firewall for you. In most cases, you don't need to do anything special. But **if your server is running behind another firewall**, you'd need to open these ports:
 
@@ -58,4 +58,6 @@ We will be using `example.com` as the domain in the following instruction. Pleas
   - `443/tcp`: HTTPS webserver
   - potentially some other ports, depending on the services that you enable in the **configuring the playbook** step (later on). Consult each service's documentation page in `docs/` for that.
 
-When ready to proceed, continue with [Configuring DNS](configuring-dns.md).
+---------------------------------------------
+
+[▶️](configuring-dns.md) When ready to proceed, continue with [Configuring DNS](configuring-dns.md).


### PR DESCRIPTION
This PR intends to update docs about installation process from setting up prerequisites, through configuring DNS record, getting a playbook, configuring it, to running the playbook to install services, based on the MDAD project's documentation.