### PR TITLE
Add docs and sample vars.yml for those who use MDAD playbook 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,8 @@ If your server and services experience issues, feel free to come to [our support
 
 - [Self-building](self-building.md)
 
+- [Setting up services on the Matrix server configured with the MDAD playbook](setting-up-services-on-mdad-server.md)
+
 - [Supported services](supported-services.md)
 
 - [Uninstalling](uninstalling.md)

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Configuring interoperability with other services
 
+*If you are installing the services on the [Matrix](https://matrix.org) server configured and managed with [matrix-docker-ansible-deploy (MDAD)](https://github.com/spantaleev/matrix-docker-ansible-deploy/) Ansible playbook, you probably might want to check [this guide](setting-up-services-on-mdad-server.md).*
+
 This playbook tries to get you up and running with minimal effort and provided you have followed the [example `vars.yml` file](../examples/vars.yml), will install the [Traefik](services/traefik.md) reverse-proxy server by default.
 
 Sometimes, you're using a server which already has Traefik. In such cases these are undesirable:

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-License-Identifier: 2023 - 2024 Slavi Pantaleev
+SPDX-License-Identifier: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Configuring interoperability with other services
 
 This playbook tries to get you up and running with minimal effort and provided you have followed the [example `vars.yml` file](../examples/vars.yml), will install the [Traefik](services/traefik.md) reverse-proxy server by default.

--- a/docs/setting-up-services-on-mdad-server.md
+++ b/docs/setting-up-services-on-mdad-server.md
@@ -1,0 +1,81 @@
+<!--
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Setting up services on the Matrix server configured with the MDAD playbook
+
+If you use the [matrix-docker-ansible-deploy (MDAD)](https://github.com/spantaleev/matrix-docker-ansible-deploy/) Ansible playbook to manage [Matrix](https://matrix.org/) services on your server, you can configure the MASH playbook to set up services such as [Forgejo](services/forgejo.md), [GoToSocial](services/gotosocial.md), [Nextcloud](services/nextcloud.md), and [PeerTube](services/peertube.md), along with the Matrix services on the same server. This page explains how to do so.
+
+The basic steps to configure the MASH playbook and use it to install services are pretty same as doing so with the MDAD playbook: **setting up prerequisites (if running this playbook on a different computer), retrieving the MASH playbook, configuring it as well as the DNS records, and installing the services on the server**. If you have been accustomed to maintain Matrix services with the MDAD playbook, it should not be difficult to set up and use this playbook too.
+
+💡 This article intends to be a guide for setting up the MASH playbook to install services on your Matrix server. If you want to know exact steps from setting up the prerequisites to running the installation command, please go to [this page](prerequisites.md) and read through the installation guide.
+
+## Set up prerequisites
+
+Most [prerequisites](prerequisites.md) for the MASH playbook are common to the MDAD playbook (you can check ones for the MDAD playbook [here](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/prerequisites.md)), so it is not likely that you would need to configure something special to run the MASH playbook.
+
+Depending on the services to enable, you might have to open ports of the server. Consult each service's documentation page in `docs/` for details. By default, you do not have to open them by yourself.
+
+For the local environment, please make sure that you have installed and configured prerequisites such as [Ansible](ansible.md), if you run the MASH playbook on a different computer than the one you run the MDAD playbook.
+
+## Retrieve the MASH playbook
+
+While it is technically not impossible to integrate the roles used by the MASH playbook to the MDAD playbook, you can just retrieve the MASH playbook and run it against the same server. This way is straightforward and recommended for most cases.
+
+See [this page](getting-the-playbook.md) for details about how to get the playbook's source code. In the same way as for the MDAD playbook, you can retrieve the playbook with git or by downloading its ZIP archive.
+
+## Configure DNS settings
+
+After making sure that you have configured prerequisites and retrieving the MASH playbook, let's configure DNS records for the services which you are installing with this playbook.
+
+To configure them, go to your DNS service provider, and adjust DNS records as described [here](configuring-dns.md).
+
+If you are adding the common `mash.example.com` domain, set the same IP address as the Matrix server (e.g. `matrix.example.com`) to its A record.
+
+💡 As [uptime-kuma](services/uptime-kuma.md), which needs its subdomain for now, will be enabled by default with the sample configuration file, you can go ahead and set its CNAME record in advance. The record should match with `uptime_kuma_hostname`, which will be specified when configuring `vars.yml` file next. If you will not enable the service, you do not have to add the CNAME record, of course.
+
+## Configure the MASH playbook
+
+Next, you'll need to copy the sample inventory hosts file ([`hosts`](../examples/hosts)) and configuration file ([`vars.yml`](../examples/matrix-docker-ansible-deploy/vars.yml)) modified for installing services on your Matrix server.
+
+To do so, run the following commands inside the playbook directory. Before creating a directory, make sure to replace `mash.example.com` with your domain. Here `example.com` should be the same one where the Matrix server is hosted.
+
+```sh
+mkdir -p inventory/host_vars/mash.example.com
+
+cp examples/hosts inventory/hosts
+
+cp examples/matrix-docker-ansible-deploy/vars.yml inventory/host_vars/mash.example.com/vars.yml
+```
+
+### Configure `hosts` file
+
+After copying the files, let's edit your `hosts` file.
+
+Because you are running the playbook against the same server where the Matrix services run, you can just copy the server's external IP address specified on `hosts` file on the MDAD playbook.
+
+If you have edited the MDAD's `hosts` file on your preference (such as adjusting the SSH port), you might probably want to copy the entire line and replace the domain with the one for this playbook such as `mash.example.com`. This should work for most case, as you should have already connected to your Matrix server with such preference.
+
+### Configure `vars.yml` file
+
+Having edited the `hosts` file, you need to edit the `vars.yml` file by setting passwords, etc. Check the comments on the file for details about how to configure it.
+
+Note that `example.com` is specified as hostname values for services enabled by default such as [exim-relay](services/exim-relay.md), [uptime-kuma](services/uptime-kuma.md), etc., so do not forget to replace them with your domain.
+
+💡 The modified sample `vars.yml` file is not configured to install basic services such as [Docker](services/docker.md) and [Traefik](services/traefik.md), as both have been installed and configured on your Matrix server with the MDAD playbook. Installing them with this playbook will cause conflicts on the server. You can check [this page on interoperability](interoperability.md) for more information.
+
+## Install services by running the MASH playbook
+
+After configuring the playbook, you can proceed to installing the services.
+
+The step for installation is common to both MASH and MDAD playbooks (ie. fetching the Ansible roles and running the installation command), so there should not be a problem. If you do not feel confident pretty much, please see [this page](installing.md) to make sure what needs to be done.
+
+You can see [this page](supported-services.md) for a full list of the supported services and pick services which you want to install. When enabling a service, please check its documentation for the instruction.
+
+If you want to install services, you can do so whenever you want by running the playbook. However, it is generally not recommended to install a lot of services all at once, since it can overflow the server, which can already be suffering from heavy load of [Synapse](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-synapse.md), its de-facto Matrix homeserver.
+
+After running the installation command, make sure to check the installed services can be accessed. **If you can access to them, the installation has completed and you can use the services along with the Matrix services**🎉
+
+See [this section](installing.md#things-to-do-next) for details about what to do after successful installation. The MASH playbook, like the MDAD playbook, will **not** automatically run the maintenance task for you, so do not forget to update the playbook and re-run it **manually**.

--- a/examples/matrix-docker-ansible-deploy/vars.yml
+++ b/examples/matrix-docker-ansible-deploy/vars.yml
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: 2023 - 2025 Slavi Pantaleev
+# SPDX-License-Identifier: 2023 Julian-Samuel Gebühr
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+
+# Below is an example which installs a few services on the host, in different configuration.
+# You should tweak this example as you see fit and enable the services that you need.
+
+########################################################################
+#                                                                      #
+# Playbook                                                             #
+#                                                                      #
+########################################################################
+
+# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
+# Various other secrets will be derived from this secret automatically.
+mash_playbook_generic_secret_key: ''
+
+########################################################################
+#                                                                      #
+# /Playbook                                                            #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# Docker                                                               #
+#                                                                      #
+########################################################################
+
+# To disable Docker installation (in case you'd be installing Docker in another way),
+# remove the line below.
+mash_playbook_docker_installation_enabled: true
+
+# To disable Docker SDK for Python installation (in case you'd be installing the SDK in another way),
+# remove the line below.
+devture_docker_sdk_for_python_installation_enabled: true
+
+########################################################################
+#                                                                      #
+# /Docker                                                              #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# com.devture.ansible.role.timesync                                    #
+#                                                                      #
+########################################################################
+
+# To ensure the server's clock is synchronized (using systemd-timesyncd/ntpd),
+# we enable the timesync service.
+
+devture_timesync_installation_enabled: true
+
+########################################################################
+#                                                                      #
+# /com.devture.ansible.role.timesync                                   #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# traefik                                                              #
+#                                                                      #
+########################################################################
+
+# Most services require a reverse-proxy, so we enable Traefik here.
+#
+# Learn more about the Traefik service in docs/services/traefik.md
+#
+# If your server already runs Traefik, you will run into port conflicts by installing it twice.
+# See docs/interoperability.md for solutions.
+
+mash_playbook_reverse_proxy_type: playbook-managed-traefik
+
+########################################################################
+#                                                                      #
+# /traefik                                                             #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# postgres                                                             #
+#                                                                      #
+########################################################################
+
+# Most services require a Postgres database, so we enable Postgres here.
+#
+# Learn more about the Postgres service in docs/services/postgres.md
+
+postgres_enabled: true
+
+# Put a strong password below, generated with `pwgen -s 64 1` or in another way
+postgres_connection_password: ''
+
+########################################################################
+#                                                                      #
+# /postgres                                                            #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# exim_relay                                                           #
+#                                                                      #
+########################################################################
+
+# Various services need to send out email.
+#
+# Enabling this Exim relay SMTP mailer service automatically wires
+# all other services to send email through it.
+#
+# exim-relay then gives you a centralized place for configuring email-sending.
+
+exim_relay_enabled: true
+
+exim_relay_hostname: mash.example.com
+
+exim_relay_sender_address: "someone@{{ exim_relay_hostname }}"
+
+# By default, exim-relay attempts to deliver emails directly.
+# To make it relay via an external SMTP server, see docs/services/exim-relay.md
+
+########################################################################
+#                                                                      #
+# /exim_relay                                                          #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# miniflux                                                             #
+#                                                                      #
+########################################################################
+
+# Learn more about the Miniflux service in docs/services/miniflux.md
+#
+# This service is only here as an example. If you don't wish to use the
+# Miniflux service, remove the whole section.
+
+miniflux_enabled: true
+
+miniflux_hostname: mash.example.com
+miniflux_path_prefix: /miniflux
+
+miniflux_admin_login: your-username-here
+miniflux_admin_password: a-strong-password-here
+
+########################################################################
+#                                                                      #
+# /miniflux                                                            #
+#                                                                      #
+########################################################################
+
+
+
+########################################################################
+#                                                                      #
+# uptime-kuma                                                          #
+#                                                                      #
+########################################################################
+
+# Learn more about the Uptime-kuma service in docs/services/uptime-kuma.md
+#
+# This service is only here as an example. If you don't wish to use the
+# Uptime-kuma service, remove the whole section.
+
+uptime_kuma_enabled: true
+
+uptime_kuma_hostname: uptime-kuma.example.com
+
+# For now, hosting uptime-kuma under a path is not supported.
+# See: https://github.com/louislam/uptime-kuma/issues/147
+# uptime_kuma_path_prefix: /uptime-kuma
+
+########################################################################
+#                                                                      #
+# /uptime-kuma                                                         #
+#                                                                      #
+########################################################################
+
+
+# You can add additional services here, as you see fit.
+# To discover new services and configuration, see docs/supported-services.md

--- a/examples/matrix-docker-ansible-deploy/vars.yml
+++ b/examples/matrix-docker-ansible-deploy/vars.yml
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: 2023 - 2025 Slavi Pantaleev
 # SPDX-License-Identifier: 2023 Julian-Samuel Gebühr
+# SPDX-License-Identifier: 2025 Suguru Hirahara
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 ---
 
-# Below is an example which installs a few services on the host, in different configuration.
+# Below is an example which installs a few services on the same server
+# as your Matrix services have been installed and configured with
+# matrix-docker-ansible-deploy (MDAD) playbook.
+#
+# If you are installing services on the server where neither Docker
+# nor Traefik is installed, see vars.yml on the parent directory instead.
+#
 # You should tweak this example as you see fit and enable the services that you need.
 
 ########################################################################
@@ -30,10 +37,6 @@ mash_playbook_generic_secret_key: ''
 # Docker                                                               #
 #                                                                      #
 ########################################################################
-
-# To disable Docker installation (in case you'd be installing Docker in another way),
-# remove the line below.
-mash_playbook_docker_installation_enabled: true
 
 # To disable Docker SDK for Python installation (in case you'd be installing the SDK in another way),
 # remove the line below.
@@ -72,14 +75,21 @@ devture_timesync_installation_enabled: true
 #                                                                      #
 ########################################################################
 
-# Most services require a reverse-proxy, so we enable Traefik here.
-#
-# Learn more about the Traefik service in docs/services/traefik.md
-#
-# If your server already runs Traefik, you will run into port conflicts by installing it twice.
-# See docs/interoperability.md for solutions.
+# Tell the playbook you're using Traefik installed in another way.
+# It won't bother installing Traefik.
+mash_playbook_reverse_proxy_type: other-traefik-container
 
-mash_playbook_reverse_proxy_type: playbook-managed-traefik
+# Tell the playbook to attach services which require reverse-proxying to an additional network by default (e.g. traefik)
+# This needs to match your Traefik network.
+mash_playbook_reverse_proxyable_services_additional_network: traefik
+
+# Uncomment and adjust the variables below if you'd like to enable HTTP-compression.
+#
+# For this to work, you will need to define a compress middleware (https://doc.traefik.io/traefik/middlewares/http/compress/) for your Traefik instance
+# using a file (https://doc.traefik.io/traefik/providers/file/) or Docker (https://doc.traefik.io/traefik/providers/docker/) configuration provider.
+#
+# mash_playbook_reverse_proxy_traefik_middleware_compession_enabled: true
+# mash_playbook_reverse_proxy_traefik_middleware_compession_name: my-compression-middleware@file
 
 ########################################################################
 #                                                                      #

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: 2023 - 2025 Slavi Pantaleev
+# SPDX-License-Identifier: 2023 Julian-Samuel Gebühr
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Below is an example which installs a few services on the host, in different configuration.


### PR DESCRIPTION
This PR intends to add and edit docs for those who use the [MDAD playbook](https://github.com/spantaleev/matrix-docker-ansible-deploy), so that they can jump start using the MASH playbook on their Matrix server.

Since they are expected to be somewhat familiar with running and setting an Ansible playbook (as well as reading docs about installation steps on the MDAD playbook), such a guide should help them to use this playbook to manage services along with the Matrix services.

There is already a nice instruction on docs/interoperability.md about what to be configured how, and providing a whole picture with a single document from setting up prerequisites (which in fact should not be really necessary as they are almost same as for the MDAD playbook) to running a installation command should also be as helpful as it. Because most things which need to be configured are common to the MDAD playbook, I think the documentation does not have to be so detailed.

Additionally, on my experience I think preparing a customized vars.yml file should also be helpful for those who are not perfectly quite sure how to adjust Docker and Traefik on the default sample vars.yml. Even though it is indeed documented on docs/interoperability.md pretty clearly, I think that the less there are variables which have to be adjusted manually, the better it should be :smile: