### PR TITLE
Update docs: introductions

### DIFF
--- a/docs/services/backup-borg.md
+++ b/docs/services/backup-borg.md
@@ -14,6 +14,6 @@ The playbook can install and configure [BorgBackup](https://www.borgbackup.org/)
 
 BorgBackup is a deduplicating backup program with optional compression and encryption. That means your daily incremental backups can be stored in a fraction of the space and is safe whether you store it at home or on a cloud service.
 
-The Ansible role for BorgBackup is developed and maintained by [the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg). For details about configuring BorgBackup, you can check them via:
+The [Ansible role for BorgBackup](https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg) is developed and maintained by the MASH project. For details about configuring BorgBackup, you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg/blob/main/docs/configuring-backup-borg.md) online
 - 📁 `roles/galaxy/backup_borg/docs/configuring-backup-borg.md` locally, if you have [fetched the Ansible roles](../installing.md)

--- a/docs/services/exim-relay.md
+++ b/docs/services/exim-relay.md
@@ -13,7 +13,7 @@ Various services need to send out email.
 
 The default playbook configuration (`examples/vars.yml`) recommends that you enable the Exim relay SMTP mailer service (powered by [exim-relay](https://github.com/devture/exim-relay) and the [ansible-role-exim-relay](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay) Ansible role). Enabling this service **automatically wires various other services to send email through it**. Exim-relay then gives you a centralized place for configuring email-sending.
 
-The Ansible role for exim-relay is developed and maintained by [the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay). For details about configuring exim-relay, you can check them via:
+The [Ansible role for exim-relay](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay) is developed and maintained by the MASH project. For details about configuring exim-relay, you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md) online
 - 📁 `roles/galaxy/exim_relay/docs/configuring-exim-relay.md` locally, if you have [fetched the Ansible roles](../installing.md)
 

--- a/docs/services/jitsi.md
+++ b/docs/services/jitsi.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 The playbook can install and configure the [Jitsi](https://jitsi.org/) video-conferencing platform for you.
 
-The Ansible role for Jitsi is developed and maintained by [the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi). For details about configuring Jitsi, you can check them via:
+The [Ansible role for Jitsi](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi) is developed and maintained by the MASH project. For details about configuring Jitsi, you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/docs/configuring-jitsi.md) online
 - 📁 `roles/galaxy/jitsi/docs/configuring-jitsi.md` locally, if you have [fetched the Ansible roles](../installing.md)
 

--- a/docs/services/postgres-backup.md
+++ b/docs/services/postgres-backup.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 The playbook can install and configure [docker-postgres-backup-local](https://github.com/prodrigestivill/docker-postgres-backup-local) for you.
 
-The Ansible role for docker-postgres-backup-local is developed and maintained by [the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-postgres-backup). For details about configuring docker-postgres-backup-local, you can check them via:
+The [Ansible role for docker-postgres-backup-local](https://github.com/mother-of-all-self-hosting/ansible-role-postgres-backup) is developed and maintained by the MASH project. For details about configuring docker-postgres-backup-local, you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-postgres-backup/blob/main/docs/configuring-postgres-backup.md) online
 - 📁 `roles/galaxy/postgres_backup/docs/configuring-postgres-backup.md` locally, if you have [fetched the Ansible roles](../installing.md)
 


### PR DESCRIPTION
Linking to the roles instead of the project: because both those roles and the playbook are maintained by the MASH project, linking to the project is insistent.