### PR TITLE
Tidy up group_vars_mash_servers

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -3413,6 +3413,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
     }}
   # /role-specific:focalboard
 
+  # role-specific:forgejo
+  - |-
+    {{
+      ({
+        'name': hubsite_service_forgejo_name,
+        'url': hubsite_service_forgejo_url,
+        'logo_location': hubsite_service_forgejo_logo_location,
+        'description': hubsite_service_forgejo_description,
+        'priority': hubsite_service_forgejo_priority,
+      } if hubsite_service_forgejo_enabled else omit)
+    }}
+  # /role-specific:forgejo
+
   # role-specific:freshrss
   - |-
     {{

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -6063,6 +6063,31 @@ readeck_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 
 
 
+# role-specific:redis
+########################################################################
+#                                                                      #
+# redis                                                                #
+#                                                                      #
+########################################################################
+
+redis_enabled: false
+
+redis_identifier: "{{ mash_playbook_service_identifier_prefix }}redis"
+
+redis_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}redis"
+
+redis_uid: "{{ mash_playbook_uid }}"
+redis_gid: "{{ mash_playbook_gid }}"
+
+########################################################################
+#                                                                      #
+# /redis                                                               #
+#                                                                      #
+########################################################################
+# /role-specific:redis
+
+
+
 # role-specific:redmine
 ########################################################################
 #                                                                      #
@@ -6119,31 +6144,6 @@ redmine_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 #                                                                      #
 ########################################################################
 # /role-specific:redmine
-
-
-
-# role-specific:redis
-########################################################################
-#                                                                      #
-# redis                                                                #
-#                                                                      #
-########################################################################
-
-redis_enabled: false
-
-redis_identifier: "{{ mash_playbook_service_identifier_prefix }}redis"
-
-redis_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}redis"
-
-redis_uid: "{{ mash_playbook_uid }}"
-redis_gid: "{{ mash_playbook_gid }}"
-
-########################################################################
-#                                                                      #
-# /redis                                                               #
-#                                                                      #
-########################################################################
-# /role-specific:redis
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -6656,6 +6656,44 @@ container_socket_proxy_api_images_enabled: "{{ true if tsdproxy_docker_endpoint 
 
 
 
+# role-specific:uptime_kuma
+########################################################################
+#                                                                      #
+# uptime_kuma                                                          #
+#                                                                      #
+########################################################################
+
+uptime_kuma_enabled: false
+
+uptime_kuma_identifier: "{{ mash_playbook_service_identifier_prefix }}uptime-kuma"
+
+uptime_kuma_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}uptime-kuma"
+
+uptime_kuma_uid: "{{ mash_playbook_uid }}"
+uptime_kuma_gid: "{{ mash_playbook_gid }}"
+
+uptime_kuma_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+uptime_kuma_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+uptime_kuma_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+uptime_kuma_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+uptime_kuma_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /uptime_kuma                                                         #
+#                                                                      #
+########################################################################
+# /role-specific:uptime_kuma
+
+
+
 # role-specific:valkey
 ########################################################################
 #                                                                      #
@@ -6748,44 +6786,6 @@ vaultwarden_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_
 #                                                                      #
 ########################################################################
 # /role-specific:vaultwarden
-
-
-
-# role-specific:uptime_kuma
-########################################################################
-#                                                                      #
-# uptime_kuma                                                          #
-#                                                                      #
-########################################################################
-
-uptime_kuma_enabled: false
-
-uptime_kuma_identifier: "{{ mash_playbook_service_identifier_prefix }}uptime-kuma"
-
-uptime_kuma_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}uptime-kuma"
-
-uptime_kuma_uid: "{{ mash_playbook_uid }}"
-uptime_kuma_gid: "{{ mash_playbook_gid }}"
-
-uptime_kuma_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-uptime_kuma_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-uptime_kuma_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-uptime_kuma_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-uptime_kuma_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /uptime_kuma                                                         #
-#                                                                      #
-########################################################################
-# /role-specific:uptime_kuma
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1792,44 +1792,6 @@ changedetection_container_labels_traefik_tls_certResolver: "{{ traefik_certResol
 
 
 
-# role-specific:wetty
-########################################################################
-#                                                                      #
-# wetty                                                                #
-#                                                                      #
-########################################################################
-
-wetty_enabled: false
-
-wetty_identifier: "{{ mash_playbook_service_identifier_prefix }}wetty"
-
-wetty_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}wetty"
-
-wetty_uid: "{{ mash_playbook_uid }}"
-wetty_gid: "{{ mash_playbook_gid }}"
-
-wetty_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-wetty_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-wetty_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-wetty_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-wetty_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /wetty                                                               #
-#                                                                      #
-########################################################################
-# /role-specific:wetty
-
-
-
 # role-specific:readeck
 ########################################################################
 #                                                                      #
@@ -6766,6 +6728,44 @@ versatiles_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_p
 #                                                                      #
 ########################################################################
 # /role-specific:versatiles
+
+
+
+# role-specific:wetty
+########################################################################
+#                                                                      #
+# wetty                                                                #
+#                                                                      #
+########################################################################
+
+wetty_enabled: false
+
+wetty_identifier: "{{ mash_playbook_service_identifier_prefix }}wetty"
+
+wetty_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}wetty"
+
+wetty_uid: "{{ mash_playbook_uid }}"
+wetty_gid: "{{ mash_playbook_gid }}"
+
+wetty_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+wetty_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+wetty_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+wetty_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+wetty_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /wetty                                                               #
+#                                                                      #
+########################################################################
+# /role-specific:wetty
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2966,16 +2966,6 @@ hubsite_service_adguard_home_description: "A network-wide DNS software for block
 hubsite_service_adguard_home_priority: 1000
 # /role-specific:adguard_home
 
-# role-specific:authentik
-# authentik
-hubsite_service_authentik_enabled: "{{ authentik_enabled }}"
-hubsite_service_authentik_name: Authentik
-hubsite_service_authentik_url: "https://{{ authentik_hostname }}"
-hubsite_service_authentik_logo_location: "{{ role_path }}/assets/authentik.png"
-hubsite_service_authentik_description: "An open source identity provider"
-hubsite_service_authentik_priority: 1000
-# /role-specific:authentik
-
 # role-specific:appsmith
 # Appsmith
 hubsite_service_appsmith_enabled: "{{ appsmith_enabled }}"
@@ -2985,6 +2975,16 @@ hubsite_service_appsmith_logo_location: "{{ role_path }}/assets/appsmith.png"
 hubsite_service_appsmith_description: "Platform for building and deploying custom internal tools and applications without writing code"
 hubsite_service_appsmith_priority: 1000
 # /role-specific:appsmith
+
+# role-specific:authentik
+# authentik
+hubsite_service_authentik_enabled: "{{ authentik_enabled }}"
+hubsite_service_authentik_name: Authentik
+hubsite_service_authentik_url: "https://{{ authentik_hostname }}"
+hubsite_service_authentik_logo_location: "{{ role_path }}/assets/authentik.png"
+hubsite_service_authentik_description: "An open source identity provider"
+hubsite_service_authentik_priority: 1000
+# /role-specific:authentik
 
 # role-specific:docker_registry_browser
 # Docker Registry Browser
@@ -3025,6 +3025,16 @@ hubsite_service_focalboard_logo_location: "{{ role_path }}/assets/focalboard.png
 hubsite_service_focalboard_description: "An open source, self-hosted alternative to Trello, Notion, and Asana."
 hubsite_service_focalboard_priority: 1000
 # /role-specific:focalboard
+
+# role-specific:forgejo
+# Forgejo
+hubsite_service_forgejo_enabled: "{{ forgejo_enabled }}"
+hubsite_service_forgejo_name: Forgejo
+hubsite_service_forgejo_url: "https://{{ forgejo_hostname }}{{ forgejo_path_prefix }}"
+hubsite_service_forgejo_logo_location: "{{ role_path }}/assets/forgejo.png"
+hubsite_service_forgejo_description: "Another git service"
+hubsite_service_forgejo_priority: 1000
+# /role-specific:forgejo
 
 # role-specific:freshrss
 # FreshRSS
@@ -3136,6 +3146,16 @@ hubsite_service_languagetool_description: "An open source online grammar, style 
 hubsite_service_languagetool_priority: 1000
 # /role-specific:languagetool
 
+# role-specific:linkding
+# Linkding
+hubsite_service_linkding_enabled: "{{ linkding_enabled }}"
+hubsite_service_linkding_name: Linkding
+hubsite_service_linkding_url: "https://{{ linkding_hostname }}{{ linkding_path_prefix }}"
+hubsite_service_linkding_logo_location: "{{ role_path }}/assets/linkding.png"
+hubsite_service_linkding_description: "Bookmark manager that is designed be to be minimal and fast."
+hubsite_service_linkding_priority: 1000
+# /role-specific:linkding
+
 # role-specific:miniflux
 # Miniflux
 hubsite_service_miniflux_enabled: "{{ miniflux_enabled }}"
@@ -3145,16 +3165,6 @@ hubsite_service_miniflux_logo_location: "{{ role_path }}/assets/miniflux.png"
 hubsite_service_miniflux_description: "An opinionated feed reader"
 hubsite_service_miniflux_priority: 1000
 # /role-specific:miniflux
-
-# role-specific:navidrome
-# Navidrome
-hubsite_service_navidrome_enabled: "{{ navidrome_enabled }}"
-hubsite_service_navidrome_name: Navidrome
-hubsite_service_navidrome_url: "https://{{ navidrome_hostname }}{{ navidrome_path_prefix }}"
-hubsite_service_navidrome_logo_location: "{{ role_path }}/assets/navidrome.png"
-hubsite_service_navidrome_description: "A Subsonic-API compatible music server"
-hubsite_service_navidrome_priority: 1000
-# /role-specific:navidrome
 
 # role-specific:n8n
 # n8n
@@ -3166,15 +3176,15 @@ hubsite_service_n8n_description: "Workflow automation for technical people."
 hubsite_service_n8n_priority: 1000
 # /role-specific:n8n
 
-# role-specific:linkding
-# Linkding
-hubsite_service_linkding_enabled: "{{ linkding_enabled }}"
-hubsite_service_linkding_name: Linkding
-hubsite_service_linkding_url: "https://{{ linkding_hostname }}{{ linkding_path_prefix }}"
-hubsite_service_linkding_logo_location: "{{ role_path }}/assets/linkding.png"
-hubsite_service_linkding_description: "Bookmark manager that is designed be to be minimal and fast."
-hubsite_service_linkding_priority: 1000
-# /role-specific:linkding
+# role-specific:navidrome
+# Navidrome
+hubsite_service_navidrome_enabled: "{{ navidrome_enabled }}"
+hubsite_service_navidrome_name: Navidrome
+hubsite_service_navidrome_url: "https://{{ navidrome_hostname }}{{ navidrome_path_prefix }}"
+hubsite_service_navidrome_logo_location: "{{ role_path }}/assets/navidrome.png"
+hubsite_service_navidrome_description: "A Subsonic-API compatible music server"
+hubsite_service_navidrome_priority: 1000
+# /role-specific:navidrome
 
 # role-specific:nextcloud
 # Nextcloud
@@ -3307,16 +3317,6 @@ hubsite_service_yourls_description: "Your Own URL Shortener, on your server"
 hubsite_service_yourls_priority: 1000
 # /role-specific:yourls
 
-# role-specific:forgejo
-# Forgejo
-hubsite_service_forgejo_enabled: "{{ forgejo_enabled }}"
-hubsite_service_forgejo_name: Forgejo
-hubsite_service_forgejo_url: "https://{{ forgejo_hostname }}{{ forgejo_path_prefix }}"
-hubsite_service_forgejo_logo_location: "{{ role_path }}/assets/forgejo.png"
-hubsite_service_forgejo_description: "Another git service"
-hubsite_service_forgejo_priority: 1000
-# /role-specific:forgejo
-
 mash_playbook_hubsite_service_list_auto_itemized:
   # Dummy entry, which is not role-specific.
   # Ensures there's at least one entry defined in the list.
@@ -3335,19 +3335,6 @@ mash_playbook_hubsite_service_list_auto_itemized:
     }}
   # /role-specific:adguard_home
 
-  # role-specific:authentik
-  - |-
-    {{
-      ({
-        'name': hubsite_service_authentik_name,
-        'url': hubsite_service_authentik_url,
-        'logo_location': hubsite_service_authentik_logo_location,
-        'description': hubsite_service_authentik_description,
-        'priority': hubsite_service_adguard_home_priority,
-      } if hubsite_service_authentik_enabled else omit)
-    }}
-  # /role-specific:authentik
-
   # role-specific:appsmith
   - |-
     {{
@@ -3360,6 +3347,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_appsmith_enabled else omit)
     }}
   # /role-specific:appsmith
+
+  # role-specific:authentik
+  - |-
+    {{
+      ({
+        'name': hubsite_service_authentik_name,
+        'url': hubsite_service_authentik_url,
+        'logo_location': hubsite_service_authentik_logo_location,
+        'description': hubsite_service_authentik_description,
+        'priority': hubsite_service_adguard_home_priority,
+      } if hubsite_service_authentik_enabled else omit)
+    }}
+  # /role-specific:authentik
 
   # role-specific:docker_registry_browser
   - |-
@@ -3582,19 +3582,6 @@ mash_playbook_hubsite_service_list_auto_itemized:
     }}
   # /role-specific:miniflux
 
-  # role-specific:navidrome
-  - |-
-    {{
-      ({
-        'name': hubsite_service_navidrome_name,
-        'url': hubsite_service_navidrome_url,
-        'logo_location': hubsite_service_navidrome_logo_location,
-        'description': hubsite_service_navidrome_description,
-        'priority': hubsite_service_navidrome_priority,
-      } if hubsite_service_navidrome_enabled else omit)
-    }}
-  # /role-specific:navidrome
-
   # role-specific:n8n
   - |-
     {{
@@ -3607,6 +3594,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_n8n_enabled else omit)
     }}
   # /role-specific:n8n
+
+  # role-specific:navidrome
+  - |-
+    {{
+      ({
+        'name': hubsite_service_navidrome_name,
+        'url': hubsite_service_navidrome_url,
+        'logo_location': hubsite_service_navidrome_logo_location,
+        'description': hubsite_service_navidrome_description,
+        'priority': hubsite_service_navidrome_priority,
+      } if hubsite_service_navidrome_enabled else omit)
+    }}
+  # /role-specific:navidrome
 
   # role-specific:nextcloud
   - |-
@@ -3673,19 +3673,6 @@ mash_playbook_hubsite_service_list_auto_itemized:
     }}
   # /role-specific:radicale
 
-  # role-specific:uptime_kuma
-  - |-
-    {{
-      ({
-        'name': hubsite_service_uptime_kuma_name,
-        'url': hubsite_service_uptime_kuma_url,
-        'logo_location': hubsite_service_uptime_kuma_logo_location,
-        'description': hubsite_service_uptime_kuma_description,
-        'priority': hubsite_service_uptime_kuma_priority,
-      } if hubsite_service_uptime_kuma_enabled else omit)
-    }}
-  # /role-specific:uptime_kuma
-
   # role-specific:send
   - |-
     {{
@@ -3724,6 +3711,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_tandoor_enabled else omit)
     }}
   # /role-specific:tandoor
+
+  # role-specific:uptime_kuma
+  - |-
+    {{
+      ({
+        'name': hubsite_service_uptime_kuma_name,
+        'url': hubsite_service_uptime_kuma_url,
+        'logo_location': hubsite_service_uptime_kuma_logo_location,
+        'description': hubsite_service_uptime_kuma_description,
+        'priority': hubsite_service_uptime_kuma_priority,
+      } if hubsite_service_uptime_kuma_enabled else omit)
+    }}
+  # /role-specific:uptime_kuma
 
   # role-specific:vaultwarden
   - |-

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4416,45 +4416,6 @@ languagetool_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver
 
 
 
-# role-specific:loki
-########################################################################
-#                                                                      #
-# loki                                                                 #
-#                                                                      #
-########################################################################
-
-loki_enabled: false
-
-loki_identifier: "{{ mash_playbook_service_identifier_prefix }}loki"
-
-loki_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}loki"
-
-loki_uid: "{{ mash_playbook_uid }}"
-loki_gid: "{{ mash_playbook_gid }}"
-
-loki_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
-loki_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and loki_hostname | length > 0 }}"
-loki_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-loki_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-loki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /loki                                                                #
-#                                                                      #
-########################################################################
-# /role-specific:loki
-
-
-
 # role-specific:linkding
 ########################################################################
 #                                                                      #
@@ -4503,6 +4464,45 @@ linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:linkding
+
+
+
+# role-specific:loki
+########################################################################
+#                                                                      #
+# loki                                                                 #
+#                                                                      #
+########################################################################
+
+loki_enabled: false
+
+loki_identifier: "{{ mash_playbook_service_identifier_prefix }}loki"
+
+loki_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}loki"
+
+loki_uid: "{{ mash_playbook_uid }}"
+loki_gid: "{{ mash_playbook_gid }}"
+
+loki_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+loki_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and loki_hostname | length > 0 }}"
+loki_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+loki_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+loki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /loki                                                                #
+#                                                                      #
+########################################################################
+# /role-specific:loki
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4907,6 +4907,59 @@ neko_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary
 
 
 
+# role-specific:netbox
+########################################################################
+#                                                                      #
+# netbox                                                               #
+#                                                                      #
+########################################################################
+
+netbox_enabled: false
+
+netbox_identifier: "{{ mash_playbook_service_identifier_prefix }}netbox"
+
+netbox_uid: "{{ mash_playbook_uid }}"
+netbox_gid: "{{ mash_playbook_gid }}"
+
+netbox_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}netbox"
+
+netbox_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and netbox_database_hostname == postgres_identifier else [])
+  }}
+
+netbox_container_additional_networks_auto: |
+  {{
+    (
+      ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+      +
+      ([postgres_container_network] if postgres_enabled and netbox_database_hostname == postgres_identifier and netbox_container_network != postgres_container_network else [])
+    ) | unique
+  }}
+
+netbox_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+netbox_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+netbox_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+netbox_database_port: "{{ '5432' if postgres_enabled else '' }}"
+netbox_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.netbox', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /netbox                                                              #
+#                                                                      #
+########################################################################
+# /role-specific:netbox
+
+
+
 # role-specific:nextcloud
 ########################################################################
 #                                                                      #
@@ -4976,59 +5029,6 @@ nextcloud_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pr
 #                                                                      #
 ########################################################################
 # /role-specific:nextcloud
-
-
-
-# role-specific:netbox
-########################################################################
-#                                                                      #
-# netbox                                                               #
-#                                                                      #
-########################################################################
-
-netbox_enabled: false
-
-netbox_identifier: "{{ mash_playbook_service_identifier_prefix }}netbox"
-
-netbox_uid: "{{ mash_playbook_uid }}"
-netbox_gid: "{{ mash_playbook_gid }}"
-
-netbox_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}netbox"
-
-netbox_systemd_required_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled and netbox_database_hostname == postgres_identifier else [])
-  }}
-
-netbox_container_additional_networks_auto: |
-  {{
-    (
-      ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-      +
-      ([postgres_container_network] if postgres_enabled and netbox_database_hostname == postgres_identifier and netbox_container_network != postgres_container_network else [])
-    ) | unique
-  }}
-
-netbox_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-netbox_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:postgres
-netbox_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-netbox_database_port: "{{ '5432' if postgres_enabled else '' }}"
-netbox_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.netbox', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
-# role-specific:traefik
-netbox_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /netbox                                                              #
-#                                                                      #
-########################################################################
-# /role-specific:netbox
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1792,44 +1792,6 @@ changedetection_container_labels_traefik_tls_certResolver: "{{ traefik_certResol
 
 
 
-# role-specific:readeck
-########################################################################
-#                                                                      #
-# readeck                                                            #
-#                                                                      #
-########################################################################
-
-readeck_enabled: false
-
-readeck_identifier: "{{ mash_playbook_service_identifier_prefix }}readeck"
-
-readeck_uid: "{{ mash_playbook_uid }}"
-readeck_gid: "{{ mash_playbook_gid }}"
-
-readeck_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}readeck"
-
-readeck_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-readeck_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-readeck_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-readeck_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-readeck_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /readeck                                                           #
-#                                                                      #
-########################################################################
-# /role-specific:readeck
-
-
-
 # role-specific:clickhouse
 ########################################################################
 #                                                                      #
@@ -5932,6 +5894,44 @@ radicale_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:radicale
+
+
+
+# role-specific:readeck
+########################################################################
+#                                                                      #
+# readeck                                                              #
+#                                                                      #
+########################################################################
+
+readeck_enabled: false
+
+readeck_identifier: "{{ mash_playbook_service_identifier_prefix }}readeck"
+
+readeck_uid: "{{ mash_playbook_uid }}"
+readeck_gid: "{{ mash_playbook_gid }}"
+
+readeck_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}readeck"
+
+readeck_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+readeck_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+readeck_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+readeck_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+readeck_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /readeck                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:readeck
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5607,67 +5607,6 @@ postgis_managed_databases_auto: |
 
 
 
-
-# role-specific:prometheus_postgres_exporter
-########################################################################
-#                                                                      #
-# prometheus_postgres_exporter                                         #
-#                                                                      #
-########################################################################
-
-prometheus_postgres_exporter_enabled: false
-
-prometheus_postgres_exporter_identifier: "{{ mash_playbook_service_identifier_prefix }}prometheus-postgres-exporter"
-
-prometheus_postgres_exporter_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
-prometheus_postgres_exporter_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ prometheus_postgres_exporter_identifier }}"
-
-prometheus_postgres_exporter_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}prometheus-postgres-exporter"
-
-prometheus_postgres_exporter_uid: "{{ mash_playbook_uid }}"
-prometheus_postgres_exporter_gid: "{{ mash_playbook_gid }}"
-
-prometheus_postgres_exporter_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([postgres_container_network] if postgres_enabled and prometheus_postgres_exporter_database_hostname == postgres_identifier and prometheus_postgres_exporter_container_network != postgres_container_network else [])
-  }}
-
-prometheus_postgres_exporter_systemd_required_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled else [])
-  }}
-
-prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
-
-# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
-prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_postgres_exporter_hostname | length > 0 }}"
-prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:postgres
-prometheus_postgres_exporter_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-prometheus_postgres_exporter_database_username: prometheus_postgres_exporter
-prometheus_postgres_exporter_database_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
-prometheus_postgres_exporter_database_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
-prometheus_postgres_exporter_database_ssl: false
-# /role-specific:postgres
-
-# role-specific:traefik
-prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /prometheus_postgres_exporter                                        #
-#                                                                      #
-########################################################################
-# /role-specific:prometheus_postgres_exporter
-
-
-
 # role-specific:prometheus
 ########################################################################
 #                                                                      #
@@ -5751,52 +5690,6 @@ prometheus_blackbox_exporter_container_labels_traefik_tls_certResolver: "{{ trae
 # /role-specific:prometheus_blackbox_exporter
 
 
-
-# role-specific:prometheus_ssh_exporter
-########################################################################
-#                                                                      #
-# prometheus_ssh_exporter                                              #
-#                                                                      #
-########################################################################
-
-prometheus_ssh_exporter_enabled: false
-
-prometheus_ssh_exporter_identifier: "{{ mash_playbook_service_identifier_prefix }}prometheus-ssh-exporter"
-
-prometheus_ssh_exporter_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
-prometheus_ssh_exporter_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ prometheus_ssh_exporter_identifier }}"
-
-prometheus_ssh_exporter_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}prometheus-ssh-exporter"
-
-prometheus_ssh_exporter_uid: "{{ mash_playbook_uid }}"
-prometheus_ssh_exporter_gid: "{{ mash_playbook_gid }}"
-
-prometheus_ssh_exporter_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
-prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
-
-# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
-prometheus_ssh_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_ssh_exporter_hostname }}"
-prometheus_ssh_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-prometheus_ssh_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-prometheus_ssh_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /prometheus_ssh_exporter                                             #
-#                                                                      #
-########################################################################
-# /role-specific:prometheus_ssh_exporter
-
-
-
 # role-specific:prometheus_node_exporter
 ########################################################################
 #                                                                      #
@@ -5851,6 +5744,111 @@ prometheus_node_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_
 #                                                                      #
 ########################################################################
 # /role-specific:prometheus_node_exporter
+
+
+
+# role-specific:prometheus_postgres_exporter
+########################################################################
+#                                                                      #
+# prometheus_postgres_exporter                                         #
+#                                                                      #
+########################################################################
+
+prometheus_postgres_exporter_enabled: false
+
+prometheus_postgres_exporter_identifier: "{{ mash_playbook_service_identifier_prefix }}prometheus-postgres-exporter"
+
+prometheus_postgres_exporter_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
+prometheus_postgres_exporter_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ prometheus_postgres_exporter_identifier }}"
+
+prometheus_postgres_exporter_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}prometheus-postgres-exporter"
+
+prometheus_postgres_exporter_uid: "{{ mash_playbook_uid }}"
+prometheus_postgres_exporter_gid: "{{ mash_playbook_gid }}"
+
+prometheus_postgres_exporter_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and prometheus_postgres_exporter_database_hostname == postgres_identifier and prometheus_postgres_exporter_container_network != postgres_container_network else [])
+  }}
+
+prometheus_postgres_exporter_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled else [])
+  }}
+
+prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+prometheus_postgres_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_postgres_exporter_hostname | length > 0 }}"
+prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+prometheus_postgres_exporter_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+prometheus_postgres_exporter_database_username: prometheus_postgres_exporter
+prometheus_postgres_exporter_database_password: "{{ postgres_connection_password if postgres_enabled else '' }}"
+prometheus_postgres_exporter_database_port: "{{ postgres_connection_port if postgres_enabled else 5432 }}"
+prometheus_postgres_exporter_database_ssl: false
+# /role-specific:postgres
+
+# role-specific:traefik
+prometheus_postgres_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+prometheus_postgres_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /prometheus_postgres_exporter                                        #
+#                                                                      #
+########################################################################
+# /role-specific:prometheus_postgres_exporter
+
+
+
+# role-specific:prometheus_ssh_exporter
+########################################################################
+#                                                                      #
+# prometheus_ssh_exporter                                              #
+#                                                                      #
+########################################################################
+
+prometheus_ssh_exporter_enabled: false
+
+prometheus_ssh_exporter_identifier: "{{ mash_playbook_service_identifier_prefix }}prometheus-ssh-exporter"
+
+prometheus_ssh_exporter_hostname: "{{ mash_playbook_metrics_exposure_hostname }}"
+prometheus_ssh_exporter_path_prefix: "{{ mash_playbook_metrics_exposure_path_prefix }}/{{ prometheus_ssh_exporter_identifier }}"
+
+prometheus_ssh_exporter_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}prometheus-ssh-exporter"
+
+prometheus_ssh_exporter_uid: "{{ mash_playbook_uid }}"
+prometheus_ssh_exporter_gid: "{{ mash_playbook_gid }}"
+
+prometheus_ssh_exporter_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ mash_playbook_metrics_exposure_http_basic_auth_enabled }}"
+prometheus_ssh_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ mash_playbook_metrics_exposure_http_basic_auth_users }}"
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+prometheus_ssh_exporter_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and prometheus_ssh_exporter_hostname }}"
+prometheus_ssh_exporter_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+prometheus_ssh_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+prometheus_ssh_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /prometheus_ssh_exporter                                             #
+#                                                                      #
+########################################################################
+# /role-specific:prometheus_ssh_exporter
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2471,6 +2471,55 @@ forgejo_runner_systemd_required_systemd_services_list: |
 
 
 
+# role-specific:freescout
+########################################################################
+#                                                                      #
+# freescout                                                            #
+#                                                                      #
+########################################################################
+
+freescout_enabled: false
+
+freescout_identifier: "{{ mash_playbook_service_identifier_prefix }}freescout"
+
+freescout_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}freescout"
+
+freescout_systemd_required_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+    +
+    ([postgres_identifier ~ '.service'] if postgres_enabled and freescout_database_hostname == postgres_identifier else [])
+  }}
+
+freescout_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and freescout_database_hostname == postgres_identifier and freescout_container_network != postgres_container_network else [])
+  }}
+
+freescout_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+freescout_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+freescout_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+freescout_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'freescout.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /freescout                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:freescout
+
+
+
 # role-specific:freshrss
 ########################################################################
 #                                                                      #
@@ -4420,55 +4469,6 @@ linkding_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:linkding
-
-
-
-# role-specific:freescout
-########################################################################
-#                                                                      #
-# freescout                                                            #
-#                                                                      #
-########################################################################
-
-freescout_enabled: false
-
-freescout_identifier: "{{ mash_playbook_service_identifier_prefix }}freescout"
-
-freescout_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}freescout"
-
-freescout_systemd_required_services_list: |
-  {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
-    ([postgres_identifier ~ '.service'] if postgres_enabled and freescout_database_hostname == postgres_identifier else [])
-  }}
-
-freescout_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([postgres_container_network] if postgres_enabled and freescout_database_hostname == postgres_identifier and freescout_container_network != postgres_container_network else [])
-  }}
-
-freescout_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-freescout_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:postgres
-freescout_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
-freescout_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'freescout.db', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
-# role-specific:traefik
-freescout_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-freescout_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /freescout                                                           #
-#                                                                      #
-########################################################################
-# /role-specific:freescout
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -152,11 +152,6 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
   # Ensures there's at least one entry defined in the list.
   - "{{ omit }}"
 
-  # role-specific:backup_borg
-  - |-
-    {{ ({'name': (backup_borg_identifier + '.timer'), 'priority': 5000, 'groups': ['mash', 'backup', 'borg']} if backup_borg_enabled else omit) }}
-  # /role-specific:backup_borg
-
   # role-specific:adguard_home
   - |-
     {{ ({'name': (adguard_home_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'adguard-home']} if adguard_home_enabled else omit) }}
@@ -177,6 +172,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (appsmith_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'appsmith']} if appsmith_enabled else omit) }}
   # /role-specific:appsmith
 
+  # role-specific:authelia
+  - |-
+    {{ ({'name': (authelia_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authelia']} if authelia_enabled else omit) }}
+  # /role-specific:authelia
+
   # role-specific:authentik
   - |-
     {{ ({'name': (authentik_server_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authentik']} if authentik_enabled else omit) }}
@@ -184,20 +184,15 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (authentik_worker_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authentik']} if authentik_enabled else omit) }}
   # /role-specific:authentik
 
-  # role-specific:authelia
+  # role-specific:backup_borg
   - |-
-    {{ ({'name': (authelia_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authelia']} if authelia_enabled else omit) }}
-  # /role-specific:authelia
+    {{ ({'name': (backup_borg_identifier + '.timer'), 'priority': 5000, 'groups': ['mash', 'backup', 'borg']} if backup_borg_enabled else omit) }}
+  # /role-specific:backup_borg
 
   # role-specific:calibre-web
   - |-
     {{ ({'name': (calibre_web_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'calibre-web']} if calibre_web_enabled else omit) }}
   # /role-specific:calibre-web
-
-  # role-specific:readeck
-  - |-
-    {{ ({'name': (readeck_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'readeck']} if readeck_enabled else omit) }}
-  # /role-specific:readeck
 
   # role-specific:changedetection
   - |-
@@ -205,11 +200,6 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
   - |-
     {{ ({'name': (changedetection_playwright_driver_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'changedetection']} if changedetection_playwright_driver_enabled else omit) }}
   # /role-specific:changedetection
-
-  # role-specific:wetty
-  - |-
-    {{ ({'name': (wetty_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wetty']} if wetty_enabled else omit) }}
-  # /role-specific:wetty
 
   # role-specific:clickhouse
   - |-
@@ -226,35 +216,10 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (couchdb_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'couchdb']} if couchdb_enabled else omit) }}
   # /role-specific:couchdb
 
-  # role-specific:postgres
-  - |-
-    {{ ({'name': (postgres_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'postgres']} if postgres_enabled else omit) }}
-  # /role-specific:postgres
-
-  # role-specific:postgres_backup
-  - |-
-    {{ ({'name': (postgres_backup_identifier + '.service'), 'priority': 5000, 'groups': ['mash', 'backup', 'postgres-backup']} if postgres_backup_enabled else omit) }}
-  # /role-specific:postgres_backup
-
   # role-specific:container_socket_proxy
   - |-
     {{ ({'name': (container_socket_proxy_identifier + '.service'), 'priority': 200, 'groups': ['mash', 'reverse-proxies', 'container-socket-proxy']} if container_socket_proxy_enabled else omit) }}
   # /role-specific:container_socket_proxy
-
-  # role-specific:traefik
-  - |-
-    {{ ({'name': (traefik_identifier + '.service'), 'priority': 250, 'groups': ['mash', 'traefik', 'reverse-proxies']} if traefik_enabled else omit) }}
-  # /role-specific:traefik
-
-  # role-specific:woodpecker_ci_server
-  - |-
-    {{ ({'name': (woodpecker_ci_server_identifier + '.service'), 'priority': 4000, 'groups': ['mash', 'woodpecker', 'ci', 'woodpecker-ci-server']} if woodpecker_ci_server_enabled else omit) }}
-  # /role-specific:woodpecker_ci_server
-
-  # role-specific:woodpecker_ci_agent
-  - |-
-    {{ ({'name': (woodpecker_ci_agent_identifier + '.service'), 'priority': 4100, 'groups': ['mash', 'woodpecker', 'ci', 'woodpecker-ci-agent']} if woodpecker_ci_agent_enabled else omit) }}
-  # /role-specific:woodpecker_ci_agent
 
   # role-specific:docker_registry
   - |-
@@ -263,15 +228,15 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (docker_registry_identifier + '-garbage-collect.timer'), 'priority': 2500, 'groups': ['mash', 'docker-registry', 'docker-registry-gc']} if docker_registry_enabled else omit) }}
   # /role-specific:docker_registry
 
-  # role-specific:docker_registry_proxy
-  - |-
-    {{ ({'name': (docker_registry_proxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'docker-registry-proxy']} if docker_registry_proxy_enabled else omit) }}
-  # /role-specific:docker_registry_proxy
-
   # role-specific:docker_registry_browser
   - |-
     {{ ({'name': (docker_registry_browser_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'docker-registry-browser']} if docker_registry_browser_enabled else omit) }}
   # /role-specific:docker_registry_browser
+
+  # role-specific:docker_registry_proxy
+  - |-
+    {{ ({'name': (docker_registry_proxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'docker-registry-proxy']} if docker_registry_proxy_enabled else omit) }}
+  # /role-specific:docker_registry_proxy
 
   # role-specific:docker_registry_purger
   - |-
@@ -318,6 +283,21 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (focalboard_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'focalboard']} if focalboard_enabled else omit) }}
   # /role-specific:focalboard
 
+  # role-specific:forgejo
+  - |-
+    {{ ({'name': (forgejo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo', 'forgejo-server']} if forgejo_enabled else omit) }}
+  # /role-specific:forgejo
+
+  # role-specific:forgejo_runner
+  - |-
+    {{ ({'name': (forgejo_runner_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo-runner']} if forgejo_runner_enabled else omit) }}
+  # /role-specific:forgejo_runner
+
+  # role-specific:freescout
+  - |-
+    {{ ({'name': (freescout_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'freescout']} if freescout_enabled else omit) }}
+  # /role-specific:freescout
+
   # role-specific:freshrss
   - |-
     {{ ({'name': (freshrss_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'freshrss']} if freshrss_enabled else omit) }}
@@ -351,11 +331,6 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (grafana_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'grafana']} if grafana_enabled else omit) }}
   # /role-specific:grafana
 
-  # role-specific:hubsite
-  - |-
-    {{ ({'name': (hubsite_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'hubsite']} if hubsite_enabled else omit) }}
-  # /role-specific:hubsite
-
   # role-specific:headscale
   - |-
     {{ ({'name': (headscale_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'headscale']} if headscale_enabled else omit) }}
@@ -365,6 +340,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
   - |-
     {{ ({'name': (healthchecks_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'healthchecks']} if healthchecks_enabled else omit) }}
   # /role-specific:healthchecks
+
+  # role-specific:hubsite
+  - |-
+    {{ ({'name': (hubsite_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'hubsite']} if hubsite_enabled else omit) }}
+  # /role-specific:hubsite
 
   # role-specific:ihatemoney
   - |-
@@ -409,15 +389,20 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (joplin_server_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'joplin-server']} if joplin_server_enabled else omit) }}
   # /role-specific:joplin_server
 
-  # role-specific:labelstudio
-  - |-
-    {{ ({'name': (labelstudio_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'labelstudio']} if labelstudio_enabled else omit) }}
-  # /role-specific:labelstudio
-
   # role-specific:keycloak
   - |-
     {{ ({'name': (keycloak_identifier + '.service'), 'priority': 1000, 'groups': ['mash', 'keycloak']} if keycloak_enabled else omit) }}
   # /role-specific:keycloak
+
+  # role-specific:keydb
+  - |-
+    {{ ({'name': (keydb_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'keydb']} if keydb_enabled else omit) }}
+  # /role-specific:keydb
+
+  # role-specific:labelstudio
+  - |-
+    {{ ({'name': (labelstudio_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'labelstudio']} if labelstudio_enabled else omit) }}
+  # /role-specific:labelstudio
 
   # role-specific:lago
   - |-
@@ -437,20 +422,20 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (languagetool_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'languagetool']} if languagetool_enabled else omit) }}
   # /role-specific:languagetool
 
-  # role-specific:loki
-  - |-
-    {{ ({'name': (loki_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'loki']} if loki_enabled else omit) }}
-  # /role-specific:loki
-
   # role-specific:linkding
   - |-
     {{ ({'name': (linkding_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'linkding']} if linkding_enabled else omit) }}
   # /role-specific:linkding
 
-  # role-specific:freescout
+  # role-specific:loki
   - |-
-    {{ ({'name': (freescout_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'freescout']} if freescout_enabled else omit) }}
-  # /role-specific:freescout
+    {{ ({'name': (loki_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'loki']} if loki_enabled else omit) }}
+  # /role-specific:loki
+
+  # role-specific:mariadb
+  - |-
+    {{ ({'name': (mariadb_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'mariadb']} if mariadb_enabled else omit) }}
+  # /role-specific:mariadb
 
   # role-specific:miniflux
   - |-
@@ -526,25 +511,20 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (ntfy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'ntfy']} if ntfy_enabled else omit) }}
   # /role-specific:ntfy
 
-  # role-specific:mariadb
-  - |-
-    {{ ({'name': (mariadb_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'mariadb']} if mariadb_enabled else omit) }}
-  # /role-specific:mariadb
-
   # role-specific:oauth2_proxy
   - |-
     {{ ({'name': (oauth2_proxy_identifier + '.service'), 'priority': 1900, 'groups': ['mash', 'oauth2-proxy']} if oauth2_proxy_enabled else omit) }}
   # /role-specific:oauth2_proxy
 
-  # role-specific:overseerr
-  - |-
-    {{ ({'name': (overseerr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'overseerr']} if overseerr_enabled else omit) }}
-  # /role-specific:overseerr
-
   # role-specific:outline
   - |-
     {{ ({'name': (outline_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'outline']} if outline_enabled else omit) }}
   # /role-specific:outline
+
+  # role-specific:overseerr
+  - |-
+    {{ ({'name': (overseerr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'overseerr']} if overseerr_enabled else omit) }}
+  # /role-specific:overseerr
 
   # role-specific:owncast
   - |-
@@ -570,15 +550,25 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (peertube_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'peertube']} if peertube_enabled else omit) }}
   # /role-specific:peertube
 
+  # role-specific:plausible
+  - |-
+    {{ ({'name': (plausible_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'plausible']} if plausible_enabled else omit) }}
+  # /role-specific:plausible
+
   # role-specific:postgis
   - |-
     {{ ({'name': (postgis_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'metrics', 'postgis']} if postgis_enabled else omit) }}
   # /role-specific:postgis
 
-  # role-specific:plausible
+  # role-specific:postgres
   - |-
-    {{ ({'name': (plausible_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'plausible']} if plausible_enabled else omit) }}
-  # /role-specific:plausible
+    {{ ({'name': (postgres_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'postgres']} if postgres_enabled else omit) }}
+  # /role-specific:postgres
+
+  # role-specific:postgres_backup
+  - |-
+    {{ ({'name': (postgres_backup_identifier + '.service'), 'priority': 5000, 'groups': ['mash', 'backup', 'postgres-backup']} if postgres_backup_enabled else omit) }}
+  # /role-specific:postgres_backup
 
   # role-specific:prometheus
   - |-
@@ -590,11 +580,6 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (prometheus_blackbox_exporter_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'metrics', 'prometheus-blackbox-exporter']} if prometheus_blackbox_exporter_enabled else omit) }}
   # /role-specific:prometheus_blackbox_exporter
 
-  # role-specific:prometheus_ssh_exporter
-  - |-
-    {{ ({'name': (prometheus_ssh_exporter_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'metrics', 'prometheus-ssh-exporter']} if prometheus_ssh_exporter_enabled else omit) }}
-  # /role-specific:prometheus_ssh_exporter
-
   # role-specific:prometheus_node_exporter
   - |-
     {{ ({'name': (prometheus_node_exporter_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'metrics', 'prometheus-node-exporter']} if prometheus_node_exporter_enabled else omit) }}
@@ -604,6 +589,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
   - |-
     {{ ({'name': (prometheus_postgres_exporter_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'metrics', 'prometheus-postgres-exporter']} if prometheus_postgres_exporter_enabled else omit) }}
   # /role-specific:prometheus_postgres_exporter
+
+  # role-specific:prometheus_ssh_exporter
+  - |-
+    {{ ({'name': (prometheus_ssh_exporter_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'metrics', 'prometheus-ssh-exporter']} if prometheus_ssh_exporter_enabled else omit) }}
+  # /role-specific:prometheus_ssh_exporter
 
   # role-specific:promtail
   - |-
@@ -625,6 +615,16 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (radicale_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'radicale']} if radicale_enabled else omit) }}
   # /role-specific:radicale
 
+  # role-specific:readeck
+  - |-
+    {{ ({'name': (readeck_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'readeck']} if readeck_enabled else omit) }}
+  # /role-specific:readeck
+
+  # role-specific:redis
+  - |-
+    {{ ({'name': (redis_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'redis']} if redis_enabled else omit) }}
+  # /role-specific:redis
+
   # role-specific:redmine
   - |-
     {{ ({'name': (redmine_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'redmine']} if redmine_enabled else omit) }}
@@ -633,16 +633,6 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
   - |-
     {{ ({'name': (redmine_identifier + '-recurring-tasks.timer'), 'priority': 2000, 'groups': ['mash', 'redmine']} if redmine_enabled and redmine_recurring_tasks_enabled else omit) }}
   # /role-specific:redmine
-
-  # role-specific:redis
-  - |-
-    {{ ({'name': (redis_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'redis']} if redis_enabled else omit) }}
-  # /role-specific:redis
-
-  # role-specific:keydb
-  - |-
-    {{ ({'name': (keydb_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'keydb']} if keydb_enabled else omit) }}
-  # /role-specific:keydb
 
   # role-specific:roundcube
   - |-
@@ -701,6 +691,21 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (telegraf_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'telegraf']} if telegraf_enabled else omit) }}
   # /role-specific:telegraf
 
+  # role-specific:traefik
+  - |-
+    {{ ({'name': (traefik_identifier + '.service'), 'priority': 250, 'groups': ['mash', 'traefik', 'reverse-proxies']} if traefik_enabled else omit) }}
+  # /role-specific:traefik
+
+  # role-specific:tsdproxy
+  - |-
+    {{ ({'name': (tsdproxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'tsdproxy']} if tsdproxy_enabled else omit) }}
+  # /role-specific:tsdproxy
+
+  # role-specific:uptime_kuma
+  - |-
+    {{ ({'name': (uptime_kuma_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'uptime-kuma']} if uptime_kuma_enabled else omit) }}
+  # /role-specific:uptime_kuma
+
   # role-specific:valkey
   - |-
     {{ ({'name': (valkey_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'valkey']} if valkey_enabled else omit) }}
@@ -711,35 +716,30 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (vaultwarden_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'vaultwarden', 'vaultwarden-server']} if vaultwarden_enabled else omit) }}
   # /role-specific:vaultwarden
 
-  # role-specific:uptime_kuma
+  # role-specific:wetty
   - |-
-    {{ ({'name': (uptime_kuma_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'uptime-kuma']} if uptime_kuma_enabled else omit) }}
-  # /role-specific:uptime_kuma
+    {{ ({'name': (wetty_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wetty']} if wetty_enabled else omit) }}
+  # /role-specific:wetty
 
   # role-specific:wg_easy
   - |-
     {{ ({'name': (wg_easy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wg-easy']} if wg_easy_enabled else omit) }}
   # /role-specific:wg_easy
 
+  # role-specific:woodpecker_ci_agent
+  - |-
+    {{ ({'name': (woodpecker_ci_agent_identifier + '.service'), 'priority': 4100, 'groups': ['mash', 'woodpecker', 'ci', 'woodpecker-ci-agent']} if woodpecker_ci_agent_enabled else omit) }}
+  # /role-specific:woodpecker_ci_agent
+
+  # role-specific:woodpecker_ci_server
+  - |-
+    {{ ({'name': (woodpecker_ci_server_identifier + '.service'), 'priority': 4000, 'groups': ['mash', 'woodpecker', 'ci', 'woodpecker-ci-server']} if woodpecker_ci_server_enabled else omit) }}
+  # /role-specific:woodpecker_ci_server
+
   # role-specific:wordpress
   - |-
     {{ ({'name': (wordpress_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'wordpress']} if wordpress_enabled else omit) }}
   # /role-specific:wordpress
-
-  # role-specific:forgejo
-  - |-
-    {{ ({'name': (forgejo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo', 'forgejo-server']} if forgejo_enabled else omit) }}
-  # /role-specific:forgejo
-
-  # role-specific:forgejo_runner
-  - |-
-    {{ ({'name': (forgejo_runner_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'forgejo-runner']} if forgejo_runner_enabled else omit) }}
-  # /role-specific:forgejo_runner
-
-  # role-specific:tsdproxy
-  - |-
-    {{ ({'name': (tsdproxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'tsdproxy']} if tsdproxy_enabled else omit) }}
-  # /role-specific:tsdproxy
 
   # role-specific:writefreely
   - |-

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4234,6 +4234,40 @@ keycloak_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 
 
 
+# role-specific:keydb
+########################################################################
+#                                                                      #
+# keydb                                                                #
+#                                                                      #
+########################################################################
+
+keydb_enabled: false
+
+keydb_identifier: "{{ mash_playbook_service_identifier_prefix }}keydb"
+
+keydb_uid: "{{ mash_playbook_uid }}"
+keydb_gid: "{{ mash_playbook_gid }}"
+
+keydb_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}keydb"
+
+keydb_arch: |-
+  {{
+    ({
+      'amd64': 'x86_64',
+      'arm32': 'arm32',
+      'arm64': 'arm64',
+    })[mash_playbook_architecture]
+  }}
+
+########################################################################
+#                                                                      #
+# /keydb                                                               #
+#                                                                      #
+########################################################################
+# /role-specific:keydb
+
+
+
 # role-specific:labelstudio
 ########################################################################
 #                                                                      #
@@ -6112,38 +6146,6 @@ redis_gid: "{{ mash_playbook_gid }}"
 ########################################################################
 # /role-specific:redis
 
-
-# role-specific:keydb
-########################################################################
-#                                                                      #
-# keydb                                                                #
-#                                                                      #
-########################################################################
-
-keydb_enabled: false
-
-keydb_identifier: "{{ mash_playbook_service_identifier_prefix }}keydb"
-
-keydb_uid: "{{ mash_playbook_uid }}"
-keydb_gid: "{{ mash_playbook_gid }}"
-
-keydb_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}keydb"
-
-keydb_arch: |-
-  {{
-    ({
-      'amd64': 'x86_64',
-      'arm32': 'arm32',
-      'arm64': 'arm64',
-    })[mash_playbook_architecture]
-  }}
-
-########################################################################
-#                                                                      #
-# /keydb                                                               #
-#                                                                      #
-########################################################################
-# /role-specific:keydb
 
 
 # role-specific:roundcube

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -21,70 +21,6 @@ aux_file_default_group: "{{ mash_playbook_user_groupname }}"
 # /role-specific:auxiliary
 
 
-# role-specific:authelia
-########################################################################
-#                                                                      #
-# authelia                                                             #
-#                                                                      #
-########################################################################
-
-authelia_enabled: false
-
-authelia_identifier: "{{ mash_playbook_service_identifier_prefix }}authelia"
-
-authelia_uid: "{{ mash_playbook_uid }}"
-authelia_gid: "{{ mash_playbook_gid }}"
-
-authelia_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}authelia"
-
-authelia_systemd_required_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled and authelia_config_storage_postgres_host == postgres_identifier else [])
-  }}
-
-authelia_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([postgres_container_network] if postgres_enabled and authelia_config_storage_postgres_host == postgres_identifier and authelia_container_network != postgres_container_network else [])
-  }}
-
-authelia_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-authelia_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-authelia_config_jwt_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jwt.authelia', rounds=655555) | to_uuid }}"
-
-authelia_config_session_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'ses.authelia', rounds=655555) | to_uuid }}"
-
-authelia_config_identity_providers_oidc_hmac_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'hm.authelia', rounds=655555) | to_uuid }}"
-
-# role-specific:mariadb
-# If Postgres and MariaDB are not enabled, we favor Postgres.
-# We only enable MySQL if it's the only enabled component (that is, if Postgres is not enabled at the same time).
-authelia_config_storage_mysql_host: "{{ mariadb_identifier if mariadb_enabled and not postgres_enabled | default(false) else '' }}"
-authelia_config_storage_mysql_port: "{{ '3306' if mariadb_enabled else '' }}"
-authelia_config_storage_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
-# /role-specific:mariadb
-
-# role-specific:postgres
-authelia_config_storage_postgres_host: "{{ postgres_identifier if postgres_enabled else '' }}"
-authelia_config_storage_postgres_port: "{{ '5432' if postgres_enabled else '' }}"
-authelia_config_storage_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
-# role-specific:traefik
-authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /authelia                                                            #
-#                                                                      #
-########################################################################
-# /role-specific:authelia
-
-
 
 # role-specific:ssh
 ########################################################################
@@ -1590,6 +1526,71 @@ appsmith_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:appsmith
+
+
+
+# role-specific:authelia
+########################################################################
+#                                                                      #
+# authelia                                                             #
+#                                                                      #
+########################################################################
+
+authelia_enabled: false
+
+authelia_identifier: "{{ mash_playbook_service_identifier_prefix }}authelia"
+
+authelia_uid: "{{ mash_playbook_uid }}"
+authelia_gid: "{{ mash_playbook_gid }}"
+
+authelia_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}authelia"
+
+authelia_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and authelia_config_storage_postgres_host == postgres_identifier else [])
+  }}
+
+authelia_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and authelia_config_storage_postgres_host == postgres_identifier and authelia_container_network != postgres_container_network else [])
+  }}
+
+authelia_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+authelia_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+authelia_config_jwt_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'jwt.authelia', rounds=655555) | to_uuid }}"
+
+authelia_config_session_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'ses.authelia', rounds=655555) | to_uuid }}"
+
+authelia_config_identity_providers_oidc_hmac_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'hm.authelia', rounds=655555) | to_uuid }}"
+
+# role-specific:mariadb
+# If Postgres and MariaDB are not enabled, we favor Postgres.
+# We only enable MySQL if it's the only enabled component (that is, if Postgres is not enabled at the same time).
+authelia_config_storage_mysql_host: "{{ mariadb_identifier if mariadb_enabled and not postgres_enabled | default(false) else '' }}"
+authelia_config_storage_mysql_port: "{{ '3306' if mariadb_enabled else '' }}"
+authelia_config_storage_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
+# /role-specific:mariadb
+
+# role-specific:postgres
+authelia_config_storage_postgres_host: "{{ postgres_identifier if postgres_enabled else '' }}"
+authelia_config_storage_postgres_port: "{{ '5432' if postgres_enabled else '' }}"
+authelia_config_storage_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authelia', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+authelia_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+authelia_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /authelia                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:authelia
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -4506,6 +4506,71 @@ loki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary
 
 
 
+# role-specific:mariadb
+########################################################################
+#                                                                      #
+# mariadb                                                              #
+#                                                                      #
+########################################################################
+
+mariadb_enabled: false
+
+mariadb_identifier: "{{ mash_playbook_service_identifier_prefix }}mariadb"
+
+mariadb_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}mariadb"
+
+mariadb_uid: "{{ mash_playbook_uid }}"
+mariadb_gid: "{{ mash_playbook_gid }}"
+
+mash_playbook_mariadb_managed_databases_auto_itemized:
+  # Dummy entry, which is not role-specific.
+  # Ensures there's at least one entry defined in the list.
+  - "{{ omit }}"
+
+  # role-specific:authelia
+  - |-
+    {{
+      ({
+        'name': authelia_config_storage_mysql_database,
+        'username': authelia_config_storage_mysql_username,
+        'password': authelia_config_storage_mysql_password,
+      } if authelia_enabled and authelia_config_storage_mysql_host == mariadb_identifier else omit)
+    }}
+  # /role-specific:authelia
+
+  # role-specific:wordpress
+  - |-
+    {{
+      ({
+        'name': wordpress_database_name,
+        'username': wordpress_database_username,
+        'password': wordpress_database_password,
+      } if wordpress_enabled and wordpress_database_hostname == mariadb_identifier | default('mash-mariadb') else omit)
+    }}
+  # /role-specific:wordpress
+
+  # role-specific:yourls
+  - |-
+    {{
+      ({
+        'name': yourls_environment_variable_db_name,
+        'username': yourls_environment_variable_db_user,
+        'password': yourls_environment_variable_db_pass,
+      } if yourls_enabled and yourls_environment_variable_db_host_name == mariadb_identifier | default('mash-mariadb') else omit)
+    }}
+  # /role-specific:yourls
+
+mariadb_managed_databases_auto: "{{ mash_playbook_mariadb_managed_databases_auto_itemized | reject('equalto', omit) }}"
+
+########################################################################
+#                                                                      #
+# /mariadb                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:mariadb
+
+
+
 # role-specific:miniflux
 ########################################################################
 #                                                                      #
@@ -4964,71 +5029,6 @@ netbox_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prima
 #                                                                      #
 ########################################################################
 # /role-specific:netbox
-
-
-
-# role-specific:mariadb
-########################################################################
-#                                                                      #
-# mariadb                                                              #
-#                                                                      #
-########################################################################
-
-mariadb_enabled: false
-
-mariadb_identifier: "{{ mash_playbook_service_identifier_prefix }}mariadb"
-
-mariadb_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}mariadb"
-
-mariadb_uid: "{{ mash_playbook_uid }}"
-mariadb_gid: "{{ mash_playbook_gid }}"
-
-mash_playbook_mariadb_managed_databases_auto_itemized:
-  # Dummy entry, which is not role-specific.
-  # Ensures there's at least one entry defined in the list.
-  - "{{ omit }}"
-
-  # role-specific:authelia
-  - |-
-    {{
-      ({
-        'name': authelia_config_storage_mysql_database,
-        'username': authelia_config_storage_mysql_username,
-        'password': authelia_config_storage_mysql_password,
-      } if authelia_enabled and authelia_config_storage_mysql_host == mariadb_identifier else omit)
-    }}
-  # /role-specific:authelia
-
-  # role-specific:wordpress
-  - |-
-    {{
-      ({
-        'name': wordpress_database_name,
-        'username': wordpress_database_username,
-        'password': wordpress_database_password,
-      } if wordpress_enabled and wordpress_database_hostname == mariadb_identifier | default('mash-mariadb') else omit)
-    }}
-  # /role-specific:wordpress
-
-  # role-specific:yourls
-  - |-
-    {{
-      ({
-        'name': yourls_environment_variable_db_name,
-        'username': yourls_environment_variable_db_user,
-        'password': yourls_environment_variable_db_pass,
-      } if yourls_enabled and yourls_environment_variable_db_host_name == mariadb_identifier | default('mash-mariadb') else omit)
-    }}
-  # /role-specific:yourls
-
-mariadb_managed_databases_auto: "{{ mash_playbook_mariadb_managed_databases_auto_itemized | reject('equalto', omit) }}"
-
-########################################################################
-#                                                                      #
-# /mariadb                                                             #
-#                                                                      #
-########################################################################
-# /role-specific:mariadb
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1716,6 +1716,44 @@ backup_borg_postgresql_databases_auto: "{{ postgres_managed_databases | map(attr
 
 
 
+# role-specific:calibre-web
+########################################################################
+#                                                                      #
+# calibre-web                                                          #
+#                                                                      #
+########################################################################
+
+calibre_web_enabled: false
+
+calibre_web_identifier: "{{ mash_playbook_service_identifier_prefix }}calibre-web"
+
+calibre_web_uid: "{{ mash_playbook_uid }}"
+calibre_web_gid: "{{ mash_playbook_gid }}"
+
+calibre_web_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}calibre-web"
+
+calibre_web_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+calibre_web_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+calibre_web_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+calibre_web_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+calibre_web_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /calibre-web                                                         #
+#                                                                      #
+########################################################################
+# /role-specific:calibre-web
+
+
+
 # role-specific:changedetection
 ########################################################################
 #                                                                      #
@@ -1789,44 +1827,6 @@ wetty_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primar
 #                                                                      #
 ########################################################################
 # /role-specific:wetty
-
-
-
-# role-specific:calibre-web
-########################################################################
-#                                                                      #
-# calibre-web                                                            #
-#                                                                      #
-########################################################################
-
-calibre_web_enabled: false
-
-calibre_web_identifier: "{{ mash_playbook_service_identifier_prefix }}calibre-web"
-
-calibre_web_uid: "{{ mash_playbook_uid }}"
-calibre_web_gid: "{{ mash_playbook_gid }}"
-
-calibre_web_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}calibre-web"
-
-calibre_web_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-calibre_web_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-calibre_web_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-calibre_web_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-calibre_web_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /calibre-web                                                           #
-#                                                                      #
-########################################################################
-# /role-specific:calibre-web
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -6903,6 +6903,49 @@ wg_easy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 
 
 
+# role-specific:woodpecker_ci_agent
+########################################################################
+#                                                                      #
+# woodpecker-ci-agent                                                  #
+#                                                                      #
+########################################################################
+
+woodpecker_ci_agent_enabled: false
+
+woodpecker_ci_agent_identifier: "{{ mash_playbook_service_identifier_prefix }}woodpecker-ci-agent"
+
+woodpecker_ci_agent_uid: "{{ mash_playbook_uid }}"
+woodpecker_ci_agent_gid: "{{ mash_playbook_gid }}"
+
+woodpecker_ci_agent_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}woodpecker-ci/agent"
+
+woodpecker_ci_agent_systemd_required_systemd_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+    +
+    ([woodpecker_ci_server_identifier ~ '.service'] if woodpecker_ci_server_enabled else [])
+  }}
+
+woodpecker_ci_agent_container_additional_networks: |
+  {{
+    (
+      ([woodpecker_ci_server_container_network] if woodpecker_ci_server_enabled and woodpecker_ci_server_container_network != woodpecker_ci_agent_container_network else [])
+    ) | unique
+  }}
+
+woodpecker_ci_agent_config_server: "{{ (woodpecker_ci_server_identifier + ':' + woodpecker_ci_server_config_grpc_addr_port | string) if woodpecker_ci_agent_enabled else '' }}"
+
+woodpecker_ci_agent_config_agent_secret: "{{ woodpecker_ci_server_config_agent_secret if woodpecker_ci_agent_enabled else '' }}"
+
+########################################################################
+#                                                                      #
+# /woodpecker-ci-agent                                                 #
+#                                                                      #
+########################################################################
+# /role-specific:woodpecker_ci_agent
+
+
+
 # role-specific:woodpecker_ci_server
 ########################################################################
 #                                                                      #
@@ -6958,49 +7001,6 @@ woodpecker_ci_server_database_datasource_db_name: woodpecker_ci_server
 #                                                                      #
 ########################################################################
 # /role-specific:woodpecker_ci_server
-
-
-
-# role-specific:woodpecker_ci_agent
-########################################################################
-#                                                                      #
-# woodpecker-ci-agent                                                  #
-#                                                                      #
-########################################################################
-
-woodpecker_ci_agent_enabled: false
-
-woodpecker_ci_agent_identifier: "{{ mash_playbook_service_identifier_prefix }}woodpecker-ci-agent"
-
-woodpecker_ci_agent_uid: "{{ mash_playbook_uid }}"
-woodpecker_ci_agent_gid: "{{ mash_playbook_gid }}"
-
-woodpecker_ci_agent_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}woodpecker-ci/agent"
-
-woodpecker_ci_agent_systemd_required_systemd_services_list: |
-  {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
-    ([woodpecker_ci_server_identifier ~ '.service'] if woodpecker_ci_server_enabled else [])
-  }}
-
-woodpecker_ci_agent_container_additional_networks: |
-  {{
-    (
-      ([woodpecker_ci_server_container_network] if woodpecker_ci_server_enabled and woodpecker_ci_server_container_network != woodpecker_ci_agent_container_network else [])
-    ) | unique
-  }}
-
-woodpecker_ci_agent_config_server: "{{ (woodpecker_ci_server_identifier + ':' + woodpecker_ci_server_config_grpc_addr_port | string) if woodpecker_ci_agent_enabled else '' }}"
-
-woodpecker_ci_agent_config_agent_secret: "{{ woodpecker_ci_server_config_agent_secret if woodpecker_ci_agent_enabled else '' }}"
-
-########################################################################
-#                                                                      #
-# /woodpecker-ci-agent                                                 #
-#                                                                      #
-########################################################################
-# /role-specific:woodpecker_ci_agent
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5142,6 +5142,42 @@ ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary
 # /role-specific:ntfy
 
 
+
+# role-specific:oauth2_proxy
+########################################################################
+#                                                                      #
+# oauth2_proxy                                                         #
+#                                                                      #
+########################################################################
+
+oauth2_proxy_enabled: false
+
+oauth2_proxy_identifier: "{{ mash_playbook_service_identifier_prefix }}oauth2-proxy"
+
+oauth2_proxy_uid: "{{ mash_playbook_uid }}"
+oauth2_proxy_gid: "{{ mash_playbook_gid }}"
+
+oauth2_proxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}oauth2-proxy"
+
+oauth2_proxy_container_network: "{{ (mash_playbook_reverse_proxyable_services_additional_network if mash_playbook_traefik_labels_enabled else '') | default(oauth2_proxy_identifier) }}"
+
+oauth2_proxy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+oauth2_proxy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+oauth2_proxy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+oauth2_proxy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /oauth2_proxy                                                        #
+#                                                                      #
+########################################################################
+# /role-specific:oauth2_proxy
+
+
+
 # role-specific:outline
 ########################################################################
 #                                                                      #
@@ -5193,41 +5229,6 @@ outline_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 #                                                                      #
 ########################################################################
 # /role-specific:outline
-
-
-
-# role-specific:oauth2_proxy
-########################################################################
-#                                                                      #
-# oauth2_proxy                                                         #
-#                                                                      #
-########################################################################
-
-oauth2_proxy_enabled: false
-
-oauth2_proxy_identifier: "{{ mash_playbook_service_identifier_prefix }}oauth2-proxy"
-
-oauth2_proxy_uid: "{{ mash_playbook_uid }}"
-oauth2_proxy_gid: "{{ mash_playbook_gid }}"
-
-oauth2_proxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}oauth2-proxy"
-
-oauth2_proxy_container_network: "{{ (mash_playbook_reverse_proxyable_services_additional_network if mash_playbook_traefik_labels_enabled else '') | default(oauth2_proxy_identifier) }}"
-
-oauth2_proxy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-oauth2_proxy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-oauth2_proxy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-oauth2_proxy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /oauth2_proxy                                                        #
-#                                                                      #
-########################################################################
-# /role-specific:oauth2_proxy
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2377,6 +2377,100 @@ focalboard_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_p
 
 
 
+# role-specific:forgejo
+########################################################################
+#                                                                      #
+# forgejo                                                              #
+#                                                                      #
+########################################################################
+
+forgejo_enabled: false
+
+forgejo_identifier: "{{ mash_playbook_service_identifier_prefix }}forgejo"
+
+forgejo_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}forgejo"
+
+forgejo_uid: "{{ mash_playbook_uid }}"
+forgejo_gid: "{{ mash_playbook_gid }}"
+
+forgejo_systemd_required_systemd_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and forgejo_config_database_hostname == postgres_identifier else [])
+  }}
+
+forgejo_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and forgejo_config_database_hostname == postgres_identifier and forgejo_container_network != postgres_container_network else [])
+    +
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and forgejo_config_mailer_smtp_addr == exim_relay_identifier | default('mash-exim-relay') and forgejo_container_network != exim_relay_container_network) else [])
+  }}
+
+forgejo_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+forgejo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+forgejo_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
+forgejo_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
+
+# role-specific:exim_relay
+forgejo_config_mailer_enabled: "{{ exim_relay_enabled }}"
+forgejo_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+forgejo_config_mailer_smtp_port: 8025
+forgejo_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+forgejo_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
+# role-specific:postgres
+forgejo_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+forgejo_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
+forgejo_config_database_username: "forgejo"
+forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.forgejo', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /forgejo                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:forgejo
+
+
+
+# role-specific:forgejo_runner
+########################################################################
+#                                                                      #
+# forgejo_runner                                                       #
+#                                                                      #
+########################################################################
+
+forgejo_runner_enabled: false
+
+forgejo_runner_uid: "0"
+forgejo_runner_gid: "0"
+
+forgejo_runner_identifier: "{{ mash_playbook_service_identifier_prefix }}forgejo-runner"
+
+forgejo_runner_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}forgejo-runner"
+
+forgejo_runner_systemd_required_systemd_services_list: |
+  {{
+    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
+  }}
+
+########################################################################
+#                                                                      #
+# /forgejo_runner                                                      #
+#                                                                      #
+########################################################################
+# /role-specific:forgejo_runner
+
+
+
 # role-specific:freshrss
 ########################################################################
 #                                                                      #
@@ -6805,100 +6899,6 @@ wg_easy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prim
 #                                                                      #
 ########################################################################
 # /role-specific:wg_easy
-
-
-
-# role-specific:forgejo
-########################################################################
-#                                                                      #
-# forgejo                                                              #
-#                                                                      #
-########################################################################
-
-forgejo_enabled: false
-
-forgejo_identifier: "{{ mash_playbook_service_identifier_prefix }}forgejo"
-
-forgejo_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}forgejo"
-
-forgejo_uid: "{{ mash_playbook_uid }}"
-forgejo_gid: "{{ mash_playbook_gid }}"
-
-forgejo_systemd_required_systemd_services_list_auto: |
-  {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled and forgejo_config_database_hostname == postgres_identifier else [])
-  }}
-
-forgejo_container_additional_networks_auto: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-    +
-    ([postgres_container_network] if postgres_enabled and forgejo_config_database_hostname == postgres_identifier and forgejo_container_network != postgres_container_network else [])
-    +
-    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and forgejo_config_mailer_smtp_addr == exim_relay_identifier | default('mash-exim-relay') and forgejo_container_network != exim_relay_container_network) else [])
-  }}
-
-forgejo_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-forgejo_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-forgejo_container_labels_traefik_compression_middleware_enabled: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_enabled }}"
-forgejo_container_labels_traefik_compression_middleware_name: "{{ mash_playbook_reverse_proxy_traefik_middleware_compession_name if mash_playbook_reverse_proxy_traefik_middleware_compession_enabled else '' }}"
-
-# role-specific:exim_relay
-forgejo_config_mailer_enabled: "{{ exim_relay_enabled }}"
-forgejo_config_mailer_smtp_addr: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
-forgejo_config_mailer_smtp_port: 8025
-forgejo_config_mailer_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
-forgejo_config_mailer_protocol: "{{ 'smtp' if exim_relay_enabled else '' }}"
-# /role-specific:exim_relay
-
-# role-specific:postgres
-forgejo_config_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-forgejo_config_database_port: "{{ '5432' if postgres_enabled else '' }}"
-forgejo_config_database_username: "forgejo"
-forgejo_config_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.forgejo', rounds=655555) | to_uuid }}"
-# /role-specific:postgres
-
-# role-specific:traefik
-forgejo_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-forgejo_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /forgejo                                                             #
-#                                                                      #
-########################################################################
-# /role-specific:forgejo
-
-
-
-# role-specific:forgejo_runner
-########################################################################
-#                                                                      #
-# forgejo_runner                                                       #
-#                                                                      #
-########################################################################
-
-forgejo_runner_enabled: false
-
-forgejo_runner_uid: "0"
-forgejo_runner_gid: "0"
-
-forgejo_runner_identifier: "{{ mash_playbook_service_identifier_prefix }}forgejo-runner"
-
-forgejo_runner_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}forgejo-runner"
-
-forgejo_runner_systemd_required_systemd_services_list: |
-  {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-  }}
-
-########################################################################
-#                                                                      #
-# /forgejo_runner                                                      #
-#                                                                      #
-########################################################################
-# /role-specific:forgejo_runner
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1942,47 +1942,6 @@ docker_registry_container_labels_traefik_tls_certResolver: "{{ traefik_certResol
 
 
 
-# role-specific:docker_registry_proxy
-########################################################################
-#                                                                      #
-# docker-registry-proxy                                              #
-#                                                                      #
-########################################################################
-
-docker_registry_proxy_enabled: false
-
-docker_registry_proxy_identifier: "{{ mash_playbook_service_identifier_prefix }}docker-registry-proxy"
-
-docker_registry_proxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}docker-registry-proxy"
-
-docker_registry_proxy_uid: "{{ mash_playbook_uid }}"
-docker_registry_proxy_gid: "{{ mash_playbook_gid }}"
-
-docker_registry_proxy_target_scheme: "{{ 'http' if docker_registry_enabled else '' }}"
-docker_registry_proxy_target_host: "{{ docker_registry_identifier+':5000' if docker_registry_enabled else '' }}"
-
-docker_registry_proxy_container_additional_networks: |
-  {{
-    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
-  }}
-
-docker_registry_proxy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
-docker_registry_proxy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
-
-# role-specific:traefik
-docker_registry_proxy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-docker_registry_proxy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-# /role-specific:traefik
-
-########################################################################
-#                                                                      #
-# /docker-registry-proxy                                             #
-#                                                                      #
-########################################################################
-# /role-specific:docker_registry_proxy
-
-
-
 # role-specific:docker_registry_browser
 ########################################################################
 #                                                                      #
@@ -2020,6 +1979,48 @@ docker_registry_browser_container_labels_traefik_tls_certResolver: "{{ traefik_c
 #                                                                      #
 ########################################################################
 # /role-specific:docker_registry_browser
+
+
+
+# role-specific:docker_registry_proxy
+########################################################################
+#                                                                      #
+# docker-registry-proxy                                                #
+#                                                                      #
+########################################################################
+
+docker_registry_proxy_enabled: false
+
+docker_registry_proxy_identifier: "{{ mash_playbook_service_identifier_prefix }}docker-registry-proxy"
+
+docker_registry_proxy_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}docker-registry-proxy"
+
+docker_registry_proxy_uid: "{{ mash_playbook_uid }}"
+docker_registry_proxy_gid: "{{ mash_playbook_gid }}"
+
+docker_registry_proxy_target_scheme: "{{ 'http' if docker_registry_enabled else '' }}"
+docker_registry_proxy_target_host: "{{ docker_registry_identifier+':5000' if docker_registry_enabled else '' }}"
+
+docker_registry_proxy_container_additional_networks: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+docker_registry_proxy_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+docker_registry_proxy_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+docker_registry_proxy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+docker_registry_proxy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /docker-registry-proxy                                               #
+#                                                                      #
+########################################################################
+# /role-specific:docker_registry_proxy
+
 
 
 # role-specific:docker_registry_purger


### PR DESCRIPTION
- Sort blocks from `# role-specific:adguard_home` to `# role-specific:yourls`  alphabetically, on the assumption that variables would neither cascade nor depend on its appearance order
  - if other factors have been taken into consideration it should be detailed with a comment
- Add forgejo (`# role-specific:forgejo`) to `mash_playbook_hubsite_service_list_auto_itemized` thanks to clear view obtained by sorting.