### PR TITLE
Update group_vars_mash_servers

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -58,17 +58,6 @@ authelia_config_session_secret: "{{ '%s' | format(mash_playbook_generic_secret_k
 
 authelia_config_identity_providers_oidc_hmac_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'hm.authelia', rounds=655555) | to_uuid }}"
 
-# role-specific:traefik
-authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-# role-specific:postgres
-authelia_config_storage_postgres_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-authelia_config_storage_postgres_port: "{{ '5432' if postgres_enabled else '' }}"
-authelia_config_storage_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 # role-specific:mariadb
 # If Postgres and MariaDB are not enabled, we favor Postgres.
 # We only enable MySQL if it's the only enabled component (that is, if Postgres is not enabled at the same time).
@@ -76,6 +65,17 @@ authelia_config_storage_mysql_host: "{{ mariadb_identifier if mariadb_enabled an
 authelia_config_storage_mysql_port: "{{ '3306' if mariadb_enabled else '' }}"
 authelia_config_storage_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
 # /role-specific:mariadb
+
+# role-specific:postgres
+authelia_config_storage_postgres_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+authelia_config_storage_postgres_port: "{{ '5432' if postgres_enabled else '' }}"
+authelia_config_storage_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -1457,11 +1457,6 @@ apisix_dashboard_container_additional_networks_auto: |
 apisix_dashboard_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 apisix_dashboard_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-apisix_dashboard_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-apisix_dashboard_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:etcd
 apisix_dashboard_config_conf_etcd_endpoints: |
   {{
@@ -1481,6 +1476,11 @@ apisix_dashboard_systemd_required_systemd_services_list_auto: |
     ([(etcd_identifier + '.service')] if etcd_enabled else [])
   }}
 # /role-specific:etcd
+
+# role-specific:traefik
+apisix_dashboard_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+apisix_dashboard_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -1521,11 +1521,6 @@ apisix_gateway_container_labels_metrics_path_prefix: "{{ mash_playbook_metrics_e
 apisix_gateway_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 apisix_gateway_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
-# role-specific:traefik
-apisix_gateway_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-apisix_gateway_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:etcd
 apisix_gateway_config_deployment_etcd_host: |
   {{
@@ -1545,6 +1540,11 @@ apisix_gateway_systemd_required_systemd_services_list_auto: |
     ([(etcd_identifier + '.service')] if etcd_enabled else [])
   }}
 # /role-specific:etcd
+
+# role-specific:traefik
+apisix_gateway_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+apisix_gateway_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -1687,16 +1687,8 @@ backup_borg_systemd_required_services_list: |
     ([mariadb_identifier ~ '.service'] if mariadb_enabled | default(false) else [])
   }}
 
-backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
 backup_borg_mysql_enabled: "{{ mariadb_enabled }}"
-
-# role-specific:postgres
-backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
-backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
-# /role-specific:postgres
+backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
 
 # role-specific:mariadb
 backup_borg_mysql_databases_hostname: "{{ mariadb_identifier if mariadb_enabled else '' }}"
@@ -1705,6 +1697,14 @@ backup_borg_mysql_databases_password: "{{ mariadb_root_password if mariadb_enabl
 backup_borg_mysql_databases_port: 3306
 backup_borg_mysql_databases: "{{ mariadb_managed_databases | map(attribute='name') if mariadb_enabled else [] }}"
 # /role-specific:mariadb
+
+# role-specific:postgres
+backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
+backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -2486,17 +2486,18 @@ freshrss_container_additional_networks: |
 freshrss_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 freshrss_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
+# role-specific:postgres
+freshrss_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+#
+# Intentionally not auto-generating freshrss_database_password.
+# It's meant to be explicitly defined, so that it can be used in the setup wizard after installation.
+#
+# /role-specific:postgres
+
 # role-specific:traefik
 freshrss_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 freshrss_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-# role-specific:postgres
-freshrss_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-# /role-specific:postgres
-
-# Intentionally not auto-generating freshrss_database_password.
-# It's meant to be explicitly defined, so that it can be used in the setup wizard after installation.
 
 ########################################################################
 #                                                                      #
@@ -2608,10 +2609,13 @@ gitea_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyab
 gitea_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 gitea_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
-# role-specific:traefik
-gitea_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-gitea_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+gitea_config_mailer_enabled: "{{ exim_relay_enabled }}"
+gitea_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+gitea_config_mailer_smtp_port: 8025
+gitea_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+gitea_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 gitea_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -2620,13 +2624,10 @@ gitea_config_database_username: "gitea"
 gitea_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.gitea', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-gitea_config_mailer_enabled: "{{ exim_relay_enabled }}"
-gitea_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-gitea_config_mailer_smtp_port: 8025
-gitea_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-gitea_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+gitea_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+gitea_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2675,10 +2676,11 @@ gotosocial_container_additional_networks_auto: |
 gotosocial_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 gotosocial_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-gotosocial_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-gotosocial_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+gotosocial_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+gotosocial_smtp_port: 8025
+gotosocial_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 gotosocial_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -2687,11 +2689,10 @@ gotosocial_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key
 gotosocial_database_username: "{{ gotosocial_identifier }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-gotosocial_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-gotosocial_smtp_port: 8025
-gotosocial_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+gotosocial_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+gotosocial_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2827,16 +2828,6 @@ healthchecks_environment_variable_secret_key: "{{ '%s' | format(mash_playbook_ge
 healthchecks_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 healthchecks_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-healthchecks_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-# role-specific:postgres
-healthchecks_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-healthchecks_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks.db', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 # role-specific:exim_relay
 healthchecks_environment_variable_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
 healthchecks_environment_variable_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -2844,6 +2835,16 @@ healthchecks_environment_variable_email_port: "{{ 8025 if exim_relay_enabled els
 healthchecks_environment_variable_email_use_tls: "{{ false if exim_relay_enabled else true }}"
 healthchecks_environment_variable_email_use_verification: "{{ false if exim_relay_enabled else true }}"
 # /role-specific:exim_relay
+
+# role-specific:postgres
+healthchecks_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+healthchecks_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+healthchecks_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -3759,18 +3760,18 @@ ihatemoney_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pr
 
 ihatemoney_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.imoney', rounds=655555) | to_uuid }}"
 
+# role-specific:exim_relay
+ihatemoney_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+ihatemoney_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
+ihatemoney_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
 # role-specific:postgres
 ihatemoney_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 ihatemoney_database_port: "{{ '5432' if postgres_enabled else '' }}"
 ihatemoney_database_username: "ihatemoney"
 ihatemoney_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ihatemoney', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
-
-# role-specific:exim_relay
-ihatemoney_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-ihatemoney_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
-ihatemoney_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
 
 # role-specific:traefik
 ihatemoney_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -3890,18 +3891,18 @@ infisical_frontend_container_additional_networks: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+# role-specific:mongodb
+infisical_mongodb_hostname: "{{ mongodb_identifier if mongodb_enabled else '' }}"
+infisical_mongodb_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'infisical.db', rounds=655555) | to_uuid }}"
+infisical_mongodb_auth_source: "{{ infisical_mongodb_db_name }}"
+# /role-specific:mongodb
+
 # role-specific:traefik
 infisical_backend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 infisical_backend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 infisical_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 infisical_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-# role-specific:mongodb
-infisical_mongodb_hostname: "{{ mongodb_identifier if mongodb_enabled else '' }}"
-infisical_mongodb_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'infisical.db', rounds=655555) | to_uuid }}"
-infisical_mongodb_auth_source: "{{ infisical_mongodb_db_name }}"
-# /role-specific:mongodb
 
 ########################################################################
 #                                                                      #
@@ -4077,10 +4078,13 @@ joplin_server_container_additional_networks_auto: |
 joplin_server_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 joplin_server_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-joplin_server_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-joplin_server_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+joplin_server_environment_variable_mailer_enabled: "{{ exim_relay_enabled }}"
+joplin_server_environment_variable_mailer_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+joplin_server_environment_variable_mailer_port: 8025
+joplin_server_environment_variable_mailer_noreply_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+joplin_server_environment_variable_mailer_security: MailerSecurity.None
+# /role-specific:exim_relay
 
 # role-specific:postgres
 joplin_server_environment_variable_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -4089,13 +4093,10 @@ joplin_server_environment_variable_database_user: "{{ joplin_server_identifier }
 joplin_server_environment_variable_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.joplinserver', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-joplin_server_environment_variable_mailer_enabled: "{{ exim_relay_enabled }}"
-joplin_server_environment_variable_mailer_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-joplin_server_environment_variable_mailer_port: 8025
-joplin_server_environment_variable_mailer_noreply_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-joplin_server_environment_variable_mailer_security: MailerSecurity.None
-# /role-specific:exim_relay
+# role-specific:traefik
+joplin_server_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+joplin_server_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4144,16 +4145,16 @@ keycloak_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook
 
 keycloak_environment_variable_kc_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 
-# role-specific:traefik
-keycloak_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 keycloak_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 keycloak_database_port: "{{ '5432' if postgres_enabled else '' }}"
 keycloak_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.keycloak', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+keycloak_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4194,11 +4195,6 @@ labelstudio_container_labels_traefik_compression_middleware_name: "{{ mash_playb
 
 labelstudio_postgres_backend_enabled: "{{ postgres_enabled }}"
 
-# role-specific:traefik
-labelstudio_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-labelstudio_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 labelstudio_database_name: "labelstudio"
 labelstudio_database_username: "labelstudio"
@@ -4206,6 +4202,11 @@ labelstudio_database_port: "{{ '5432' if postgres_enabled else '' }}"
 labelstudio_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 labelstudio_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.labelstudio', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+labelstudio_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+labelstudio_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4254,16 +4255,16 @@ lago_api_environment_variable_encryption_key_derivation_salt: "{{ '%s' | format(
 lago_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 lago_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-lago_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-lago_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 lago_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 lago_database_port: "{{ '5432' if postgres_enabled else '' }}"
 lago_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+lago_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+lago_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4382,16 +4383,16 @@ linkding_container_additional_networks_auto: |
 linkding_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 linkding_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-linkding_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 linkding_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 linkding_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'linkding.db', rounds=655555) | to_uuid }}"
 linkding_database_engine: "{{ 'postgres' if postgres_enabled and linkding_database_hostname == postgres_connection_hostname else 'sqlite' }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+linkding_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4432,15 +4433,15 @@ freescout_container_additional_networks: |
 freescout_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 freescout_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 freescout_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 freescout_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'freescout.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4484,15 +4485,15 @@ miniflux_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_prox
 miniflux_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 miniflux_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
-# role-specific:traefik
-miniflux_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-miniflux_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 miniflux_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 miniflux_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'miniflux.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+miniflux_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+miniflux_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4691,15 +4692,15 @@ n8n_container_additional_networks: |
 n8n_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 n8n_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-n8n_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-n8n_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 n8n_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 n8n_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'n8n.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+n8n_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+n8n_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4829,18 +4830,6 @@ nextcloud_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pro
 nextcloud_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 nextcloud_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
-# role-specific:traefik
-nextcloud_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-# role-specific:postgres
-nextcloud_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-nextcloud_database_port: "{{ '5432' if postgres_enabled else '' }}"
-nextcloud_database_username: "nextcloud"
-nextcloud_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nextcloud', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 # role-specific:exim_relay
 nextcloud_config_parameter_mail_smtphost: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
 nextcloud_config_parameter_mail_smtpport: "{{ 8025 if exim_relay_enabled else '' }}"
@@ -4849,6 +4838,18 @@ nextcloud_config_parameter_mail_smtpauth: false
 nextcloud_config_parameter_mail_from_address: "{{ (exim_relay_sender_address | split('@'))[0] if exim_relay_enabled else '' }}"
 nextcloud_config_parameter_mail_domain: "{{ (exim_relay_sender_address | split('@'))[1] if exim_relay_enabled else '' }}"
 # /role-specific:exim_relay
+
+# role-specific:postgres
+nextcloud_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+nextcloud_database_port: "{{ '5432' if postgres_enabled else '' }}"
+nextcloud_database_username: "nextcloud"
+nextcloud_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nextcloud', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+nextcloud_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4892,16 +4893,16 @@ netbox_container_additional_networks_auto: |
 netbox_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 netbox_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 netbox_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 netbox_database_port: "{{ '5432' if postgres_enabled else '' }}"
 netbox_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.netbox', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5067,17 +5068,17 @@ ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
     [ntfy_hostname]
   }}
 
-# role-specific:traefik
-ntfy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:exim_relay
 ntfy_smtp_sender_enabled: "{{ exim_relay_enabled }}"
 ntfy_smtp_sender_addr_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
 ntfy_smtp_sender_addr_port: 8025
 ntfy_smtp_sender_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
 # /role-specific:exim_relay
+
+# role-specific:traefik
+ntfy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5120,17 +5121,17 @@ outline_environment_variable_utils_secret: "{{ '%s' | format(mash_playbook_gener
 outline_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 outline_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-outline_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 outline_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 outline_database_port: "{{ '5432' if postgres_enabled else '' }}"
 outline_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.out', rounds=655555) | to_uuid }}"
 outline_database_sslmode: "{{ 'disable' if postgres_enabled and outline_database_hostname == postgres_identifier else 'prefer' }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+outline_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5341,6 +5342,12 @@ paperless_container_additional_networks_auto: |
 paperless_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 paperless_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
+# role-specific:exim_relay
+paperless_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+paperless_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
+paperless_email_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
 # role-specific:postgres
 paperless_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 paperless_database_username: "paperless"
@@ -5352,12 +5359,6 @@ paperless_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key)
 paperless_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 paperless_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-# role-specific:exim_relay
-paperless_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-paperless_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
-paperless_email_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
 
 ########################################################################
 #                                                                      #
@@ -5408,10 +5409,11 @@ peertube_systemd_wanted_services_list_auto: |
 peertube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 peertube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-peertube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-peertube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+peertube_config_smtp_hostname: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+peertube_config_smtp_port: "{{ 8025 if exim_relay_enabled else '' }}"
+peertube_config_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 peertube_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -5420,11 +5422,10 @@ peertube_config_database_username: peertube
 peertube_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.peertube', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-peertube_config_smtp_hostname: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-peertube_config_smtp_port: "{{ 8025 if exim_relay_enabled else '' }}"
-peertube_config_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+peertube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+peertube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5476,16 +5477,6 @@ plausible_container_additional_networks_auto: |
 plausible_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 plausible_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-plausible_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-plausible_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-# role-specific:postgres
-plausible_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-plausible_database_password: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'plausible.db', rounds=655555) | to_uuid) if postgres_enabled else '' }}"
-# /role-specific:postgres
-
 # role-specific:clickhouse
 plausible_clickhouse_database_hostname: "{{ clickhouse_identifier if clickhouse_enabled else '' }}"
 plausible_clickhouse_database_password: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'plaus.clk.db', rounds=655555) | to_uuid) if clickhouse_enabled else '' }}"
@@ -5500,6 +5491,16 @@ plausible_environment_variable_smtp_host_addr: "{{ exim_relay_identifier if exim
 plausible_environment_variable_smtp_host_port: "{{ 8025 if exim_relay_enabled else '587' }}"
 plausible_environment_variable_smtp_host_ssl_enabled: false
 # /role-specific:exim_relay
+
+# role-specific:postgres
+plausible_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+plausible_database_password: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'plausible.db', rounds=655555) | to_uuid) if postgres_enabled else '' }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+plausible_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+plausible_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5590,11 +5591,6 @@ prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_user
 prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_postgres_exporter_hostname | length > 0 }}"
 prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:postgres
 prometheus_postgres_exporter_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 prometheus_postgres_exporter_database_username: prometheus_postgres_exporter
@@ -5602,6 +5598,11 @@ prometheus_postgres_exporter_database_password: "{{ postgres_connection_password
 prometheus_postgres_exporter_database_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
 prometheus_postgres_exporter_database_ssl: false
 # /role-specific:postgres
+
+# role-specific:traefik
+prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6008,11 +6009,6 @@ redmine_container_additional_networks: |
 redmine_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 redmine_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-redmine_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-redmine_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 redmine_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite3' }}"
 
 # role-specific:postgres
@@ -6020,6 +6016,11 @@ redmine_database_hostname: "{{ postgres_connection_hostname if postgres_enabled 
 redmine_database_username: "redmine"
 redmine_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'redmine.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
+
+# role-specific:traefik
+redmine_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+redmine_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6491,10 +6492,11 @@ tandoor_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_sec
 tandoor_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 tandoor_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-tandoor_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-tandoor_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+tandoor_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+tandoor_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
+tandoor_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 tandoor_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6503,11 +6505,10 @@ tandoor_database_username: "tandoor"
 tandoor_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.tandoor', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-tandoor_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-tandoor_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
-tandoor_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+tandoor_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+tandoor_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6663,10 +6664,12 @@ vaultwarden_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_p
 vaultwarden_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 vaultwarden_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
-# role-specific:traefik
-vaultwarden_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+vaultwarden_config_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+vaultwarden_config_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+vaultwarden_config_smtp_port: "{{ 8025 if exim_relay_enabled else '587' }}"
+vaultwarden_config_smtp_security: "{{ 'off' if exim_relay_enabled else 'starttls' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 vaultwarden_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6675,12 +6678,10 @@ vaultwarden_database_username: "vaultwarden"
 vaultwarden_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.vaultwarden', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-vaultwarden_config_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-vaultwarden_config_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-vaultwarden_config_smtp_port: "{{ 8025 if exim_relay_enabled else '587' }}"
-vaultwarden_config_smtp_security: "{{ 'off' if exim_relay_enabled else 'starttls' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+vaultwarden_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6840,10 +6841,13 @@ forgejo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxy
 forgejo_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 forgejo_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
-# role-specific:traefik
-forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+# role-specific:exim_relay
+forgejo_config_mailer_enabled: "{{ exim_relay_enabled }}"
+forgejo_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+forgejo_config_mailer_smtp_port: 8025
+forgejo_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+forgejo_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:postgres
 forgejo_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6852,13 +6856,10 @@ forgejo_config_database_username: "forgejo"
 forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.forgejo', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-# role-specific:exim_relay
-forgejo_config_mailer_enabled: "{{ exim_relay_enabled }}"
-forgejo_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-forgejo_config_mailer_smtp_port: 8025
-forgejo_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-forgejo_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
+# role-specific:traefik
+forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -7032,16 +7033,16 @@ wordpress_container_additional_networks_auto: |
 wordpress_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 wordpress_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-wordpress_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-wordpress_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 # role-specific:mariadb
 wordpress_database_hostname: "{{ mariadb_identifier if mariadb_enabled | default(false) else '' }}"
 wordpress_mysql_port: "{{ '3306' if mariadb_enabled | default(false) else '' }}"
 wordpress_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.mariadb', rounds=655555) | to_uuid }}"
 # /role-specific:mariadb
+
+# role-specific:traefik
+wordpress_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+wordpress_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -3899,9 +3899,11 @@ infisical_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_
 infisical_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
 
+# role-specific:mongodb
 infisical_mongodb_hostname: "{{ mongodb_identifier if mongodb_enabled else '' }}"
 infisical_mongodb_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'infisical.db', rounds=655555) | to_uuid }}"
 infisical_mongodb_auth_source: "{{ infisical_mongodb_db_name }}"
+# /role-specific:mongodb
 
 ########################################################################
 #                                                                      #

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -52,16 +52,16 @@ authelia_container_additional_networks_auto: |
 authelia_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 authelia_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 authelia_config_jwt_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jwt.authelia', rounds=655555) | to_uuid }}"
 
 authelia_config_session_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'ses.authelia', rounds=655555) | to_uuid }}"
 
 authelia_config_identity_providers_oidc_hmac_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'hm.authelia', rounds=655555) | to_uuid }}"
+
+# role-specific:traefik
+authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 authelia_config_storage_postgres_host: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -1332,10 +1332,6 @@ traefik_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_
 traefik_uid: "{{ mash_playbook_uid }}"
 traefik_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:container_socket_proxy
-traefik_config_providers_docker_endpoint: "{{ container_socket_proxy_endpoint if container_socket_proxy_enabled else 'unix:///var/run/docker.sock' }}"
-# /role-specific:container_socket_proxy
-
 traefik_container_additional_networks_auto: |
   {{
     ([container_socket_proxy_container_network] if container_socket_proxy_enabled | default(false) else [])
@@ -1347,6 +1343,10 @@ traefik_systemd_required_services_list: |
     +
     ([container_socket_proxy_identifier + '.service'] if container_socket_proxy_enabled | default(false) else [])
   }}
+
+# role-specific:container_socket_proxy
+traefik_config_providers_docker_endpoint: "{{ container_socket_proxy_endpoint if container_socket_proxy_enabled else 'unix:///var/run/docker.sock' }}"
+# /role-specific:container_socket_proxy
 
 ########################################################################
 #                                                                      #
@@ -1515,16 +1515,16 @@ apisix_gateway_container_additional_networks_auto: |
 apisix_gateway_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 apisix_gateway_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-apisix_gateway_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-apisix_gateway_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 apisix_gateway_container_labels_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 apisix_gateway_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
 apisix_gateway_container_labels_metrics_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ apisix_gateway_identifier }}"
 apisix_gateway_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 apisix_gateway_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
+# role-specific:traefik
+apisix_gateway_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+apisix_gateway_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:etcd
 apisix_gateway_config_deployment_etcd_host: |
@@ -1609,13 +1609,6 @@ authentik_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 authentik_uid: "{{ mash_playbook_uid }}"
 authentik_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:postgres
-authentik_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-authentik_database_port: "{{ '5432' if postgres_enabled else '' }}"
-authentik_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authentik', rounds=655555) | to_uuid }}"
-authentik_database_username: "{{ authentik_identifier }}"
-# /role-specific:postgres
-
 authentik_server_systemd_required_services_list_auto: |
   {{
     ([postgres_identifier ~ '.service'] if postgres_enabled and authentik_database_hostname == postgres_identifier else [])
@@ -1630,6 +1623,13 @@ authentik_container_additional_networks_auto: |
 
 authentik_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 authentik_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+authentik_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+authentik_database_port: "{{ '5432' if postgres_enabled else '' }}"
+authentik_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authentik', rounds=655555) | to_uuid }}"
+authentik_database_username: "{{ authentik_identifier }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 authentik_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -1668,25 +1668,6 @@ backup_borg_storage_archive_name_format: "{{ mash_playbook_service_identifier_pr
 
 backup_borg_container_image_self_build: "{{ mash_playbook_architecture not in ['amd64', 'arm32', 'arm64'] }}"
 
-backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
-backup_borg_mysql_enabled: "{{ mariadb_enabled }}"
-
-# role-specific:postgres
-backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
-backup_borg_postgresql_databases_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
-backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
-# /role-specific:postgres
-
-# role-specific:mariadb
-backup_borg_mysql_databases_hostname: "{{ mariadb_identifier if mariadb_enabled else '' }}"
-backup_borg_mysql_databases_username: "root"
-backup_borg_mysql_databases_password: "{{ mariadb_root_password if mariadb_enabled else '' }}"
-backup_borg_mysql_databases_port: 3306
-backup_borg_mysql_databases: "{{ mariadb_managed_databases | map(attribute='name') if mariadb_enabled else [] }}"
-# /role-specific:mariadb
-
 backup_borg_location_source_directories:
   - "{{ mash_playbook_base_path }}"
 
@@ -1705,6 +1686,25 @@ backup_borg_systemd_required_services_list: |
     +
     ([mariadb_identifier ~ '.service'] if mariadb_enabled | default(false) else [])
   }}
+
+backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
+backup_borg_mysql_enabled: "{{ mariadb_enabled }}"
+
+# role-specific:postgres
+backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
+backup_borg_postgresql_databases_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
+backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attribute='name') if postgres_enabled else [] }}"
+# /role-specific:postgres
+
+# role-specific:mariadb
+backup_borg_mysql_databases_hostname: "{{ mariadb_identifier if mariadb_enabled else '' }}"
+backup_borg_mysql_databases_username: "root"
+backup_borg_mysql_databases_password: "{{ mariadb_root_password if mariadb_enabled else '' }}"
+backup_borg_mysql_databases_port: 3306
+backup_borg_mysql_databases: "{{ mariadb_managed_databases | map(attribute='name') if mariadb_enabled else [] }}"
+# /role-specific:mariadb
 
 ########################################################################
 #                                                                      #
@@ -2227,6 +2227,8 @@ endlessh_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+endlessh_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+endlessh_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 endlessh_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and endlessh_hostname }}"
@@ -2236,9 +2238,6 @@ endlessh_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_prox
 endlessh_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 endlessh_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-endlessh_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-endlessh_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
 ########################################################################
 #                                                                      #
@@ -2363,13 +2362,6 @@ firezone_uid: "{{ mash_playbook_uid }}"
 firezone_gid: "{{ mash_playbook_gid }}"
 firezone_generic_secret: "{{ mash_playbook_generic_secret_key }}"
 
-# role-specific:postgres
-firezone_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-firezone_database_port: "{{ '5432' if postgres_enabled else '' }}"
-firezone_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'fz.db.user', rounds=655555) | to_uuid }}"
-firezone_database_username: "{{ firezone_identifier }}"
-# /role-specific:postgres
-
 firezone_systemd_required_services_list_auto: |
   {{
     ([postgres_identifier ~ '.service'] if postgres_enabled | default(false) and firezone_database_host == postgres_identifier else [])
@@ -2384,6 +2376,13 @@ firezone_container_additional_networks_auto: |
 
 firezone_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 firezone_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+firezone_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+firezone_database_port: "{{ '5432' if postgres_enabled else '' }}"
+firezone_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'fz.db.user', rounds=655555) | to_uuid }}"
+firezone_database_username: "{{ firezone_identifier }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 firezone_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -2420,14 +2419,6 @@ focalboard_systemd_required_systemd_services_list_auto: |
     ([postgres_identifier ~ '.service'] if postgres_enabled and focalboard_database_hostname == postgres_identifier else [])
   }}
 
-focalboard_database_type: "{{ 'postgres' if postgres_enabled else '' }}"
-
-# role-specific:postgres
-focalboard_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-focalboard_database_port: "{{ '5432' if postgres_enabled else '' }}"
-focalboard_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.focalboard', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 focalboard_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
@@ -2437,6 +2428,14 @@ focalboard_container_additional_networks_auto: |
 
 focalboard_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 focalboard_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+focalboard_database_type: "{{ 'postgres' if postgres_enabled else '' }}"
+
+# role-specific:postgres
+focalboard_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+focalboard_database_port: "{{ '5432' if postgres_enabled else '' }}"
+focalboard_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.focalboard', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 focalboard_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -2523,13 +2522,6 @@ funkwhale_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 funkwhale_uid: "{{ mash_playbook_uid }}"
 funkwhale_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:postgres
-funkwhale_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-funkwhale_database_port: "{{ '5432' if postgres_enabled else '' }}"
-funkwhale_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.funkwhale', rounds=655555) | to_uuid }}"
-funkwhale_database_username: "{{ funkwhale_identifier }}"
-# /role-specific:postgres
-
 funkwhale_api_systemd_required_services_list_auto: |
   {{
     ([postgres_identifier ~ '.service'] if postgres_enabled and funkwhale_database_hostname == postgres_identifier else [])
@@ -2558,6 +2550,13 @@ funkwhale_api_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels
 funkwhale_api_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 funkwhale_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 funkwhale_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+funkwhale_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+funkwhale_database_port: "{{ '5432' if postgres_enabled else '' }}"
+funkwhale_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.funkwhale', rounds=655555) | to_uuid }}"
+funkwhale_database_username: "{{ funkwhale_identifier }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 funkwhale_api_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -2719,14 +2718,6 @@ grafana_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_
 grafana_uid: "{{ mash_playbook_uid }}"
 grafana_gid: "{{ mash_playbook_gid }}"
 
-
-# role-specific:exim_relay
-grafana_smtp_enabled: "{{ exim_relay_enabled | default(false) }}"
-grafana_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-grafana_smtp_port: 8025
-grafana_smtp_from_address: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
-
 grafana_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if (grafana_container_labels_traefik_enabled and mash_playbook_reverse_proxyable_services_additional_network) else [])
@@ -2736,6 +2727,13 @@ grafana_container_additional_networks_auto: |
 
 grafana_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 grafana_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:exim_relay
+grafana_smtp_enabled: "{{ exim_relay_enabled | default(false) }}"
+grafana_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+grafana_smtp_port: 8025
+grafana_smtp_from_address: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
 
 # role-specific:traefik
 grafana_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -2824,6 +2822,8 @@ healthchecks_container_additional_networks_auto: |
     ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and healthchecks_environment_variable_email_host == exim_relay_identifier | default('mash-exim-relay') and healthchecks_container_network != exim_relay_container_network) else [])
   }}
 
+healthchecks_environment_variable_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks', rounds=655555) | to_uuid }}"
+
 healthchecks_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 healthchecks_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -2836,8 +2836,6 @@ healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver
 healthchecks_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 healthchecks_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
-
-healthchecks_environment_variable_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks', rounds=655555) | to_uuid }}"
 
 # role-specific:exim_relay
 healthchecks_environment_variable_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
@@ -3759,10 +3757,7 @@ ihatemoney_container_additional_networks_auto: |
 ihatemoney_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 ihatemoney_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-ihatemoney_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-ihatemoney_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
+ihatemoney_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.imoney', rounds=655555) | to_uuid }}"
 
 # role-specific:postgres
 ihatemoney_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -3771,13 +3766,16 @@ ihatemoney_database_username: "ihatemoney"
 ihatemoney_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ihatemoney', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-ihatemoney_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.imoney', rounds=655555) | to_uuid }}"
-
 # role-specific:exim_relay
 ihatemoney_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
 ihatemoney_email_port: "{{ 8025 if exim_relay_enabled else '' }}"
 ihatemoney_default_from_email: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
 # /role-specific:exim_relay
+
+# role-specific:traefik
+ihatemoney_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+ihatemoney_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -3806,13 +3804,6 @@ ilmo_gid: "{{ mash_playbook_gid }}"
 
 ilmo_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.ilmo', rounds=655555) | to_uuid }}"
 
-# role-specific:postgres
-ilmo_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-ilmo_database_port: "{{ '5432' if postgres_enabled else '' }}"
-ilmo_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ilmo', rounds=655555) | to_uuid }}"
-ilmo_database_username: "ilmo"
-# /role-specific:postgres
-
 ilmo_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -3829,6 +3820,13 @@ ilmo_container_additional_networks: |
 
 ilmo_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 ilmo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+ilmo_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+ilmo_database_port: "{{ '5432' if postgres_enabled else '' }}"
+ilmo_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ilmo', rounds=655555) | to_uuid }}"
+ilmo_database_username: "ilmo"
+# /role-specific:postgres
 
 # role-specific:traefik
 ilmo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -4025,6 +4023,10 @@ jitsi_jvb_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+jitsi_jibri_xmpp_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jibri', rounds=655555) | to_uuid }}"
+jitsi_jicofo_auth_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jicofo', rounds=655555) | to_uuid }}"
+jitsi_jvb_auth_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jvb', rounds=655555) | to_uuid }}"
+
 jitsi_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 jitsi_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -4032,10 +4034,6 @@ jitsi_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyab
 jitsi_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 jitsi_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-jitsi_jibri_xmpp_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jibri', rounds=655555) | to_uuid }}"
-jitsi_jicofo_auth_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jicofo', rounds=655555) | to_uuid }}"
-jitsi_jvb_auth_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jvb', rounds=655555) | to_uuid }}"
 
 ########################################################################
 #                                                                      #
@@ -4139,17 +4137,17 @@ keycloak_container_additional_networks_auto: |
 keycloak_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 keycloak_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-keycloak_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 keycloak_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
 keycloak_container_labels_metrics_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ keycloak_identifier }}"
 keycloak_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 keycloak_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
 keycloak_environment_variable_kc_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
+
+# role-specific:traefik
+keycloak_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 keycloak_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -4248,6 +4246,11 @@ lago_front_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+lago_api_environment_variable_secret_key_base: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.sec.key', rounds=655555) | to_uuid }}"
+lago_api_environment_variable_encryption_primary_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.enc.primary', rounds=655555) | to_uuid }}"
+lago_api_environment_variable_encryption_deterministic_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.deter.key', rounds=655555) | to_uuid }}"
+lago_api_environment_variable_encryption_key_derivation_salt: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.deriv.salt', rounds=655555) | to_uuid }}"
+
 lago_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 lago_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -4261,11 +4264,6 @@ lago_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 lago_database_port: "{{ '5432' if postgres_enabled else '' }}"
 lago_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.db', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
-
-lago_api_environment_variable_secret_key_base: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.sec.key', rounds=655555) | to_uuid }}"
-lago_api_environment_variable_encryption_primary_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.enc.primary', rounds=655555) | to_uuid }}"
-lago_api_environment_variable_encryption_deterministic_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.deter.key', rounds=655555) | to_uuid }}"
-lago_api_environment_variable_encryption_key_derivation_salt: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.deriv.salt', rounds=655555) | to_uuid }}"
 
 ########################################################################
 #                                                                      #
@@ -4292,6 +4290,11 @@ languagetool_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_
 languagetool_uid: "{{ mash_playbook_uid }}"
 languagetool_gid: "{{ mash_playbook_gid }}"
 
+languagetool_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
 languagetool_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 languagetool_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -4299,11 +4302,6 @@ languagetool_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_
 languagetool_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 languagetool_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-languagetool_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
 
 ########################################################################
 #                                                                      #
@@ -4330,6 +4328,11 @@ loki_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_dir
 loki_uid: "{{ mash_playbook_uid }}"
 loki_gid: "{{ mash_playbook_gid }}"
 
+loki_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 loki_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and loki_hostname | length > 0 }}"
 loki_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
@@ -4338,11 +4341,6 @@ loki_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyabl
 loki_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 loki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-loki_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
 
 ########################################################################
 #                                                                      #
@@ -4524,14 +4522,6 @@ mobilizon_gid: "{{ mash_playbook_gid }}"
 mobilizon_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'sk.mobilizon', rounds=655555) | to_uuid }}"
 mobilizon_secret_key_base: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'skb.mobilizon', rounds=655555) | to_uuid }}"
 
-# role-specific:postgis
-mobilizon_database_hostname: "{{ postgis_identifier if postgis_enabled else '' }}"
-mobilizon_database_name: "mobilizon"
-mobilizon_database_port: "{{ '5432' if postgis_enabled else '' }}"
-mobilizon_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.mobilizon', rounds=655555) | to_uuid }}"
-mobilizon_database_username: "mobilizon"
-# /role-specific:postgis
-
 mobilizon_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -4548,6 +4538,14 @@ mobilizon_container_additional_networks: |
 
 mobilizon_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 mobilizon_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgis
+mobilizon_database_hostname: "{{ postgis_identifier if postgis_enabled else '' }}"
+mobilizon_database_name: "mobilizon"
+mobilizon_database_port: "{{ '5432' if postgis_enabled else '' }}"
+mobilizon_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.mobilizon', rounds=655555) | to_uuid }}"
+mobilizon_database_username: "mobilizon"
+# /role-specific:postgis
 
 # role-specific:traefik
 mobilizon_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -4997,13 +4995,6 @@ notfellchen_gid: "{{ mash_playbook_gid }}"
 
 notfellchen_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.nf', rounds=655555) | to_uuid }}"
 
-# role-specific:postgres
-notfellchen_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-notfellchen_database_port: "{{ '5432' if postgres_enabled else '' }}"
-notfellchen_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nf', rounds=655555) | to_uuid }}"
-notfellchen_database_username: "notfellchen"
-# /role-specific:postgres
-
 notfellchen_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -5024,6 +5015,13 @@ notfellchen_sws_container_labels_traefik_enabled: "{{ notfellchen_container_labe
 notfellchen_sws_container_labels_traefik_docker_network: "{{ notfellchen_container_labels_traefik_docker_network }}"
 notfellchen_sws_container_labels_traefik_entrypoints: "{{ notfellchen_container_labels_traefik_entrypoints }}"
 notfellchen_sws_container_labels_traefik_tls_certResolver: "{{ notfellchen_container_labels_traefik_tls_certResolver }}"
+
+# role-specific:postgres
+notfellchen_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+notfellchen_database_port: "{{ '5432' if postgres_enabled else '' }}"
+notfellchen_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nf', rounds=655555) | to_uuid }}"
+notfellchen_database_username: "notfellchen"
+# /role-specific:postgres
 
 # role-specific:traefik
 notfellchen_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -5117,6 +5115,8 @@ outline_container_additional_networks_auto: |
     ([postgres_container_network] if postgres_enabled and outline_database_hostname == postgres_identifier and outline_container_network != postgres_container_network else [])
   }}
 
+outline_environment_variable_utils_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'utils.out', rounds=655555) | to_uuid }}"
+
 outline_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 outline_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -5124,8 +5124,6 @@ outline_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxy
 outline_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-outline_environment_variable_utils_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'utils.out', rounds=655555) | to_uuid }}"
 
 # role-specific:postgres
 outline_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -5270,12 +5268,6 @@ oxitraffic_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 oxitraffic_uid: "{{ mash_playbook_uid }}"
 oxitraffic_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:postgres
-oxitraffic_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-oxitraffic_database_port: "{{ '5432' if postgres_enabled else '' }}"
-oxitraffic_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.oxitraffic', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 oxitraffic_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -5292,6 +5284,12 @@ oxitraffic_container_additional_networks: |
 
 oxitraffic_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 oxitraffic_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+oxitraffic_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+oxitraffic_database_port: "{{ '5432' if postgres_enabled else '' }}"
+oxitraffic_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.oxitraffic', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 oxitraffic_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -5324,13 +5322,6 @@ paperless_gid: "{{ mash_playbook_gid }}"
 
 paperless_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'paperless.secret', rounds=655555) | to_uuid }}"
 
-# role-specific:postgres
-paperless_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-paperless_database_username: "paperless"
-paperless_database_port: "{{ '5432' if postgres_enabled else '' }}"
-paperless_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.paperless', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
 paperless_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -5349,6 +5340,13 @@ paperless_container_additional_networks_auto: |
 
 paperless_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 paperless_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+paperless_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+paperless_database_username: "paperless"
+paperless_database_port: "{{ '5432' if postgres_enabled else '' }}"
+paperless_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.paperless', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 paperless_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -5397,6 +5395,16 @@ peertube_container_additional_networks_auto: |
     ) | unique
   }}
 
+peertube_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and peertube_config_database_hostname == postgres_identifier else [])
+  }}
+
+peertube_systemd_wanted_services_list_auto: |
+  {{
+    ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if (exim_relay_enabled | default(false) and peertube_config_smtp_hostname == exim_relay_identifier | default('mash-exim-relay')) else [])
+  }}
+
 peertube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 peertube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -5411,16 +5419,6 @@ peertube_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
 peertube_config_database_username: peertube
 peertube_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.peertube', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
-
-peertube_systemd_required_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled and peertube_config_database_hostname == postgres_identifier else [])
-  }}
-
-peertube_systemd_wanted_services_list_auto: |
-  {{
-    ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if (exim_relay_enabled | default(false) and peertube_config_smtp_hostname == exim_relay_identifier | default('mash-exim-relay')) else [])
-  }}
 
 # role-specific:exim_relay
 peertube_config_smtp_hostname: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -5580,6 +5578,14 @@ prometheus_postgres_exporter_container_additional_networks: |
     ([postgres_container_network] if postgres_enabled and prometheus_postgres_exporter_database_hostname == postgres_identifier and prometheus_postgres_exporter_container_network != postgres_container_network else [])
   }}
 
+prometheus_postgres_exporter_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled else [])
+  }}
+
+prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_postgres_exporter_hostname | length > 0 }}"
 prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
@@ -5589,9 +5595,6 @@ prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_e
 prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
 
-prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
-
 # role-specific:postgres
 prometheus_postgres_exporter_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 prometheus_postgres_exporter_database_username: prometheus_postgres_exporter
@@ -5599,11 +5602,6 @@ prometheus_postgres_exporter_database_password: "{{ postgres_connection_password
 prometheus_postgres_exporter_database_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
 prometheus_postgres_exporter_database_ssl: false
 # /role-specific:postgres
-
-prometheus_postgres_exporter_systemd_required_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled else [])
-  }}
 
 ########################################################################
 #                                                                      #
@@ -5630,6 +5628,11 @@ prometheus_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 prometheus_uid: "{{ mash_playbook_uid }}"
 prometheus_gid: "{{ mash_playbook_gid }}"
 
+prometheus_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_hostname | length > 0 }}"
 prometheus_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
@@ -5638,12 +5641,6 @@ prometheus_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pr
 prometheus_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-prometheus_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
 
 ########################################################################
 #                                                                      #
@@ -5682,13 +5679,13 @@ prometheus_blackbox_exporter_container_additional_networks: |
 prometheus_blackbox_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_blackbox_exporter_hostname }}"
 prometheus_blackbox_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
+prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
 # role-specific:traefik
 prometheus_blackbox_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_blackbox_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
 ########################################################################
 #                                                                      #
@@ -5723,6 +5720,9 @@ prometheus_ssh_exporter_container_additional_networks: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_ssh_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_ssh_exporter_hostname }}"
 prometheus_ssh_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
@@ -5731,9 +5731,6 @@ prometheus_ssh_exporter_container_labels_traefik_docker_network: "{{ mash_playbo
 prometheus_ssh_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_ssh_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
 ########################################################################
 #                                                                      #
@@ -5772,11 +5769,6 @@ prometheus_node_exporter_container_additional_networks_auto: |
 prometheus_node_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_node_exporter_hostname }}"
 prometheus_node_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
-# role-specific:traefik
-prometheus_node_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-prometheus_node_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
@@ -5791,6 +5783,11 @@ prometheus_node_exporter_process_extra_arguments:
 prometheus_node_exporter_container_extra_arguments:
   - "--security-opt apparmor=unconfined"
   - "--mount type=bind,src=/var/run/dbus/system_bus_socket,dst=/var/run/dbus/system_bus_socket,ro,bind-propagation=rslave"
+
+# role-specific:traefik
+prometheus_node_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+prometheus_node_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5817,25 +5814,6 @@ promtail_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base
 promtail_uid: "{{ mash_playbook_uid }}"
 promtail_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:loki
-promtail_config_clients_auto: |
-  {{
-    ([{
-      'url': ('http://' + loki_identifier + ':' + (loki_server_http_listen_port | string) + '/loki/api/v1/push'),
-      'tenant_id': 'mash',
-    }] if loki_enabled else [])
-  }}
-# /role-specific:loki
-
-# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
-promtail_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-promtail_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-promtail_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-promtail_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
 promtail_container_labels_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 promtail_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
 promtail_container_labels_metrics_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ promtail_identifier }}"
@@ -5850,6 +5828,25 @@ promtail_container_additional_networks_auto: |
       ([loki_container_network] if (loki_enabled | default(false) and loki_container_network | default('') != promtail_container_network) else [])
     ) | unique
   }}
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+promtail_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+promtail_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:loki
+promtail_config_clients_auto: |
+  {{
+    ([{
+      'url': ('http://' + loki_identifier + ':' + (loki_server_http_listen_port | string) + '/loki/api/v1/push'),
+      'tenant_id': 'mash',
+    }] if loki_enabled else [])
+  }}
+# /role-specific:loki
+
+# role-specific:traefik
+promtail_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+promtail_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6108,6 +6105,23 @@ roundcube_gid: "0"
 
 roundcube_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite' }}"
 
+roundcube_systemd_required_systemd_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+    +
+    ([postgres_identifier ~ '.service'] if postgres_enabled and roundcube_database_hostname == postgres_identifier else [])
+  }}
+
+roundcube_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and roundcube_database_hostname == postgres_identifier and roundcube_container_network != postgres_container_network else [])
+  }}
+
+roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
 # role-specific:postgres
 roundcube_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 roundcube_database_port: "{{ '5432' if postgres_enabled else '' }}"
@@ -6116,27 +6130,10 @@ roundcube_database_username: "{{ 'roundcube' if postgres_enabled else '' }}"
 roundcube_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.roundcube', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
-roundcube_systemd_required_systemd_services_list: |
-  {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
-    ([postgres_identifier ~ '.service'] if postgres_enabled and roundcube_database_hostname == postgres_identifier else [])
-  }}
-
-roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
 # role-specific:traefik
 roundcube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 roundcube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-roundcube_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([postgres_container_network] if postgres_enabled and roundcube_database_hostname == postgres_identifier and roundcube_container_network != postgres_container_network else [])
-  }}
 
 ########################################################################
 #                                                                      #
@@ -6193,6 +6190,11 @@ searxng_systemd_required_systemd_services_list: |
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
   }}
 
+searxng_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
 searxng_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 searxng_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -6200,11 +6202,6 @@ searxng_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxy
 searxng_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 searxng_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
-
-searxng_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
 
 ########################################################################
 #                                                                      #
@@ -6231,13 +6228,6 @@ semaphore_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 semaphore_uid: "{{ mash_playbook_uid }}"
 semaphore_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:postgres
-semaphore_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-semaphore_database_port: "{{ '5432' if postgres_enabled else '' }}"
-semaphore_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.semaphore', rounds=655555) | to_uuid }}"
-semaphore_database_username: "{{ semaphore_identifier }}"
-# /role-specific:postgres
-
 semaphore_systemd_required_services_list: |
   {{
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
@@ -6254,6 +6244,13 @@ semaphore_container_additional_networks: |
 
 semaphore_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 semaphore_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+semaphore_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+semaphore_database_port: "{{ '5432' if postgres_enabled else '' }}"
+semaphore_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.semaphore', rounds=655555) | to_uuid }}"
+semaphore_database_username: "{{ semaphore_identifier }}"
+# /role-specific:postgres
 
 # role-specific:traefik
 semaphore_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
@@ -6489,6 +6486,8 @@ tandoor_frontend_container_additional_networks_auto: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
+tandoor_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.tandoor', rounds=655555) | to_uuid }}"
+
 tandoor_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 tandoor_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
@@ -6503,8 +6502,6 @@ tandoor_database_port: "{{ '5432' if postgres_enabled else '' }}"
 tandoor_database_username: "tandoor"
 tandoor_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.tandoor', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
-
-tandoor_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.tandoor', rounds=655555) | to_uuid }}"
 
 # role-specific:exim_relay
 tandoor_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -6570,14 +6567,6 @@ tsdproxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base
 tsdproxy_uid: "{{ mash_playbook_uid }}"
 tsdproxy_gid: "{{ mash_playbook_gid }}"
 
-# role-specific:container_socket_proxy
-tsdproxy_docker_endpoint_is_unix_socket: "{{ false if container_socket_proxy_enabled else true }}"
-tsdproxy_docker_endpoint: "{{ container_socket_proxy_endpoint if container_socket_proxy_enabled == true and tsdproxy_enabled == true else 'unix:///var/run/docker.sock' }}"
-# TSDProxy needs access to the Docker Networks and images to work
-container_socket_proxy_api_network_enabled: "{{ true if tsdproxy_docker_endpoint == container_socket_proxy_endpoint else false }}"
-container_socket_proxy_api_images_enabled: "{{ true if tsdproxy_docker_endpoint == container_socket_proxy_endpoint else false }}"
-# /role-specific:container_socket_proxy
-
 tsdproxy_container_additional_networks_auto: |
   {{
     ([container_socket_proxy_container_network] if container_socket_proxy_enabled | default(false) else [])
@@ -6589,6 +6578,14 @@ tsdproxy_systemd_required_services_list: |
     +
     ([container_socket_proxy_identifier + '.service'] if container_socket_proxy_enabled | default(false) else [])
   }}
+
+# role-specific:container_socket_proxy
+tsdproxy_docker_endpoint_is_unix_socket: "{{ false if container_socket_proxy_enabled else true }}"
+tsdproxy_docker_endpoint: "{{ container_socket_proxy_endpoint if container_socket_proxy_enabled == true and tsdproxy_enabled == true else 'unix:///var/run/docker.sock' }}"
+# TSDProxy needs access to the Docker Networks and images to work
+container_socket_proxy_api_network_enabled: "{{ true if tsdproxy_docker_endpoint == container_socket_proxy_endpoint else false }}"
+container_socket_proxy_api_images_enabled: "{{ true if tsdproxy_docker_endpoint == container_socket_proxy_endpoint else false }}"
+# /role-specific:container_socket_proxy
 
 ########################################################################
 #                                                                      #
@@ -6936,13 +6933,14 @@ woodpecker_ci_server_container_additional_networks: |
 
 woodpecker_ci_server_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 woodpecker_ci_server_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
 woodpecker_ci_server_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 woodpecker_ci_server_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
 woodpecker_ci_server_database_driver: postgres
+woodpecker_ci_server_database_datasource: "postgres://{{ woodpecker_ci_server_database_datasource_username }}:{{ woodpecker_ci_server_database_datasource_password }}@{{ woodpecker_ci_server_database_datasource_hostname }}:{{ woodpecker_ci_server_database_datasource_port }}/{{ woodpecker_ci_server_database_datasource_db_name }}?sslmode=disable"
 
 # role-specific:postgres
-woodpecker_ci_server_database_datasource: "postgres://{{ woodpecker_ci_server_database_datasource_username }}:{{ woodpecker_ci_server_database_datasource_password }}@{{ woodpecker_ci_server_database_datasource_hostname }}:{{ woodpecker_ci_server_database_datasource_port }}/{{ woodpecker_ci_server_database_datasource_db_name }}?sslmode=disable"
 woodpecker_ci_server_database_datasource_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 woodpecker_ci_server_database_datasource_port: "{{ '5432' if postgres_enabled else '' }}"
 woodpecker_ci_server_database_datasource_username: woodpecker_ci_server
@@ -7122,14 +7120,14 @@ yourls_container_additional_networks_auto: |
 
 yourls_environment_variable_cookiekey: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.yourls', rounds=655555) | to_uuid }}"
 
+yourls_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+yourls_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
 # role-specific:mariadb
 yourls_environment_variable_db_user: "yourls"
 yourls_environment_variable_db_pass: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.yourls', rounds=655555) | to_uuid }}"
 yourls_environment_variable_db_host_name: "{{ mariadb_identifier if mariadb_enabled else '' }}"
 # /role-specific:mariadb
-
-yourls_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-yourls_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
 # role-specific:traefik
 yourls_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4524,11 +4524,13 @@ mobilizon_gid: "{{ mash_playbook_gid }}"
 mobilizon_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'sk.mobilizon', rounds=655555) | to_uuid }}"
 mobilizon_secret_key_base: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'skb.mobilizon', rounds=655555) | to_uuid }}"
 
+# role-specific:postgis
 mobilizon_database_hostname: "{{ postgis_identifier if postgis_enabled else '' }}"
 mobilizon_database_name: "mobilizon"
 mobilizon_database_port: "{{ '5432' if postgis_enabled else '' }}"
 mobilizon_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.mobilizon', rounds=655555) | to_uuid }}"
 mobilizon_database_username: "mobilizon"
+# /role-specific:postgis
 
 mobilizon_systemd_required_services_list: |
   {{

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1659,8 +1659,9 @@ backup_borg_storage_archive_name_format: "{{ mash_playbook_service_identifier_pr
 
 backup_borg_container_image_self_build: "{{ mash_playbook_architecture not in ['amd64', 'arm32', 'arm64'] }}"
 
-# role-specific:postgres
 backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
+
+# role-specific:postgres
 backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 backup_borg_postgresql_databases_username: "{{ postgres_connection_username if postgres_enabled else '' }}"
 backup_borg_postgresql_databases_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
@@ -2401,8 +2402,9 @@ focalboard_systemd_required_systemd_services_list_auto: |
     ([postgres_identifier ~ '.service'] if postgres_enabled and focalboard_database_hostname == postgres_identifier else [])
   }}
 
-# role-specific:postgres
 focalboard_database_type: "{{ 'postgres' if postgres_enabled else '' }}"
+
+# role-specific:postgres
 focalboard_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 focalboard_database_port: "{{ '5432' if postgres_enabled else '' }}"
 focalboard_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.focalboard', rounds=655555) | to_uuid }}"
@@ -2469,7 +2471,9 @@ freshrss_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_prox
 freshrss_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 freshrss_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 freshrss_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+# /role-specific:postgres
 
 # Intentionally not auto-generating freshrss_database_password.
 # It's meant to be explicitly defined, so that it can be used in the setup wizard after installation.
@@ -2498,10 +2502,12 @@ funkwhale_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 funkwhale_uid: "{{ mash_playbook_uid }}"
 funkwhale_gid: "{{ mash_playbook_gid }}"
 
+# role-specific:postgres
 funkwhale_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 funkwhale_database_port: "{{ '5432' if postgres_enabled else '' }}"
 funkwhale_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.funkwhale', rounds=655555) | to_uuid }}"
 funkwhale_database_username: "{{ funkwhale_identifier }}"
+# /role-specific:postgres
 
 funkwhale_api_systemd_required_services_list_auto: |
   {{
@@ -2583,10 +2589,12 @@ gitea_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primar
 gitea_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 gitea_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
+# role-specific:postgres
 gitea_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 gitea_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
 gitea_config_database_username: "gitea"
 gitea_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.gitea', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:exim_relay
 gitea_config_mailer_enabled: "{{ exim_relay_enabled }}"
@@ -2645,10 +2653,12 @@ gotosocial_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pr
 gotosocial_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 gotosocial_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 gotosocial_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
 gotosocial_database_port: "{{ '5432' if postgres_enabled else '' }}"
 gotosocial_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.gotosocial', rounds=655555) | to_uuid }}"
 gotosocial_database_username: "{{ gotosocial_identifier }}"
+# /role-specific:postgres
 
 # role-specific:exim_relay
 gotosocial_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -2785,8 +2795,10 @@ healthchecks_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_
 healthchecks_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 healthchecks_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 healthchecks_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 healthchecks_environment_variable_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'healthchecks', rounds=655555) | to_uuid }}"
 
@@ -3699,7 +3711,7 @@ ihatemoney_container_additional_networks_auto: |
       ([postgres_container_network] if postgres_enabled and ihatemoney_database_hostname == postgres_identifier and ihatemoney_container_network != postgres_container_network else [])
       +
       ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and ihatemoney_email_host == exim_relay_identifier | default('mash-exim-relay') and ihatemoney_container_network != exim_relay_container_network) else [])
-      +  
+      +
       ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     ) | unique
   }}
@@ -3709,10 +3721,12 @@ ihatemoney_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pr
 ihatemoney_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 ihatemoney_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 ihatemoney_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 ihatemoney_database_port: "{{ '5432' if postgres_enabled else '' }}"
 ihatemoney_database_username: "ihatemoney"
 ihatemoney_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ihatemoney', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ihatemoney_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.imoney', rounds=655555) | to_uuid }}"
 
@@ -3749,10 +3763,12 @@ ilmo_gid: "{{ mash_playbook_gid }}"
 
 ilmo_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.ilmo', rounds=655555) | to_uuid }}"
 
+# role-specific:postgres
 ilmo_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
 ilmo_database_port: "{{ '5432' if postgres_enabled else '' }}"
 ilmo_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.ilmo', rounds=655555) | to_uuid }}"
 ilmo_database_username: "ilmo"
+# /role-specific:postgres
 
 ilmo_systemd_required_services_list: |
   {{
@@ -4075,9 +4091,11 @@ keycloak_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook
 
 keycloak_environment_variable_kc_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 
+# role-specific:postgres
 keycloak_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 keycloak_database_port: "{{ '5432' if postgres_enabled else '' }}"
 keycloak_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.keycloak', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4120,11 +4138,14 @@ labelstudio_container_labels_traefik_compression_middleware_enabled: "{{ mash_pl
 labelstudio_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
 labelstudio_postgres_backend_enabled: "{{ postgres_enabled }}"
+
+# role-specific:postgres
 labelstudio_database_name: "labelstudio"
 labelstudio_database_username: "labelstudio"
 labelstudio_database_port: "{{ '5432' if postgres_enabled else '' }}"
 labelstudio_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 labelstudio_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.labelstudio', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4170,9 +4191,11 @@ lago_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyabl
 lago_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 lago_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 lago_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 lago_database_port: "{{ '5432' if postgres_enabled else '' }}"
 lago_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 lago_api_environment_variable_secret_key_base: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.sec.key', rounds=655555) | to_uuid }}"
 lago_api_environment_variable_encryption_primary_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'lago.enc.primary', rounds=655555) | to_uuid }}"
@@ -4292,9 +4315,11 @@ linkding_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_prox
 linkding_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 linkding_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 linkding_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'linkding.db', rounds=655555) | to_uuid }}"
 linkding_database_engine: "{{ 'postgres' if postgres_enabled and linkding_database_hostname == postgres_connection_hostname else 'sqlite' }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4337,8 +4362,10 @@ freescout_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pro
 freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 freescout_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 freescout_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'freescout.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4385,8 +4412,10 @@ miniflux_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 miniflux_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 miniflux_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
+# role-specific:postgres
 miniflux_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 miniflux_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'miniflux.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4579,8 +4608,10 @@ n8n_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable
 n8n_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 n8n_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 n8n_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 n8n_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'n8n.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4708,10 +4739,12 @@ nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pr
 nextcloud_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 nextcloud_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
+# role-specific:postgres
 nextcloud_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 nextcloud_database_port: "{{ '5432' if postgres_enabled else '' }}"
 nextcloud_database_username: "nextcloud"
 nextcloud_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nextcloud', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:exim_relay
 nextcloud_config_parameter_mail_smtphost: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -4766,9 +4799,11 @@ netbox_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxya
 netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 netbox_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 netbox_database_port: "{{ '5432' if postgres_enabled else '' }}"
 netbox_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.netbox', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -4862,10 +4897,12 @@ notfellchen_gid: "{{ mash_playbook_gid }}"
 
 notfellchen_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.nf', rounds=655555) | to_uuid }}"
 
+# role-specific:postgres
 notfellchen_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
 notfellchen_database_port: "{{ '5432' if postgres_enabled else '' }}"
 notfellchen_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.nf', rounds=655555) | to_uuid }}"
 notfellchen_database_username: "notfellchen"
+# /role-specific:postgres
 
 notfellchen_systemd_required_services_list: |
   {{
@@ -4986,10 +5023,12 @@ outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 
 outline_environment_variable_utils_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'utils.out', rounds=655555) | to_uuid }}"
 
+# role-specific:postgres
 outline_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 outline_database_port: "{{ '5432' if postgres_enabled else '' }}"
 outline_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.out', rounds=655555) | to_uuid }}"
 outline_database_sslmode: "{{ 'disable' if postgres_enabled and outline_database_hostname == postgres_identifier else 'prefer' }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -5121,9 +5160,11 @@ oxitraffic_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 oxitraffic_uid: "{{ mash_playbook_uid }}"
 oxitraffic_gid: "{{ mash_playbook_gid }}"
 
+# role-specific:postgres
 oxitraffic_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 oxitraffic_database_port: "{{ '5432' if postgres_enabled else '' }}"
 oxitraffic_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.oxitraffic', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 oxitraffic_systemd_required_services_list: |
   {{
@@ -5170,10 +5211,12 @@ paperless_gid: "{{ mash_playbook_gid }}"
 
 paperless_secret_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'paperless.secret', rounds=655555) | to_uuid }}"
 
+# role-specific:postgres
 paperless_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 paperless_database_username: "paperless"
 paperless_database_port: "{{ '5432' if postgres_enabled else '' }}"
 paperless_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.paperless', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 paperless_systemd_required_services_list: |
   {{
@@ -5243,10 +5286,12 @@ peertube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_prox
 peertube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 peertube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 peertube_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 peertube_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
 peertube_config_database_username: peertube
 peertube_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.peertube', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 peertube_systemd_required_services_list_auto: |
   {{
@@ -5316,8 +5361,10 @@ plausible_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pro
 plausible_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 plausible_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 plausible_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 plausible_database_password: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'plausible.db', rounds=655555) | to_uuid) if postgres_enabled else '' }}"
+# /role-specific:postgres
 
 # role-specific:clickhouse
 plausible_clickhouse_database_hostname: "{{ clickhouse_identifier if clickhouse_enabled else '' }}"
@@ -5420,11 +5467,13 @@ prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ trae
 prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
 
+# role-specific:postgres
 prometheus_postgres_exporter_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 prometheus_postgres_exporter_database_username: prometheus_postgres_exporter
 prometheus_postgres_exporter_database_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
 prometheus_postgres_exporter_database_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
 prometheus_postgres_exporter_database_ssl: false
+# /role-specific:postgres
 
 prometheus_postgres_exporter_systemd_required_services_list_auto: |
   {{
@@ -5822,9 +5871,12 @@ redmine_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 redmine_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
 redmine_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite3' }}"
+
+# role-specific:postgres
 redmine_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
 redmine_database_username: "redmine"
 redmine_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'redmine.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #
@@ -5909,11 +5961,14 @@ roundcube_uid: "0"
 roundcube_gid: "0"
 
 roundcube_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite' }}"
+
+# role-specific:postgres
 roundcube_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 roundcube_database_port: "{{ '5432' if postgres_enabled else '' }}"
 roundcube_database_name: "{{ 'roundcube' if postgres_enabled else '' }}"
 roundcube_database_username: "{{ 'roundcube' if postgres_enabled else '' }}"
 roundcube_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.roundcube', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 roundcube_systemd_required_systemd_services_list: |
   {{
@@ -6024,10 +6079,12 @@ semaphore_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_bas
 semaphore_uid: "{{ mash_playbook_uid }}"
 semaphore_gid: "{{ mash_playbook_gid }}"
 
+# role-specific:postgres
 semaphore_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
 semaphore_database_port: "{{ '5432' if postgres_enabled else '' }}"
 semaphore_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.semaphore', rounds=655555) | to_uuid }}"
 semaphore_database_username: "{{ semaphore_identifier }}"
+# /role-specific:postgres
 
 semaphore_systemd_required_services_list: |
   {{
@@ -6275,10 +6332,12 @@ tandoor_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reve
 tandoor_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 tandoor_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
+# role-specific:postgres
 tandoor_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 tandoor_database_port: "{{ '5432' if postgres_enabled else '' }}"
 tandoor_database_username: "tandoor"
 tandoor_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.tandoor', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 tandoor_environment_variable_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'secret.tandoor', rounds=655555) | to_uuid }}"
 
@@ -6445,10 +6504,12 @@ vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_
 vaultwarden_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 vaultwarden_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
+# role-specific:postgres
 vaultwarden_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 vaultwarden_database_port: "{{ '5432' if postgres_enabled else '' }}"
 vaultwarden_database_username: "vaultwarden"
 vaultwarden_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.vaultwarden', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:exim_relay
 vaultwarden_config_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
@@ -6609,10 +6670,12 @@ forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 forgejo_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 forgejo_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
+# role-specific:postgres
 forgejo_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 forgejo_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
 forgejo_config_database_username: "forgejo"
 forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.forgejo', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
 
 # role-specific:exim_relay
 forgejo_config_mailer_enabled: "{{ exim_relay_enabled }}"
@@ -6700,13 +6763,15 @@ woodpecker_ci_server_container_labels_traefik_compression_middleware_enabled: "{
 woodpecker_ci_server_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
 woodpecker_ci_server_database_driver: postgres
-woodpecker_ci_server_database_datasource: "postgres://{{ woodpecker_ci_server_database_datasource_username }}:{{ woodpecker_ci_server_database_datasource_password }}@{{ woodpecker_ci_server_database_datasource_hostname }}:{{ woodpecker_ci_server_database_datasource_port }}/{{ woodpecker_ci_server_database_datasource_db_name }}?sslmode=disable"
 
+# role-specific:postgres
+woodpecker_ci_server_database_datasource: "postgres://{{ woodpecker_ci_server_database_datasource_username }}:{{ woodpecker_ci_server_database_datasource_password }}@{{ woodpecker_ci_server_database_datasource_hostname }}:{{ woodpecker_ci_server_database_datasource_port }}/{{ woodpecker_ci_server_database_datasource_db_name }}?sslmode=disable"
 woodpecker_ci_server_database_datasource_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
 woodpecker_ci_server_database_datasource_port: "{{ '5432' if postgres_enabled else '' }}"
 woodpecker_ci_server_database_datasource_username: woodpecker_ci_server
 woodpecker_ci_server_database_datasource_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'woodpecker.ci', rounds=655555) | to_uuid }}"
 woodpecker_ci_server_database_datasource_db_name: woodpecker_ci_server
+# /role-specific:postgres
 
 ########################################################################
 #                                                                      #

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -51,8 +51,11 @@ authelia_container_additional_networks_auto: |
 
 authelia_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 authelia_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 authelia_config_jwt_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jwt.authelia', rounds=655555) | to_uuid }}"
 
@@ -1453,8 +1456,11 @@ apisix_dashboard_container_additional_networks_auto: |
 
 apisix_dashboard_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 apisix_dashboard_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 apisix_dashboard_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 apisix_dashboard_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:etcd
 apisix_dashboard_config_conf_etcd_endpoints: |
@@ -1508,8 +1514,11 @@ apisix_gateway_container_additional_networks_auto: |
 
 apisix_gateway_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 apisix_gateway_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 apisix_gateway_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 apisix_gateway_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 apisix_gateway_container_labels_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 apisix_gateway_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
@@ -1805,8 +1814,11 @@ calibre_web_container_additional_networks_auto: |
 
 calibre_web_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 calibre_web_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 calibre_web_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 calibre_web_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -1840,8 +1852,11 @@ readeck_container_additional_networks_auto: |
 
 readeck_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 readeck_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 readeck_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 readeck_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2216,8 +2231,11 @@ endlessh_container_additional_networks_auto: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 endlessh_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and endlessh_hostname }}"
 endlessh_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 endlessh_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 endlessh_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 endlessh_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 endlessh_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
@@ -2468,8 +2486,11 @@ freshrss_container_additional_networks: |
 
 freshrss_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 freshrss_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 freshrss_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 freshrss_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 freshrss_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -2535,13 +2556,15 @@ funkwhale_frontend_container_additional_networks_auto: |
 
 funkwhale_api_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 funkwhale_api_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-funkwhale_api_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-funkwhale_api_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 funkwhale_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 funkwhale_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+funkwhale_api_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+funkwhale_api_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 funkwhale_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 funkwhale_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2583,11 +2606,13 @@ gitea_container_additional_networks_auto: |
 
 gitea_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 gitea_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-gitea_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-gitea_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 gitea_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 gitea_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+gitea_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+gitea_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 gitea_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -2650,8 +2675,11 @@ gotosocial_container_additional_networks_auto: |
 
 gotosocial_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 gotosocial_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 gotosocial_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 gotosocial_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 gotosocial_database_host: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -2708,8 +2736,11 @@ grafana_container_additional_networks_auto: |
 
 grafana_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 grafana_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 grafana_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 grafana_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2743,8 +2774,11 @@ headscale_container_additional_networks_auto: |
 
 headscale_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 headscale_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 headscale_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 headscale_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -2792,8 +2826,11 @@ healthchecks_container_additional_networks_auto: |
 
 healthchecks_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 healthchecks_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 healthchecks_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 healthchecks_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -2842,8 +2879,11 @@ hubsite_container_additional_networks_auto: |
 
 hubsite_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 hubsite_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 hubsite_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 hubsite_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # Services
 ##########
@@ -3718,8 +3758,11 @@ ihatemoney_container_additional_networks_auto: |
 
 ihatemoney_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 ihatemoney_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 ihatemoney_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 ihatemoney_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 ihatemoney_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -3786,8 +3829,11 @@ ilmo_container_additional_networks: |
 
 ilmo_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 ilmo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 ilmo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 ilmo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -3830,8 +3876,8 @@ infisical_backend_container_additional_networks: |
 
 infisical_backend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 infisical_backend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-infisical_backend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-infisical_backend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+infisical_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+infisical_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
 # Intentionally not auto-generating infisical_backend_environment_variable_encryption_key here.
 # We prefer it to be explicit as it seems important that it remains stable.
@@ -3846,10 +3892,12 @@ infisical_frontend_container_additional_networks: |
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
   }}
 
-infisical_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-infisical_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+# role-specific:traefik
+infisical_backend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+infisical_backend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 infisical_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 infisical_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 infisical_mongodb_hostname: "{{ mongodb_identifier if mongodb_enabled else '' }}"
 infisical_mongodb_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'infisical.db', rounds=655555) | to_uuid }}"
@@ -3887,8 +3935,11 @@ influxdb_container_additional_networks_auto: |
 
 influxdb_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 influxdb_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 influxdb_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 influxdb_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -3974,8 +4025,11 @@ jitsi_jvb_container_additional_networks_auto: |
 
 jitsi_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 jitsi_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 jitsi_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 jitsi_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 jitsi_jibri_xmpp_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jibri', rounds=655555) | to_uuid }}"
 jitsi_jicofo_auth_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jicofo', rounds=655555) | to_uuid }}"
@@ -4020,9 +4074,10 @@ joplin_server_container_additional_networks_auto: |
     ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and joplin_server_environment_variable_mailer_host == exim_relay_identifier | default('mash-exim-relay') and joplin_server_container_network != exim_relay_container_network) else [])
   }}
 
-# role-specific:traefik
 joplin_server_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 joplin_server_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 joplin_server_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 joplin_server_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
@@ -4081,8 +4136,11 @@ keycloak_container_additional_networks_auto: |
 
 keycloak_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 keycloak_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 keycloak_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 keycloak_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
 keycloak_container_labels_metrics_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ keycloak_identifier }}"
@@ -4131,13 +4189,15 @@ labelstudio_container_additional_networks_auto: |
 
 labelstudio_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 labelstudio_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-labelstudio_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-labelstudio_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 labelstudio_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 labelstudio_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
 labelstudio_postgres_backend_enabled: "{{ postgres_enabled }}"
+
+# role-specific:traefik
+labelstudio_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+labelstudio_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 labelstudio_database_name: "labelstudio"
@@ -4188,8 +4248,11 @@ lago_front_container_additional_networks_auto: |
 
 lago_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 lago_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 lago_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 lago_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 lago_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -4229,8 +4292,11 @@ languagetool_gid: "{{ mash_playbook_gid }}"
 
 languagetool_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 languagetool_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 languagetool_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 languagetool_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 languagetool_container_additional_networks_auto: |
   {{
@@ -4265,8 +4331,11 @@ loki_gid: "{{ mash_playbook_gid }}"
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 loki_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and loki_hostname | length > 0 }}"
 loki_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 loki_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 loki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 loki_container_additional_networks_auto: |
   {{
@@ -4312,8 +4381,11 @@ linkding_container_additional_networks_auto: |
 
 linkding_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 linkding_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 linkding_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 linkding_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -4359,8 +4431,11 @@ freescout_container_additional_networks: |
 
 freescout_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 freescout_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 freescout_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -4406,11 +4481,13 @@ miniflux_container_additional_networks_auto: |
 
 miniflux_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 miniflux_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-miniflux_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-miniflux_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 miniflux_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 miniflux_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+miniflux_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+miniflux_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 miniflux_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -4467,8 +4544,11 @@ mobilizon_container_additional_networks: |
 
 mobilizon_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 mobilizon_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 mobilizon_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 mobilizon_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4559,8 +4639,11 @@ mrs_container_additional_networks: |
 
 mrs_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 mrs_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 mrs_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 mrs_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4605,8 +4688,11 @@ n8n_container_additional_networks: |
 
 n8n_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 n8n_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 n8n_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 n8n_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 n8n_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -4645,11 +4731,13 @@ navidrome_container_additional_networks_auto: |
 
 navidrome_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 navidrome_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-navidrome_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-navidrome_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 navidrome_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 navidrome_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+navidrome_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+navidrome_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4682,8 +4770,11 @@ neko_container_additional_networks_auto: |
 
 neko_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 neko_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 neko_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 neko_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -4733,11 +4824,13 @@ nextcloud_container_additional_networks_auto: |
 
 nextcloud_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 nextcloud_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-nextcloud_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 nextcloud_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 nextcloud_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+nextcloud_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 nextcloud_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -4796,8 +4889,11 @@ netbox_container_additional_networks_auto: |
 
 netbox_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 netbox_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 netbox_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -4920,14 +5016,15 @@ notfellchen_container_additional_networks_auto: |
 
 notfellchen_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 notfellchen_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-notfellchen_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-notfellchen_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 notfellchen_sws_container_labels_traefik_enabled: "{{ notfellchen_container_labels_traefik_enabled }}"
 notfellchen_sws_container_labels_traefik_docker_network: "{{ notfellchen_container_labels_traefik_docker_network }}"
 notfellchen_sws_container_labels_traefik_entrypoints: "{{ notfellchen_container_labels_traefik_entrypoints }}"
 notfellchen_sws_container_labels_traefik_tls_certResolver: "{{ notfellchen_container_labels_traefik_tls_certResolver }}"
 
+# role-specific:traefik
+notfellchen_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+notfellchen_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5018,8 +5115,11 @@ outline_container_additional_networks_auto: |
 
 outline_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 outline_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 outline_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 outline_environment_variable_utils_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'utils.out', rounds=655555) | to_uuid }}"
 
@@ -5059,8 +5159,11 @@ oauth2_proxy_container_network: "{{ (mash_playbook_reverse_proxyable_services_ad
 
 oauth2_proxy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 oauth2_proxy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 oauth2_proxy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 oauth2_proxy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5132,8 +5235,11 @@ owncast_container_additional_networks: |
 
 owncast_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 owncast_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 owncast_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 owncast_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5182,8 +5288,11 @@ oxitraffic_container_additional_networks: |
 
 oxitraffic_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 oxitraffic_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 oxitraffic_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 oxitraffic_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5236,8 +5345,11 @@ paperless_container_additional_networks_auto: |
 
 paperless_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 paperless_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 paperless_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 paperless_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:exim_relay
 paperless_email_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
@@ -5283,8 +5395,11 @@ peertube_container_additional_networks_auto: |
 
 peertube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 peertube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 peertube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 peertube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 peertube_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -5358,8 +5473,11 @@ plausible_container_additional_networks_auto: |
 
 plausible_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 plausible_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 plausible_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 plausible_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 plausible_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -5461,8 +5579,11 @@ prometheus_postgres_exporter_container_additional_networks: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_postgres_exporter_hostname | length > 0 }}"
 prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
@@ -5508,8 +5629,11 @@ prometheus_gid: "{{ mash_playbook_gid }}"
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_hostname | length > 0 }}"
 prometheus_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 prometheus_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 prometheus_container_additional_networks_auto: |
   {{
@@ -5553,8 +5677,11 @@ prometheus_blackbox_exporter_container_additional_networks: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_blackbox_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_blackbox_exporter_hostname }}"
 prometheus_blackbox_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 prometheus_blackbox_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_blackbox_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_blackbox_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
@@ -5595,8 +5722,11 @@ prometheus_ssh_exporter_container_additional_networks: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_ssh_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_ssh_exporter_hostname }}"
 prometheus_ssh_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 prometheus_ssh_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_ssh_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
@@ -5637,8 +5767,11 @@ prometheus_node_exporter_container_additional_networks_auto: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 prometheus_node_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_node_exporter_hostname }}"
 prometheus_node_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 prometheus_node_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 prometheus_node_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
@@ -5693,8 +5826,11 @@ promtail_config_clients_auto: |
 # Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
 promtail_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 promtail_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 promtail_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 promtail_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 promtail_container_labels_metrics_enabled: "{{ prometheus_enabled | default(false) or mash_playbook_metrics_exposure_enabled }}"
 promtail_container_labels_metrics_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
@@ -5819,8 +5955,11 @@ radicale_container_additional_networks_auto: |
 
 radicale_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 radicale_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 radicale_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 radicale_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -5867,8 +6006,11 @@ redmine_container_additional_networks: |
 
 redmine_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 redmine_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 redmine_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 redmine_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 redmine_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite3' }}"
 
@@ -5979,8 +6121,11 @@ roundcube_systemd_required_systemd_services_list: |
 
 roundcube_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 roundcube_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 roundcube_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 roundcube_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 roundcube_container_additional_networks: |
   {{
@@ -6046,8 +6191,11 @@ searxng_systemd_required_systemd_services_list: |
 
 searxng_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 searxng_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 searxng_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 searxng_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 searxng_container_additional_networks: |
   {{
@@ -6102,8 +6250,11 @@ semaphore_container_additional_networks: |
 
 semaphore_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 semaphore_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 semaphore_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 semaphore_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6138,9 +6289,10 @@ send_container_additional_networks_auto: |
 # Required for a Redis / KeyDB / Valkey instance
 send_environment_variable_redis_host: "{{ send_config_redis_hostname }}"
 
-# role-specific:traefik
 send_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 send_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 send_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 send_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
@@ -6240,8 +6392,11 @@ stirling_pdf_container_additional_networks_auto: |
 
 stirling_pdf_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 stirling_pdf_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 stirling_pdf_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 stirling_pdf_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6275,8 +6430,11 @@ syncthing_container_additional_networks_auto: |
 
 syncthing_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 syncthing_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 syncthing_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 syncthing_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6329,8 +6487,11 @@ tandoor_frontend_container_additional_networks_auto: |
 
 tandoor_frontend_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 tandoor_frontend_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 tandoor_frontend_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 tandoor_frontend_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 tandoor_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6498,11 +6659,13 @@ vaultwarden_container_additional_networks_auto: |
 
 vaultwarden_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 vaultwarden_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-vaultwarden_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 vaultwarden_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 vaultwarden_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+vaultwarden_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 vaultwarden_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6550,8 +6713,11 @@ uptime_kuma_container_additional_networks_auto: |
 
 uptime_kuma_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 uptime_kuma_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 uptime_kuma_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 uptime_kuma_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6585,8 +6751,11 @@ versatiles_container_additional_networks_auto: |
 
 versatiles_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 versatiles_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 versatiles_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 versatiles_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6620,8 +6789,11 @@ wg_easy_container_additional_networks_auto: |
 
 wg_easy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 wg_easy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 wg_easy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 wg_easy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 ########################################################################
 #                                                                      #
@@ -6664,11 +6836,13 @@ forgejo_container_additional_networks_auto: |
 
 forgejo_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 forgejo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
 forgejo_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 forgejo_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:traefik
+forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 # role-specific:postgres
 forgejo_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
@@ -6758,7 +6932,6 @@ woodpecker_ci_server_container_additional_networks: |
 
 woodpecker_ci_server_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 woodpecker_ci_server_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
 woodpecker_ci_server_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
 woodpecker_ci_server_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
 
@@ -6856,8 +7029,11 @@ wordpress_container_additional_networks_auto: |
 
 wordpress_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 wordpress_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 wordpress_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 wordpress_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
 
 
 wordpress_database_hostname: "{{ mariadb_identifier if mariadb_enabled | default(false) else '' }}"
@@ -6947,9 +7123,10 @@ yourls_environment_variable_db_pass: "{{ '%s' | format(mash_playbook_generic_sec
 yourls_environment_variable_db_host_name: "{{ mariadb_identifier if mariadb_enabled else '' }}"
 # /role-specific:mariadb
 
-# role-specific:traefik
 yourls_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 yourls_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
 yourls_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 yourls_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1669,6 +1669,7 @@ backup_borg_storage_archive_name_format: "{{ mash_playbook_service_identifier_pr
 backup_borg_container_image_self_build: "{{ mash_playbook_architecture not in ['amd64', 'arm32', 'arm64'] }}"
 
 backup_borg_postgresql_enabled: "{{ postgres_enabled }}"
+backup_borg_mysql_enabled: "{{ mariadb_enabled }}"
 
 # role-specific:postgres
 backup_borg_postgresql_databases_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
@@ -1679,7 +1680,6 @@ backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attr
 # /role-specific:postgres
 
 # role-specific:mariadb
-backup_borg_mysql_enabled: "{{ mariadb_enabled }}"
 backup_borg_mysql_databases_hostname: "{{ mariadb_identifier if mariadb_enabled else '' }}"
 backup_borg_mysql_databases_username: "root"
 backup_borg_mysql_databases_password: "{{ mariadb_root_password if mariadb_enabled else '' }}"
@@ -7039,10 +7039,11 @@ wordpress_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }
 wordpress_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 # /role-specific:traefik
 
-
+# role-specific:mariadb
 wordpress_database_hostname: "{{ mariadb_identifier if mariadb_enabled | default(false) else '' }}"
 wordpress_mysql_port: "{{ '3306' if mariadb_enabled | default(false) else '' }}"
 wordpress_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.mariadb', rounds=655555) | to_uuid }}"
+# /role-specific:mariadb
 
 ########################################################################
 #                                                                      #


### PR DESCRIPTION
- Group variables specific to postgres, traefik, mongodb, postgis, mariadb
- Move those groups to the bottom in each block and sort them alphabetically for sanity