### PR TITLE
Update ntfy.md: add the instruction to log in to the account with authentication enabled

### DIFF
--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -90,7 +90,7 @@ See the role's documentation for details about configuring ntfy per your prefere
 
 ## Usage
 
-To receive push notifications from the ntfy server, you need to **install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/)** and then **subscribe to a topic** where messages will be published. You can also send/receive notifications on the ntfy's web app at `example.com`.
+To receive push notifications from the ntfy server, you need to **install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/)**, **log in to the account on the ntfy app** if you have enabled the access control, and then **subscribe to a topic** where messages will be published. You can also send/receive notifications on the ntfy's web app at `example.com`.
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#usage) on the role's documentation for details.
 


### PR DESCRIPTION
This has bugged me for a while as SchildiNext, therefore Element X Android too (both are client applications for Matrix), did not return an actionable error message on its UI, and I think it deserves clear instruction.