### PR TITLE
Add ntfy

### DIFF
--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -4,35 +4,72 @@ SPDX-FileCopyrightText: 2022 Julian Foad
 SPDX-FileCopyrightText: 2022 MDAD project contributors
 SPDX-FileCopyrightText: 2023 Felix Stupp
 SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Setting up the ntfy push notifications server (optional)
+# ntfy
 
 The playbook can install and configure the [ntfy](https://ntfy.sh/) push notifications server for you.
 
-Using the [UnifiedPush](https://unifiedpush.org) standard, ntfy enables self-hosted (Google-free) push notifications from Matrix (and other) servers to UnifiedPush-compatible Matrix compatible client apps running on Android and other devices.
+ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests. It enables you to send/receive notifications, without relying on servers owned and controlled by third parties.
 
 See the project's [documentation](https://docs.ntfy.sh/) to learn what it does and why it might be useful to you.
 
-**Notes**:
-- To make use of your ntfy installation, you need to install [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/) on your device and configuring your UnifiedPush-compatible Matrix client. **Otherwise your device will not receive push notifications from the ntfy server.** Refer [this section](#usage) for details.
-- This playbook focuses on setting up a ntfy server for getting it send UnifiedPush notifications to Matrix-related services that this playbook installs, while the installed server will be available for other non-Matrix apps as well like [Tusky](https://tusky.app/) and [DAVx⁵](https://www.davx5.com/). This playbook does not intend to support all of ntfy's features.
+The [Ansible role for ntfy](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy) is developed and maintained by the MASH project. For details about configuring ntfy, you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md) online
+- 📁 `roles/galaxy/ntfy/docs/configuring-ntfy.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
-The [Ansible role for ntfy](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy) is developed and maintained by [the MASH (mother-of-all-self-hosting) project](https://github.com/mother-of-all-self-hosting). For details about configuring ntfy, you can check them via:
-- 🌐 [the role's documentation at the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md) online
-- 📁 `roles/galaxy/ntfy/docs/configuring-ntfy.md` locally, if you have [fetched the Ansible roles](installing.md#update-ansible-roles)
+**Note**: you need to install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/) on your device in order to receive push notifications from the ntfy server. Notifications can also be sent/received on the ntfy's web app if it is enabled (disabled by default). Refer [this section](#usage) for details about how to use the apps.
 
-## Adjusting DNS records
+### How ntfy works with UnifiedPush
 
-By default, this playbook installs ntfy on the `ntfy.` subdomain (`ntfy.example.com`) and requires you to create a CNAME record for `ntfy`, which targets `matrix.example.com`.
+⚠️ [UnifiedPush does not work on iOS.](https://unifiedpush.org/users/faq/#will-unifiedpush-ever-work-on-ios)
 
-When setting, replace `example.com` with your own.
+ntfy implements [UnifiedPush](https://unifiedpush.org), the standard which makes it possible to send and receive push notifications without using Google's Firebase Cloud Messaging (FCM) service.
+
+Working as a **Push Server**, a ntfy server can forward messages to a **Distributor** running on Android and other devices (see [here](https://unifiedpush.org/users/distributors/#definitions) for the definition of the Push Server and the Distributor).
+
+This role installs and manages a self-hosted ntfy server as the Push Server, which the Distributor (such as the ntfy Android app) on your device listens to.
+
+Your UnifiedPush-compatible applications (such as [Tusky](https://tusky.app/) and [DAVx⁵](https://www.davx5.com/)) listen to the Distributor, and push notitications are "distributed" from it. This means that the UnifiedPush-compatible applications cannot receive push notifications from the Push Server without the Distributor.
+
+As the ntfy Android app functions as the Distributor too, you do not have to install something else on your device.
+
+💡 **Notes**:
+- Refer [this official documentation of UnifiedPush](https://unifiedpush.org/users/troubleshooting/#understand-unifiedpush) for a simple explanation about relationship among UnifiedPush-compatible application, Distributor, Push Server, and the application's server.
+- [Here](https://unifiedpush.org/users/apps/) is a non-exhaustive list of the end-user applications that use UnifiedPush.
+- Unlike push notifications using Google's FCM or Apple's APNs, each end-user can choose the Push Server which one prefer. This means that deploying a ntfy server cannot enforce a UnifiedPush-compatible application (and its users) to use the exact server.
+
+### iOS instant notification
+
+Because iOS heavily restricts background processing, it is impossible to implement instant push notifications without a central server.
+
+To implement instant notification through the self-hosted ntfy server, see [this official documentation](https://docs.ntfy.sh/config/#ios-instant-notifications) for instructions.
+
+## Dependencies
+
+This service requires the following other services:
+
+- a [Traefik](traefik.md) reverse-proxy server
+- (optional) the [exim-relay](exim-relay.md) mailer
 
 ## Adjusting the playbook configuration
 
-To enable ntfy, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
 
 ```yaml
 ########################################################################
@@ -43,6 +80,8 @@ To enable ntfy, add the following configuration to your `inventory/host_vars/mat
 
 ntfy_enabled: true
 
+ntfy_hostname: ntfy.example.com
+
 ########################################################################
 #                                                                      #
 # /ntfy                                                                #
@@ -50,96 +89,24 @@ ntfy_enabled: true
 ########################################################################
 ```
 
-As the most of the necessary settings for the role have been taken care of by the playbook, you can enable ntfy on your Matrix server with this minimum configuration.
+As the most of the necessary settings for the role have been taken care of by the playbook, you can enable ntfy on your server with this minimum configuration.
 
-See the role's documentation for details about configuring ntfy per your preference (such as [setting access control with authentication](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#enable-access-control-with-authentication-optional)).
-
-### Adjusting the ntfy URL (optional)
-
-By tweaking the `ntfy_hostname` variable, you can easily make the service available at a **different hostname** than the default one.
-
-Example additional configuration for your `vars.yml` file:
-
-```yaml
-# Change the default hostname
-ntfy_hostname: push.example.com
-```
-
-After changing the domain, **you may need to adjust your DNS** records to point the ntfy domain to the Matrix server.
-
-### Enable web app (optional)
-
-ntfy also has a web app to subscribe to and push to topics from the browser. This may be helpful to troubleshoot notification issues or to use ntfy for other purposes than getting ntfy send UnifiedPush notifications to your Matrix-related services.
-
-To enable the web app, add the following configuration to your `vars.yml` file:
-
-```yaml
-ntfy_web_root: app
-```
-
-See [the official documentation](https://docs.ntfy.sh/subscribe/web/) for details about how to use it.
-
-## Installing
-
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
-
-<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
-```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
-```
-
-The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
-
-`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
+See the role's documentation for details about configuring ntfy per your preference (such as [setting access control with authentication](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#enable-access-control-with-authentication-optional), [allowing attachments](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#allow-attachments-optional), [enabling the web app](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#enable-web-app-optional) and [e-mail notification](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#enable-e-mail-notification-optional), etc.)
 
 ## Usage
 
-Unlike push notifications using Google's FCM or Apple's APNs, each end-user can choose the UnifiedPush-enabled push notification server that one prefer. This means that deploying a ntfy server does not ensure any particular user, device or Matrix client will use it.
+To receive push notifications from the ntfy server, you need to **install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/)** and then **subscribe to a topic** where messages will be published. You can also send/receive notifications on the ntfy's web app at `example.com`.
 
-To receive push notifications from your ntfy server, you need to set up these two applications on your device:
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#usage) on the role's documentation for details.
 
-* [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/)
-* a UnifiedPush-compatible Matrix client
+### UnifiedPush-compatible application
 
-For details about installing and configuring the `ntfy` app, take a look at [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#setting-up-the-ntfy-android-app) on the role's documentation.
+To receive push notifications on a UnifiedPush-compatible application, it must be able to communicate with the ntfy Android app which works as the Distributor on the same device.
 
-**Note**: on the app you do not need to subscribe to a notification topic by yourself, as UnifiedPush will do that automatically.
+Consult to documentation of applications for instruction about how to enable UnifiedPush support. Note that some applications quietly detect and use the Distributor, so you do not always have to configure the applications.
 
-### Setting up a UnifiedPush-compatible Matrix client
-
-After installing the `ntfy` app, install any UnifiedPush-enabled Matrix client on that same device. The Matrix client will learn from the `ntfy` app that you have configured UnifiedPush on this device, and then it will tell your Matrix server to use it.
-
-Steps needed for specific Matrix clients:
-
-* FluffyChat-android: this should auto-detect and use the app. No manual settings required.
-
-* SchildiChat-android:
-  1. enable `Settings` -> `Notifications` -> `UnifiedPush: Force custom push gateway`.
-  2. choose `Settings` -> `Notifications` -> `UnifiedPush: Re-register push distributor`. *(For info, a more complex alternative to achieve the same is: delete the relevant unifiedpush registration in `ntfy` app, force-close SchildiChat, re-open it.)*
-  3. verify `Settings` -> `Notifications` -> `UnifiedPush: Notification targets` as described below in the "Troubleshooting" section.
-
-* Element-android v1.4.26+:
-  1. choose `Settings` -> `Notifications` -> `Notification method` -> `ntfy`
-  2. verify `Settings` -> `Troubleshoot` -> `Troubleshoot notification settings`
-
-If the Matrix client asks, "Choose a distributor: FCM Fallback or ntfy", then choose "ntfy".
-
-If the Matrix client doesn't seem to pick it up, try restarting it and try the Troubleshooting section below.
+If you are configuring UnifiedPush on a [Matrix](https://matrix.org) client, you can refer [this section](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-ntfy.md#setting-up-a-unifiedpush-compatible-matrix-client) on matrix-docker-ansible-deploy (MDAD) playbook's documentation.
 
 ## Troubleshooting
 
-### Check the Matrix client
-
-First, make sure that the Matrix client you are using supports UnifiedPush. There may well be different variants of the app.
-
-To check if UnifiedPush is correctly configured on the client device, look at "Settings -> Notifications -> Notification Targets" in Element Android or SchildiChat Android, or "Settings -> Notifications -> Devices" in FluffyChat. There should be one entry for each Matrix client that has enabled push notifications, and when that client is using UnifiedPush you should see a URL that begins with your ntfy server's URL.
-
-In the "Notification Targets" screen in Element Android or SchildiChat Android, two relevant URLs are shown, "push\_key" and "Url", and both should begin with your ntfy server's URL. If "push\_key" shows your server but "Url" shows an external server such as `up.schildi.chat` then push notifications will still work but are being routed through that external server before they reach your ntfy server. To rectify that, in SchildiChat (at least around version 1.4.20.sc55) you must enable the `Force custom push gateway` setting as described in the "Usage" section above.
-
-If it is not working, useful tools are "Settings -> Notifications -> Re-register push distributor" and "Settings -> Notifications -> Troubleshoot Notifications" in SchildiChat Android (possibly also Element Android). In particular the "Endpoint/FCM" step of that troubleshooter should display your ntfy server's URL that it has discovered from the ntfy client app.
-
-The simple [UnifiedPush troubleshooting](https://unifiedpush.org/users/troubleshooting/) app [UP-Example](https://f-droid.org/en/packages/org.unifiedpush.example/) can be used to manually test UnifiedPush registration and operation on an Android device.
-
-### Check the service's logs
-
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#check-the-service-s-logs) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -1,0 +1,145 @@
+<!--
+SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Setting up the ntfy push notifications server (optional)
+
+The playbook can install and configure the [ntfy](https://ntfy.sh/) push notifications server for you.
+
+Using the [UnifiedPush](https://unifiedpush.org) standard, ntfy enables self-hosted (Google-free) push notifications from Matrix (and other) servers to UnifiedPush-compatible Matrix compatible client apps running on Android and other devices.
+
+See the project's [documentation](https://docs.ntfy.sh/) to learn what it does and why it might be useful to you.
+
+**Notes**:
+- To make use of your ntfy installation, you need to install [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/) on your device and configuring your UnifiedPush-compatible Matrix client. **Otherwise your device will not receive push notifications from the ntfy server.** Refer [this section](#usage) for details.
+- This playbook focuses on setting up a ntfy server for getting it send UnifiedPush notifications to Matrix-related services that this playbook installs, while the installed server will be available for other non-Matrix apps as well like [Tusky](https://tusky.app/) and [DAVx⁵](https://www.davx5.com/). This playbook does not intend to support all of ntfy's features.
+
+The [Ansible role for ntfy](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy) is developed and maintained by [the MASH (mother-of-all-self-hosting) project](https://github.com/mother-of-all-self-hosting). For details about configuring ntfy, you can check them via:
+- 🌐 [the role's documentation at the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md) online
+- 📁 `roles/galaxy/ntfy/docs/configuring-ntfy.md` locally, if you have [fetched the Ansible roles](installing.md#update-ansible-roles)
+
+## Adjusting DNS records
+
+By default, this playbook installs ntfy on the `ntfy.` subdomain (`ntfy.example.com`) and requires you to create a CNAME record for `ntfy`, which targets `matrix.example.com`.
+
+When setting, replace `example.com` with your own.
+
+## Adjusting the playbook configuration
+
+To enable ntfy, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+########################################################################
+#                                                                      #
+# ntfy                                                                 #
+#                                                                      #
+########################################################################
+
+ntfy_enabled: true
+
+########################################################################
+#                                                                      #
+# /ntfy                                                                #
+#                                                                      #
+########################################################################
+```
+
+As the most of the necessary settings for the role have been taken care of by the playbook, you can enable ntfy on your Matrix server with this minimum configuration.
+
+See the role's documentation for details about configuring ntfy per your preference (such as [setting access control with authentication](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#enable-access-control-with-authentication-optional)).
+
+### Adjusting the ntfy URL (optional)
+
+By tweaking the `ntfy_hostname` variable, you can easily make the service available at a **different hostname** than the default one.
+
+Example additional configuration for your `vars.yml` file:
+
+```yaml
+# Change the default hostname
+ntfy_hostname: push.example.com
+```
+
+After changing the domain, **you may need to adjust your DNS** records to point the ntfy domain to the Matrix server.
+
+### Enable web app (optional)
+
+ntfy also has a web app to subscribe to and push to topics from the browser. This may be helpful to troubleshoot notification issues or to use ntfy for other purposes than getting ntfy send UnifiedPush notifications to your Matrix-related services.
+
+To enable the web app, add the following configuration to your `vars.yml` file:
+
+```yaml
+ntfy_web_root: app
+```
+
+See [the official documentation](https://docs.ntfy.sh/subscribe/web/) for details about how to use it.
+
+## Installing
+
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
+
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
+
+`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
+
+## Usage
+
+Unlike push notifications using Google's FCM or Apple's APNs, each end-user can choose the UnifiedPush-enabled push notification server that one prefer. This means that deploying a ntfy server does not ensure any particular user, device or Matrix client will use it.
+
+To receive push notifications from your ntfy server, you need to set up these two applications on your device:
+
+* [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/)
+* a UnifiedPush-compatible Matrix client
+
+For details about installing and configuring the `ntfy` app, take a look at [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#setting-up-the-ntfy-android-app) on the role's documentation.
+
+**Note**: on the app you do not need to subscribe to a notification topic by yourself, as UnifiedPush will do that automatically.
+
+### Setting up a UnifiedPush-compatible Matrix client
+
+After installing the `ntfy` app, install any UnifiedPush-enabled Matrix client on that same device. The Matrix client will learn from the `ntfy` app that you have configured UnifiedPush on this device, and then it will tell your Matrix server to use it.
+
+Steps needed for specific Matrix clients:
+
+* FluffyChat-android: this should auto-detect and use the app. No manual settings required.
+
+* SchildiChat-android:
+  1. enable `Settings` -> `Notifications` -> `UnifiedPush: Force custom push gateway`.
+  2. choose `Settings` -> `Notifications` -> `UnifiedPush: Re-register push distributor`. *(For info, a more complex alternative to achieve the same is: delete the relevant unifiedpush registration in `ntfy` app, force-close SchildiChat, re-open it.)*
+  3. verify `Settings` -> `Notifications` -> `UnifiedPush: Notification targets` as described below in the "Troubleshooting" section.
+
+* Element-android v1.4.26+:
+  1. choose `Settings` -> `Notifications` -> `Notification method` -> `ntfy`
+  2. verify `Settings` -> `Troubleshoot` -> `Troubleshoot notification settings`
+
+If the Matrix client asks, "Choose a distributor: FCM Fallback or ntfy", then choose "ntfy".
+
+If the Matrix client doesn't seem to pick it up, try restarting it and try the Troubleshooting section below.
+
+## Troubleshooting
+
+### Check the Matrix client
+
+First, make sure that the Matrix client you are using supports UnifiedPush. There may well be different variants of the app.
+
+To check if UnifiedPush is correctly configured on the client device, look at "Settings -> Notifications -> Notification Targets" in Element Android or SchildiChat Android, or "Settings -> Notifications -> Devices" in FluffyChat. There should be one entry for each Matrix client that has enabled push notifications, and when that client is using UnifiedPush you should see a URL that begins with your ntfy server's URL.
+
+In the "Notification Targets" screen in Element Android or SchildiChat Android, two relevant URLs are shown, "push\_key" and "Url", and both should begin with your ntfy server's URL. If "push\_key" shows your server but "Url" shows an external server such as `up.schildi.chat` then push notifications will still work but are being routed through that external server before they reach your ntfy server. To rectify that, in SchildiChat (at least around version 1.4.20.sc55) you must enable the `Force custom push gateway` setting as described in the "Usage" section above.
+
+If it is not working, useful tools are "Settings -> Notifications -> Re-register push distributor" and "Settings -> Notifications -> Troubleshoot Notifications" in SchildiChat Android (possibly also Element Android). In particular the "Endpoint/FCM" step of that troubleshooter should display your ntfy server's URL that it has discovered from the ntfy client app.
+
+The simple [UnifiedPush troubleshooting](https://unifiedpush.org/users/troubleshooting/) app [UP-Example](https://f-droid.org/en/packages/org.unifiedpush.example/) can be used to manually test UnifiedPush registration and operation on an Android device.
+
+### Check the service's logs
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#check-the-service-s-logs) on the role's documentation for details.

--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -94,6 +94,8 @@ To receive push notifications from the ntfy server, you need to **install [the n
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#usage) on the role's documentation for details.
 
+If you enable [Uptime-kuma](uptime-kuma.md), the self-hosted monitoring tool (hint: this playbook enables it by default on its example `vars.yml` files), it is possible to set it up to have it send notifications to a topic when the monitored web service is down. You can subscribe to the topic both from the ntfy Android/iOS app and the web app.
+
 ### UnifiedPush-compatible application
 
 To receive push notifications on a UnifiedPush-compatible application, it must be able to communicate with the ntfy Android app which works as the Distributor on the same device.

--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # ntfy
 
-The playbook can install and configure the [ntfy](https://ntfy.sh/) push notifications server for you.
+The playbook can install and configure the [ntfy](https://ntfy.sh/) (pronounced "notify") push notifications server for you.
 
 ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests. It enables you to send/receive notifications, without relying on servers owned and controlled by third parties.
 

--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -1,9 +1,4 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
-SPDX-FileCopyrightText: 2022 Julian Foad
-SPDX-FileCopyrightText: 2022 MDAD project contributors
-SPDX-FileCopyrightText: 2023 Felix Stupp
-SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
 SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
 SPDX-FileCopyrightText: 2020 Aaron Raimist

--- a/docs/services/uptime-kuma.md
+++ b/docs/services/uptime-kuma.md
@@ -1,6 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Uptime-kuma
 
-[Uptime-kuma](https://uptime.kuma.pet/) is a fancy self-hosted monitoring tool.
+[Uptime-kuma](https://uptime.kuma.pet/) is a fancy self-hosted monitoring tool. You can add a monitor for various web services like HTTP, TCP port, Docker Container, PostgreSQL, and so on.
 
 
 ## Dependencies
@@ -38,4 +45,6 @@ uptime_kuma_hostname: mash.example.com
 
 ## Usage
 
-The first time you open the Uptime-kuma Web UI it will make you go through a setup wizard, which will set up your admin credentials.
+When you open the Uptime-kuma Web UI for the first time, it starts a setup wizard where you'll create your admin credentials. You can then add monitors for web services as many as you like.
+
+If you have enabled a self-hosted [ntfy](ntfy.md) server, it is possible to set up the Uptime-kuma instance to have it send notifications to a ntfy's "topic" (channel) when the monitored web service is down, without relaying the notifications through servers owned and controlled by third parties.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -60,6 +60,7 @@
 | [n.eko](https://neko.m1k1o.net/) | A self-hosted virtual browser or even desktop environment | [Link](services/neko.md) |
 | [NetBox](https://docs.netbox.dev/en/stable/) | Web application that provides [IP address management (IPAM)](https://en.wikipedia.org/wiki/IP_address_management) and [data center infrastructure management (DCIM)](https://en.wikipedia.org/wiki/Data_center_management#Data_center_infrastructure_management) functionality | [Link](services/netbox.md) |
 | [Nextcloud](https://nextcloud.com/) | The most popular self-hosted collaboration solution for tens of millions of users at thousands of organizations across the globe. | [Link](services/nextcloud.md) |
+| [ntfy](https://ntfy.sh/) | Simple HTTP-based pub-sub notification service to send you push notifications from any computer, using simple HTTP PUT or POST requests. | [Link](services/ntfy.md) |
 | [Outline](https://www.getoutline.com/) | An open-source knowledge base for growing teams. | [Link](services/outline.md) |
 | [OAuth2-Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) | A reverse proxy and static file server that provides authentication using OpenID Connect Providers (Google, GitHub, [Keycloak](services/keycloak.md), and others) to SSO-protect services which do not support SSO natively. | [Link](services/oauth2-proxy.md) |
 | [Overseerr](https://overseerr.dev/) | A request management and media discovery tool for the Plex ecosystem | [Link](services/overseerr.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4562,6 +4562,8 @@ ntfy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_dir
 ntfy_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and ntfy_smtp_sender_addr_host == exim_relay_identifier | default('mash-exim-relay') and ntfy_container_network != exim_relay_container_network) else [])
   }}
 
 ntfy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
@@ -4576,6 +4578,13 @@ ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
 ntfy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
+
+# role-specific:exim_relay
+ntfy_smtp_sender_enabled: "{{ 'true' if exim_relay_enabled else '' }}"
+ntfy_smtp_sender_addr_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+ntfy_smtp_sender_addr_port: 8025
+ntfy_smtp_sender_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 ########################################################################
 #                                                                      #

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -503,6 +503,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (notfellchen_celery_worker_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'notfellchen']} if notfellchen_enabled else omit) }}
   # /role-specific:notfellchen
 
+  # role-specific:ntfy
+  - |-
+    {{ ({'name': (ntfy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'ntfy']} if ntfy_enabled else omit) }}
+  # /role-specific:ntfy
+
   # role-specific:mariadb
   - |-
     {{ ({'name': (mariadb_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'mariadb']} if mariadb_enabled else omit) }}
@@ -2924,6 +2929,16 @@ hubsite_service_nextcloud_description: "Sync your files & much more"
 hubsite_service_nextcloud_priority: 1000
 # /role-specific:nextcloud
 
+# role-specific:ntfy
+# ntfy
+hubsite_service_ntfy_enabled: "{{ ntfy_enabled }}"
+hubsite_service_ntfy_name: ntfy
+hubsite_service_ntfy_url: "https://{{ ntfy_hostname }}{{ ntfy_path_prefix }}"
+hubsite_service_ntfy_logo_location: "{{ role_path }}/assets/ntfy.png"
+hubsite_service_ntfy_description: "Send push notifications from any computer"
+hubsite_service_ntfy_priority: 1000
+# /role-specific:ntfy
+
 # role-specific:owncast
 # Owncast
 hubsite_service_owncast_enabled: "{{ owncast_enabled }}"
@@ -3289,6 +3304,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_nextcloud_enabled else omit)
     }}
   # /role-specific:nextcloud
+
+  # role-specific:ntfy
+  - |-
+    {{
+      ({
+        'name': hubsite_service_ntfy_name,
+        'url': hubsite_service_ntfy_url,
+        'logo_location': hubsite_service_ntfy_logo_location,
+        'description': hubsite_service_ntfy_description,
+        'priority': hubsite_service_ntfy_priority,
+      } if hubsite_service_ntfy_enabled else omit)
+    }}
+  # /role-specific:ntfy
 
   # role-specific:owncast
   - |-
@@ -4514,6 +4542,47 @@ notfellchen_sws_container_labels_traefik_tls_certResolver: "{{ notfellchen_conta
 ########################################################################
 # /role-specific:notfellchen
 
+
+# role-specific:ntfy
+########################################################################
+#                                                                      #
+# ntfy                                                                 #
+#                                                                      #
+########################################################################
+
+ntfy_enabled: false
+
+ntfy_identifier: "{{ mash_playbook_service_identifier_prefix }}ntfy"
+
+ntfy_uid: "{{ mash_playbook_uid }}"
+ntfy_gid: "{{ mash_playbook_gid }}"
+
+ntfy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}ntfy"
+
+ntfy_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+ntfy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+ntfy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
+  {{
+    [ntfy_hostname]
+  }}
+
+# role-specific:traefik
+ntfy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /ntfy                                                                #
+#                                                                      #
+########################################################################
+# /role-specific:ntfy
 
 
 # role-specific:outline

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -260,6 +260,10 @@
   version: v0.4.0-0
   name: notfellchen
   activation_prefix: notfellchen_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-ntfy.git
+  version: v2.11.0-4
+  name: ntfy
+  activation_prefix: ntfy_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-oauth2-proxy.git
   version: v7.6.0-1
   name: oauth2_proxy

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -315,6 +315,10 @@
     - role: galaxy/notfellchen
     # /role-specific:notfellchen
 
+    # role-specific:ntfy
+    - role: galaxy/ntfy
+    # /role-specific:ntfy
+
     # role-specific:oauth2_proxy
     - role: galaxy/oauth2_proxy
     # /role-specific:oauth2_proxy


### PR DESCRIPTION
This PR intends to add ntfy, based on the existing implementation at matrix-docker-ansible-deploy.

ntfy is not just a humble UnifiedPush service but also has its own powerful functions like sending/receiving notifications with attachment, forwarding notifications to email address, and so on.

As this is my first ever trial of implementing a role to a playbook, I have to admit that there is likely to be misconfiguration on `templates/group_vars_mash_servers`… Please feel free to correct them as they should be.