### PR TITLE
Add Etherpad

### DIFF
--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -12,14 +12,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Etherpad
 
-The playbook can install and configure [Etherpad](https://etherpad.org) for you.
-
-Etherpad is an open source collaborative text editor. When enabled together with the Jitsi video-conferencing platform (see [our docs on Jitsi](jitsi.md)), it will be made available as an option during the conferences.
+The playbook can install and configure [Etherpad](https://etherpad.org), an open source collaborative text editor, for you.
 
 The [Ansible role for Etherpad](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad) is developed and maintained by the MASH project. For details about configuring Etherpad, you can check them via:
 
 - 🌐 [the role's documentation at the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md) online
-- 📁 `roles/galaxy/etherpad/docs/configuring-etherpad.md` locally, if you have [fetched the Ansible roles](installing.md#update-ansible-roles)
+- 📁 `roles/galaxy/etherpad/docs/configuring-etherpad.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -61,6 +59,12 @@ You probably might want to enable authentication to disallow anonymous access to
 It is possible to enable HTTP basic authentication by **creating an admin user** with `etherpad_admin_username` and `etherpad_admin_password` variables. The admin user account is also used by plugins for authentication and authorization.
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#create-admin-user-optional) on the role's documentation for details about how to create the admin user.
+
+### Control Etherpad's availability on Jitsi conferences (optional)
+
+If a Jitsi video-conferencing platform (see [our docs on Jitsi](jitsi.md)) is enabled on your server, you can configure it so to make Etherpad available on conferences.
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/docs/configuring-jitsi.md#control-etherpads-availability-on-jitsi-conferences) on the Jitsi role's documentation for details about how to set it up.
 
 ## Usage
 

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -10,28 +10,27 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Setting up Etherpad (optional)
+# Etherpad
 
 The playbook can install and configure [Etherpad](https://etherpad.org) for you.
 
-Etherpad is an open source collaborative text editor. It can not only be integrated with Element clients ([Element Web](configuring-playbook-client-element-web.md)/Desktop, Android and iOS) as a widget, but also be used as standalone web app.
+Etherpad is an open source collaborative text editor. When enabled together with the Jitsi video-conferencing platform (see [our docs on Jitsi](jitsi.md)), it will be made available as an option during the conferences.
 
-When enabled together with the Jitsi video-conferencing platform (see [our docs on Jitsi](configuring-playbook-jitsi.md)), it will be made available as an option during the conferences.
-
-The [Ansible role for Etherpad](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad) is developed and maintained by [the MASH (mother-of-all-self-hosting) project](https://github.com/mother-of-all-self-hosting). For details about configuring Etherpad, you can check them via:
+The [Ansible role for Etherpad](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad) is developed and maintained by the MASH project. For details about configuring Etherpad, you can check them via:
 
 - 🌐 [the role's documentation at the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md) online
 - 📁 `roles/galaxy/etherpad/docs/configuring-etherpad.md` locally, if you have [fetched the Ansible roles](installing.md#update-ansible-roles)
 
-## Adjusting DNS records
+## Dependencies
 
-By default, this playbook installs Etherpad on the `etherpad.` subdomain (`etherpad.example.com`) and requires you to create a CNAME record for `etherpad`, which targets `matrix.example.com`.
+This service requires the following other services:
 
-When setting, replace `example.com` with your own.
+- a [Postgres](postgres.md) database
+- a [Traefik](traefik.md) reverse-proxy server
 
 ## Adjusting the playbook configuration
 
-To enable Etherpad, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
 
 ```yaml
 ########################################################################
@@ -42,6 +41,8 @@ To enable Etherpad, add the following configuration to your `inventory/host_vars
 
 etherpad_enabled: true
 
+etherpad_hostname: etherpad.example.com
+
 ########################################################################
 #                                                                      #
 # /etherpad                                                            #
@@ -49,7 +50,7 @@ etherpad_enabled: true
 ########################################################################
 ```
 
-As the most of the necessary settings for the role have been taken care of by the playbook, you can enable Etherpad on your Matrix server with this minimum configuration.
+As the most of the necessary settings for the role have been taken care of by the playbook, you can enable Etherpad on your server with this minimum configuration.
 
 See the role's documentation for details about configuring Etherpad per your preference (such as [the name of the instance](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#set-the-name-of-the-instance-optional) and [the default pad text](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#set-the-default-text-optional)).
 
@@ -61,51 +62,11 @@ It is possible to enable HTTP basic authentication by **creating an admin user**
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#create-admin-user-optional) on the role's documentation for details about how to create the admin user.
 
-### Adjusting the Etherpad URL (optional)
-
-By tweaking the `etherpad_hostname` and `etherpad_path_prefix` variables, you can easily make the service available at a **different hostname and/or path** than the default one.
-
-Example additional configuration for your `vars.yml` file:
-
-```yaml
-# Switch to the domain used for Matrix services (`matrix.example.com`),
-# so we won't need to add additional DNS records for Etherpad.
-etherpad_hostname: "{{ matrix_server_fqn_matrix }}"
-
-# Expose under the /etherpad subpath
-etherpad_path_prefix: /etherpad
-```
-
-After changing the domain, **you may need to adjust your DNS** records to point the Etherpad domain to the Matrix server.
-
-If you've decided to reuse the `matrix.` domain, you won't need to do any extra DNS configuration.
-
-## Installing
-
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
-
-<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
-```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
-```
-
-The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
-
-`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
-
 ## Usage
 
 By default, the Etherpad UI should be available at `https://etherpad.example.com`, while the admin UI (if enabled) should then be available at `https://etherpad.example.com/admin`.
 
-If you've [decided on another hostname or path-prefix](#adjusting-the-etherpad-url-optional) (e.g. `https://matrix.example.com/etherpad`), adjust these URLs accordingly before using it.
-
 💡 For more information about usage, take a look at [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#usage) on the role's documentation.
-
-### Integrating a Etherpad widget in a room
-
-**Note**: this is how it works in Element Web. It might work quite similar with other clients:
-
-To integrate a standalone Etherpad in a room, create your pad by visiting `https://etherpad.example.com`. When the pad opens, copy the URL and send a command like this to the room: `/addwidget URL`. You will then find your integrated Etherpad within the right sidebar in the `Widgets` section.
 
 ## Troubleshooting
 

--- a/docs/services/etherpad.md
+++ b/docs/services/etherpad.md
@@ -1,0 +1,112 @@
+<!--
+SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2021 Béla Becker
+SPDX-FileCopyrightText: 2021 pushytoxin
+SPDX-FileCopyrightText: 2022 Jim Myhrberg
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+SPDX-FileCopyrightText: 2022 felixx9
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Setting up Etherpad (optional)
+
+The playbook can install and configure [Etherpad](https://etherpad.org) for you.
+
+Etherpad is an open source collaborative text editor. It can not only be integrated with Element clients ([Element Web](configuring-playbook-client-element-web.md)/Desktop, Android and iOS) as a widget, but also be used as standalone web app.
+
+When enabled together with the Jitsi video-conferencing platform (see [our docs on Jitsi](configuring-playbook-jitsi.md)), it will be made available as an option during the conferences.
+
+The [Ansible role for Etherpad](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad) is developed and maintained by [the MASH (mother-of-all-self-hosting) project](https://github.com/mother-of-all-self-hosting). For details about configuring Etherpad, you can check them via:
+
+- 🌐 [the role's documentation at the MASH project](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md) online
+- 📁 `roles/galaxy/etherpad/docs/configuring-etherpad.md` locally, if you have [fetched the Ansible roles](installing.md#update-ansible-roles)
+
+## Adjusting DNS records
+
+By default, this playbook installs Etherpad on the `etherpad.` subdomain (`etherpad.example.com`) and requires you to create a CNAME record for `etherpad`, which targets `matrix.example.com`.
+
+When setting, replace `example.com` with your own.
+
+## Adjusting the playbook configuration
+
+To enable Etherpad, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+########################################################################
+#                                                                      #
+# etherpad                                                             #
+#                                                                      #
+########################################################################
+
+etherpad_enabled: true
+
+########################################################################
+#                                                                      #
+# /etherpad                                                            #
+#                                                                      #
+########################################################################
+```
+
+As the most of the necessary settings for the role have been taken care of by the playbook, you can enable Etherpad on your Matrix server with this minimum configuration.
+
+See the role's documentation for details about configuring Etherpad per your preference (such as [the name of the instance](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#set-the-name-of-the-instance-optional) and [the default pad text](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#set-the-default-text-optional)).
+
+### Create admin user (optional)
+
+You probably might want to enable authentication to disallow anonymous access to your Etherpad.
+
+It is possible to enable HTTP basic authentication by **creating an admin user** with `etherpad_admin_username` and `etherpad_admin_password` variables. The admin user account is also used by plugins for authentication and authorization.
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#create-admin-user-optional) on the role's documentation for details about how to create the admin user.
+
+### Adjusting the Etherpad URL (optional)
+
+By tweaking the `etherpad_hostname` and `etherpad_path_prefix` variables, you can easily make the service available at a **different hostname and/or path** than the default one.
+
+Example additional configuration for your `vars.yml` file:
+
+```yaml
+# Switch to the domain used for Matrix services (`matrix.example.com`),
+# so we won't need to add additional DNS records for Etherpad.
+etherpad_hostname: "{{ matrix_server_fqn_matrix }}"
+
+# Expose under the /etherpad subpath
+etherpad_path_prefix: /etherpad
+```
+
+After changing the domain, **you may need to adjust your DNS** records to point the Etherpad domain to the Matrix server.
+
+If you've decided to reuse the `matrix.` domain, you won't need to do any extra DNS configuration.
+
+## Installing
+
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
+
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
+
+`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
+
+## Usage
+
+By default, the Etherpad UI should be available at `https://etherpad.example.com`, while the admin UI (if enabled) should then be available at `https://etherpad.example.com/admin`.
+
+If you've [decided on another hostname or path-prefix](#adjusting-the-etherpad-url-optional) (e.g. `https://matrix.example.com/etherpad`), adjust these URLs accordingly before using it.
+
+💡 For more information about usage, take a look at [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#usage) on the role's documentation.
+
+### Integrating a Etherpad widget in a room
+
+**Note**: this is how it works in Element Web. It might work quite similar with other clients:
+
+To integrate a standalone Etherpad in a room, create your pad by visiting `https://etherpad.example.com`. When the pad opens, copy the URL and send a command like this to the room: `/addwidget URL`. You will then find your integrated Etherpad within the right sidebar in the `Widgets` section.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-etherpad/blob/main/docs/configuring-etherpad.md#troubleshooting) on the role's documentation for details.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -24,6 +24,7 @@
 | [Echo IP](https://github.com/mpolden/echoip) | A simple service for looking up your IP address | [Link](services/echoip.md) |
 | [Endlessh-go](https://github.com/shizunge/endlessh-go) | A golang implementation of endlessh, a ssh trapit | [Link](services/endlessh.md) |
 | [etcd](https://etcd.io/) | A distributed, reliable key-value store for the most critical data of a distributed system | [Link](services/etcd.md) |
+| [Etherpad](https://etherpad.org) | Open source collaborative text editor | [Link](services/etherpad.md) |
 | [exim-relay](https://github.com/devture/exim-relay) | A lightweight [Exim](https://www.exim.org/) SMTP mail relay server | [Link](services/exim-relay.md) |
 | [Focalboard](https://www.focalboard.com/) | An open source, self-hosted alternative to [Trello](https://trello.com/), [Notion](https://www.notion.so/), and [Asana](https://asana.com/). | [Link](services/focalboard.md) |
 | [FreshRSS](https://freshrss.org/) | RSS and Atom feed aggregator. | [Link](services/freshrss.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -295,6 +295,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (etcd_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'etcd']} if etcd_enabled else omit) }}
   # /role-specific:etcd
 
+  # role-specific:etherpad
+  - |-
+    {{ ({'name': (etherpad_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'etherpad']} if etherpad_enabled else omit) }}
+  # /role-specific:etherpad
+
   # role-specific:exim_relay
   - |-
     {{ ({'name': (exim_relay_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'exim-relay']} if exim_relay_enabled else omit) }}
@@ -782,6 +787,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
       } if authentik_enabled and authentik_database_hostname == postgres_identifier else omit)
     }}
   # /role-specific:authentik
+
+  # role-specific:etherpad
+  - |-
+    {{
+      ({
+        'name': etherpad_database_name,
+        'username': etherpad_database_username,
+        'password': etherpad_database_password,
+      } if etherpad_enabled else omit)
+    }}
+  # /role-specific:etherpad
 
   # role-specific:focalboard
   - |-
@@ -2195,6 +2211,55 @@ etcd_environment_variable_etcd_root_password: "{{ '' if etcd_environment_variabl
 ########################################################################
 # /role-specific:etcd
 
+# role-specific:etherpad
+########################################################################
+#                                                                      #
+# etherpad                                                             #
+#                                                                      #
+########################################################################
+
+etherpad_enabled: false
+
+etherpad_identifier: "{{ mash_playbook_service_identifier_prefix }}etherpad"
+
+etherpad_uid: "{{ mash_playbook_uid }}"
+etherpad_gid: "{{ mash_playbook_gid }}"
+
+etherpad_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}etherpad"
+
+etherpad_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled | default(false) and etherpad_database_hostname == postgres_identifier else [])
+  }}
+
+etherpad_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled | default(false) and etherpad_database_hostname == postgres_identifier and etherpad_container_network != postgres_container_network else [])
+  }}
+
+etherpad_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+etherpad_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+etherpad_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+etherpad_database_port: "{{ '5432' if postgres_enabled else '' }}"
+etherpad_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.etherpad', rounds=655555) | to_uuid }}"
+etherpad_database_username: "{{ etherpad_identifier }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+etherpad_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+etherpad_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /etherpad                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:etherpad
 
 # role-specific:exim_relay
 ########################################################################
@@ -2769,6 +2834,16 @@ hubsite_service_docker_registry_browser_description: "Browse docker images"
 hubsite_service_docker_registry_browser_priority: 1000
 # /role-specific:docker_registry_browser
 
+# role-specific:etherpad
+# etherpad
+hubsite_service_etherpad_enabled: "{{ etherpad_enabled }}"
+hubsite_service_etherpad_name: Etherpad
+hubsite_service_etherpad_url: "https://{{ etherpad_hostname }}{{ etherpad_path_prefix }}"
+hubsite_service_etherpad_logo_location: "{{ role_path }}/assets/etherpad.png"
+hubsite_service_etherpad_description: "Open source collaborative text editor"
+hubsite_service_etherpad_priority: 1000
+# /role-specific:etherpad
+
 # role-specific:firezone
 # Firezone
 hubsite_service_firezone_enabled: "{{ firezone_enabled }}"
@@ -3096,6 +3171,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_docker_registry_browser_enabled else omit)
     }}
   # /role-specific:docker_registry_browser
+
+  # role-specific:etherpad
+  - |-
+    {{
+      ({
+        'name': hubsite_service_etherpad_name,
+        'url': hubsite_service_etherpad_url,
+        'logo_location': hubsite_service_etherpad_logo_location,
+        'description': hubsite_service_etherpad_description,
+        'priority': hubsite_service_etherpad_priority,
+      } if hubsite_service_etherpad_enabled else omit)
+    }}
+  # /role-specific:etherpad
 
   # role-specific:firezone
   - |-

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -104,6 +104,10 @@
   version: v4.98.1-r0-2-0
   name: exim_relay
   activation_prefix: exim_relay_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-etherpad.git
+  version: v2.2.7-4
+  name: etherpad
+  activation_prefix: etherpad_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-fail2ban.git
   version: e25d0d9b5282dbb5a1ec4cd23d26c16998e4334f
   name: fail2ban

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -175,6 +175,10 @@
     - role: galaxy/etcd
     # /role-specific:etcd
 
+    # role-specific:etherpad
+    - role: galaxy/etherpad
+    # /role-specific:etherpad
+
     # role-specific:exim_relay
     - role: galaxy/exim_relay
     # /role-specific:exim_relay


### PR DESCRIPTION
This PR intends to add Etherpad, partly in case of [Etherpad on the MDAD project](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-etherpad.md) getting less relevant (or just pointless) after Element Call will practically replace Jitsi.