### PR TITLE
Add PrivateBin

### DIFF
--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -1,0 +1,107 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# YOURLS
+
+The playbook can install and configure [YOURLS](https://yourls.org) for you.
+
+YOURLS is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
+
+See the project's [documentation](https://yourls.org/docs) to learn what YOURLS does and why it might be useful to you.
+
+For details about configuring the [Ansible role for YOURLS](https://codeberg.org/acioustick/ansible-role-yourls), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md) online
+- 📁 `roles/galaxy/yourls/docs/configuring-yourls.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+- MySQL / [MariaDB](mariadb.md) database
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# yourls                                                               #
+#                                                                      #
+########################################################################
+
+yourls_enabled: true
+
+yourls_hostname: yourls.example.com
+
+########################################################################
+#                                                                      #
+# yourls                                                               #
+#                                                                      #
+########################################################################
+```
+
+**Notes**:
+- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the YOURLS instance is going to be hosted.
+- Hosting YOURLS under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to YOURLS's technical limitations.
+
+### Enable MariaDB
+
+You can enable a MariaDB instance by adding the following configuration:
+
+```yaml
+########################################################################
+#                                                                      #
+# mariadb                                                              #
+#                                                                      #
+########################################################################
+
+mariadb_enabled: true
+
+# Put a strong password below, generated with `pwgen -s 64 1` or in another way
+mariadb_root_password: ''
+
+########################################################################
+#                                                                      #
+# /mariadb                                                             #
+#                                                                      #
+########################################################################
+```
+
+### Set the admin username and password
+
+You also need to create an instance's user to access to the admin UI after installation. To create one, add the following configuration to your `vars.yml` file. Make sure to replace `YOUR_ADMIN_USERNAME_HERE` and `YOUR_ADMIN_PASSWORD_HERE`.
+
+```yaml
+yourls_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
+yourls_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
+```
+
+## Usage
+
+After running the command for installation, YOURLS's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
+
+First, open the page with a web browser to complete installation on the server by clicking "Install YOURLS" button. After that, click the anchor link "YOURLS Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
+
+The help file is available at `yourls.example.com/readme.html`.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -137,11 +137,7 @@ See its [configuration sample file](https://github.com/PrivateBin/PrivateBin/blo
 
 ## Usage
 
-After running the command for installation, PrivateBin's admin UI is available at the specified hostname with `/admin/` such as `privatebin.example.com/admin/`.
-
-First, open the page with a web browser to complete installation on the server by clicking "Install PrivateBin" button. After that, click the anchor link "PrivateBin Administration Page" to log in with the username (`privatebin_environment_variable_user`) and password (`privatebin_environment_variable_pass`).
-
-The help file is available at `privatebin.example.com/readme.html`.
+After running the command for installation, PrivateBin becomes available at the specified hostname with the prefix (`mash.example.com/bin`).
 
 ## Troubleshooting
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -17,15 +17,15 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# YOURLS
+# PrivateBin
 
-The playbook can install and configure [YOURLS](https://yourls.org) for you.
+The playbook can install and configure [PrivateBin](https://yourls.org) for you.
 
-YOURLS is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
+PrivateBin is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
 
-See the project's [documentation](https://yourls.org/docs) to learn what YOURLS does and why it might be useful to you.
+See the project's [documentation](https://yourls.org/docs) to learn what PrivateBin does and why it might be useful to you.
 
-For details about configuring the [Ansible role for YOURLS](https://codeberg.org/acioustick/ansible-role-yourls), you can check them via:
+For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-yourls), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md) online
 - 📁 `roles/galaxy/yourls/docs/configuring-yourls.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
@@ -59,8 +59,8 @@ yourls_hostname: yourls.example.com
 ```
 
 **Notes**:
-- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the YOURLS instance is going to be hosted.
-- Hosting YOURLS under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to YOURLS's technical limitations.
+- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the PrivateBin instance is going to be hosted.
+- Hosting PrivateBin under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to PrivateBin's technical limitations.
 
 ### Enable MariaDB
 
@@ -96,9 +96,9 @@ yourls_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
 
 ## Usage
 
-After running the command for installation, YOURLS's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
+After running the command for installation, PrivateBin's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
 
-First, open the page with a web browser to complete installation on the server by clicking "Install YOURLS" button. After that, click the anchor link "YOURLS Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
+First, open the page with a web browser to complete installation on the server by clicking "Install PrivateBin" button. After that, click the anchor link "PrivateBin Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
 
 The help file is available at `yourls.example.com/readme.html`.
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -35,7 +35,7 @@ This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
 - (optional) MySQL / [MariaDB](mariadb.md) database
-- (optional) [Postgres](postgres.md) database
+- (optional) [Postgres](postgres.md) database — required on the default configuration
 - (optional) [YOURLS](yourls.md)
 
 ## Adjusting the playbook configuration
@@ -61,11 +61,15 @@ privatebin_path_prefix: bin
 ########################################################################
 ```
 
-### Configure a storage for pastes
+### Configure a storage for pastes (optional)
 
-PrivateBin instance requires a storage backend to work. The available options: local filesystem (default), PostgreSQL, MySQL, SQLite, Google Cloud Storage, and Amazon S3.
+PrivateBin instance requires a storage backend to work. The available options: PostgreSQL (default), local filesystem, MySQL, SQLite, Google Cloud Storage, and Amazon S3.
 
-#### Local filesystem (default)
+As the playbook enables the [PostgreSQL service](postgres.md) on `vars.yml` by default, it is configured to use it as the default backend. If it is fine for you, you do not have to add configuration for the storage.
+
+See below for the instruction to use one of the others.
+
+#### Local filesystem
 
 To use local filesystem database for a storage, you need to add a Docker volume to mount in the container, so that the directory for storing files is shared with the host machine.
 
@@ -80,16 +84,6 @@ privatebin_container_additional_volumes:
 ```
 
 Make sure permissions of the directory specified to `src`. If not correctly specified, the service returns a permission error while trying to put data to it.
-
-#### PostgreSQL
-
-To use PostgreSQL for a storage, add the following configuration to your `vars.yml` file:
-
-```yaml
-privatebin_config_model: PostgreSQL
-```
-
-Make sure that PostgreSQL is enabled on `vars.yml`.
 
 #### MySQL
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -51,18 +51,15 @@ To enable this service, add the following configuration to your `vars.yml` file 
 
 privatebin_enabled: true
 
-privatebin_hostname: privatebin.example.com
+privatebin_hostname: mash.example.com
+privatebin_path_prefix: bin
 
 ########################################################################
 #                                                                      #
-# privatebin                                                           #
+# /privatebin                                                          #
 #                                                                      #
 ########################################################################
 ```
-
-**Notes**:
-- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the PrivateBin instance is going to be hosted.
-- Hosting PrivateBin under a subpath (by configuring the `privatebin_path_prefix` variable) does not seem to be possible due to PrivateBin's technical limitations.
 
 ### Enable MariaDB
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -34,7 +34,9 @@ For details about configuring the [Ansible role for PrivateBin](https://codeberg
 This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
-- MySQL / [MariaDB](mariadb.md) database
+- (optional) MySQL / [MariaDB](mariadb.md) database
+- (optional) [Postgres](postgres.md) database
+- (optional) [YOURLS](yourls.md)
 
 ## Adjusting the playbook configuration
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -93,26 +93,7 @@ To use MySQL for a storage, add the following configuration to your `vars.yml` f
 privatebin_config_model: MySQL
 ```
 
-You can enable a [MariaDB](mariadb.md) instance by adding the following configuration:
-
-```yaml
-########################################################################
-#                                                                      #
-# mariadb                                                              #
-#                                                                      #
-########################################################################
-
-mariadb_enabled: true
-
-# Put a strong password below, generated with `pwgen -s 64 1` or in another way
-mariadb_root_password: ''
-
-########################################################################
-#                                                                      #
-# /mariadb                                                             #
-#                                                                      #
-########################################################################
-```
+See [here](mariadb.md) on the role's documentation for details about how to configure a MariaDB instance with the playbook.
 
 #### Google Cloud Storage / Amazon S3
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -125,6 +125,16 @@ privatebin_config_yourlsapi_url: https://yourls.example.com/yourls-api.php
 
 You can find the "signature" and API's URL on the "Tools" page of the YOURLS instance.
 
+### Extending the configuration
+
+There are some additional things you may wish to configure about the component.
+
+Take a look at:
+
+- [PrivateBin](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin)'s [`defaults/main.yml`](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/defaults/main.yml) for some variables that you can customize via your `vars.yml` file.
+
+See its [configuration sample file](https://github.com/PrivateBin/PrivateBin/blob/master/cfg/conf.sample.php) and the [documentation](https://github.com/PrivateBin/PrivateBin/wiki/Configuration) for a complete list of PrivateBin's config options such as [discussion](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#configure-the-discussion-feature-optional), [password](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#configure-the-password-feature-optional), [file upload](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#configure-the-file-upload-feature-optional), and [default theme](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#configure-the-default-template-optional) features.
+
 ## Usage
 
 After running the command for installation, PrivateBin's admin UI is available at the specified hostname with `/admin/` such as `privatebin.example.com/admin/`.

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -26,7 +26,7 @@ PrivateBin is a minimalist, open source online pastebin where the server has zer
 See the project's [documentation](https://github.com/PrivateBin/PrivateBin/tree/master/doc) to learn what PrivateBin does and why it might be useful to you.
 
 For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-privatebin), you can check them via:
-- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md) online
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md) online
 - 📁 `roles/galaxy/privatebin/docs/configuring-privatebin.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
@@ -97,7 +97,7 @@ See [here](mariadb.md) on the role's documentation for details about how to conf
 
 #### Google Cloud Storage / Amazon S3
 
-See [this section](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md#configure-a-storage-for-pastes) on the role's documentation for details about how to configure a storage at Google Cloud Storage or Amazon S3.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#configure-a-storage-for-pastes) on the role's documentation for details about how to configure a storage at Google Cloud Storage or Amazon S3.
 
 ### Configure a URL shortener (optional)
 
@@ -141,4 +141,4 @@ After running the command for installation, PrivateBin becomes available at the 
 
 ## Troubleshooting
 
-See [this section](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -19,11 +19,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # PrivateBin
 
-The playbook can install and configure [PrivateBin](https://privatebin.org) for you.
+The playbook can install and configure [PrivateBin](https://privatebin.info) for you.
 
-PrivateBin is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
+PrivateBin is a minimalist, open source online pastebin where the server has zero knowledge of pasted data.
 
-See the project's [documentation](https://privatebin.org/docs) to learn what PrivateBin does and why it might be useful to you.
+See the project's [documentation](https://github.com/PrivateBin/PrivateBin/tree/master/doc) to learn what PrivateBin does and why it might be useful to you.
 
 For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-privatebin), you can check them via:
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md) online

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -61,9 +61,45 @@ privatebin_path_prefix: bin
 ########################################################################
 ```
 
-### Enable MariaDB
+### Configure a storage for pastes
 
-You can enable a MariaDB instance by adding the following configuration:
+PrivateBin instance requires a storage backend to work. The available options: local filesystem (default), PostgreSQL, MySQL, SQLite, Google Cloud Storage, and Amazon S3.
+
+#### Local filesystem (default)
+
+To use local filesystem database for a storage, you need to add a Docker volume to mount in the container, so that the directory for storing files is shared with the host machine.
+
+To add the volume, prepare a directory on the host machine and add the following configuration to your `vars.yml` file, setting the directory path to `src`:
+
+```yaml
+privatebin_container_additional_volumes:
+  - type: bind
+    src: /path/on/the/host
+    dst: /srv/data
+    options:
+```
+
+Make sure permissions of the directory specified to `src`. If not correctly specified, the service returns a permission error while trying to put data to it.
+
+#### PostgreSQL
+
+To use PostgreSQL for a storage, add the following configuration to your `vars.yml` file:
+
+```yaml
+privatebin_config_model: PostgreSQL
+```
+
+Make sure that PostgreSQL is enabled on `vars.yml`.
+
+#### MySQL
+
+To use MySQL for a storage, add the following configuration to your `vars.yml` file:
+
+```yaml
+privatebin_config_model: MySQL
+```
+
+You can enable a [MariaDB](mariadb.md) instance by adding the following configuration:
 
 ```yaml
 ########################################################################
@@ -83,6 +119,10 @@ mariadb_root_password: ''
 #                                                                      #
 ########################################################################
 ```
+
+#### Google Cloud Storage / Amazon S3
+
+See [this section](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md#configure-a-storage-for-pastes) on the role's documentation for details about how to configure a storage at Google Cloud Storage or Amazon S3.
 
 ### Set the admin username and password
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -99,14 +99,31 @@ See [here](mariadb.md) on the role's documentation for details about how to conf
 
 See [this section](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md#configure-a-storage-for-pastes) on the role's documentation for details about how to configure a storage at Google Cloud Storage or Amazon S3.
 
-### Set the admin username and password
+### Configure a URL shortener (optional)
 
-You also need to create an instance's user to access to the admin UI after installation. To create one, add the following configuration to your `vars.yml` file. Make sure to replace `YOUR_ADMIN_USERNAME_HERE` and `YOUR_ADMIN_PASSWORD_HERE`.
+It is possible to have the PrivateBin instance use a URL shortener such as Bit.ly and a [YOURLS](https://yourls.org) instance, so that users can shorten a URL of a paste with it. **It is recommended to use a self-hosted shortener only and set a password to a paste, as the shortener will leak the paste's encryption key.**
+
+YOURLS is available on the playbook. See [here](yourls.md) for details about how to install it.
+
+**Notes**
+- YOURLS requires a MariaDB instance (see [here](mariadb.md) for details about configuring it with the playbook); if PostgreSQL is going to be used for PrivateBin (or other services), you need to use both of them.
+- If you are going to install PrivateBin and YOURLS at the same time, **you need to complete installation of YOURLS at first** by visiting its admin UI available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`. Otherwise the function to shorten a paste's URL does not work. See [here](yourls.md#usage) for the instruction to complete instalation.
+
+#### Use a private YOURLS instance with API access key
+
+If you are using the private YOURLS instance, you might probably want to disallow a third party to use it without credentials. You can configure authentication by adding the following configuration to your `vars.yml` file:
 
 ```yaml
-privatebin_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
-privatebin_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
+privatebin_config_yourlsapi_enabled: true
+
+# Set the "signature" (access key) issued by the YOURLS instance for using the account
+privatebin_config_yourlsapi_signature: ''
+
+# Set URL of the YOURLS instance's API, called to shorten a paste URL
+privatebin_config_yourlsapi_url: https://yourls.example.com/yourls-api.php
 ```
+
+You can find the "signature" and API's URL on the "Tools" page of the YOURLS instance.
 
 ## Usage
 

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -26,7 +26,7 @@ PrivateBin is a set of PHP scripts that will allow you to run Your Own URL Short
 See the project's [documentation](https://privatebin.org/docs) to learn what PrivateBin does and why it might be useful to you.
 
 For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-privatebin), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md) online
+- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md) online
 - 📁 `roles/galaxy/privatebin/docs/configuring-privatebin.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
@@ -104,4 +104,4 @@ The help file is available at `privatebin.example.com/readme.html`.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#troubleshooting) on the role's documentation for details.
+See [this section](https://codeberg.org/acioustick/ansible-role-privatebin/src/branch/master/docs/configuring-privatebin.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/privatebin.md
+++ b/docs/services/privatebin.md
@@ -19,15 +19,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # PrivateBin
 
-The playbook can install and configure [PrivateBin](https://yourls.org) for you.
+The playbook can install and configure [PrivateBin](https://privatebin.org) for you.
 
 PrivateBin is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
 
-See the project's [documentation](https://yourls.org/docs) to learn what PrivateBin does and why it might be useful to you.
+See the project's [documentation](https://privatebin.org/docs) to learn what PrivateBin does and why it might be useful to you.
 
-For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-yourls), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md) online
-- 📁 `roles/galaxy/yourls/docs/configuring-yourls.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for PrivateBin](https://codeberg.org/acioustick/ansible-role-privatebin), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md) online
+- 📁 `roles/galaxy/privatebin/docs/configuring-privatebin.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -43,24 +43,24 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# yourls                                                               #
+# privatebin                                                           #
 #                                                                      #
 ########################################################################
 
-yourls_enabled: true
+privatebin_enabled: true
 
-yourls_hostname: yourls.example.com
+privatebin_hostname: privatebin.example.com
 
 ########################################################################
 #                                                                      #
-# yourls                                                               #
+# privatebin                                                           #
 #                                                                      #
 ########################################################################
 ```
 
 **Notes**:
 - It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the PrivateBin instance is going to be hosted.
-- Hosting PrivateBin under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to PrivateBin's technical limitations.
+- Hosting PrivateBin under a subpath (by configuring the `privatebin_path_prefix` variable) does not seem to be possible due to PrivateBin's technical limitations.
 
 ### Enable MariaDB
 
@@ -90,18 +90,18 @@ mariadb_root_password: ''
 You also need to create an instance's user to access to the admin UI after installation. To create one, add the following configuration to your `vars.yml` file. Make sure to replace `YOUR_ADMIN_USERNAME_HERE` and `YOUR_ADMIN_PASSWORD_HERE`.
 
 ```yaml
-yourls_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
-yourls_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
+privatebin_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
+privatebin_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
 ```
 
 ## Usage
 
-After running the command for installation, PrivateBin's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
+After running the command for installation, PrivateBin's admin UI is available at the specified hostname with `/admin/` such as `privatebin.example.com/admin/`.
 
-First, open the page with a web browser to complete installation on the server by clicking "Install PrivateBin" button. After that, click the anchor link "PrivateBin Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
+First, open the page with a web browser to complete installation on the server by clicking "Install PrivateBin" button. After that, click the anchor link "PrivateBin Administration Page" to log in with the username (`privatebin_environment_variable_user`) and password (`privatebin_environment_variable_pass`).
 
-The help file is available at `yourls.example.com/readme.html`.
+The help file is available at `privatebin.example.com/readme.html`.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin/blob/main/docs/configuring-privatebin.md#troubleshooting) on the role's documentation for details.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -94,6 +94,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Postgis](https://postgis.net/) | A spatial database extender for PostgreSQL object-relational database | [Link](services/postgis.md) |
 | [Postgres](https://www.postgresql.org) | A powerful, open source object-relational database system | [Link](services/postgres.md) |
 | [Postgres Backup](https://github.com/prodrigestivill/docker-postgres-backup-local) | A solution for backing up PostgresSQL to local filesystem with periodic backups. | [Link](services/postgres-backup.md) |
+| [PrivateBin](https://privatebin.info/) | Minimalist, open source online pastebin where the server has zero knowledge of pasted data. | [Link](services/privatebin.md) |
 | [Prometheus](https://prometheus.io/) | A metrics collection and alerting monitoring solution | [Link](services/prometheus.md) |
 | [Prometheus Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) | Blackbox probing of HTTP/HTTPS/DNS/TCP/ICMP and gRPC endpoints | [Link](services/prometheus-blackbox-exporter.md) |
 | [Prometheus Node Exporter](https://github.com/prometheus/node_exporter) | Exporter for machine metrics | [Link](services/prometheus-node-exporter.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1059,10 +1059,10 @@ mash_playbook_postgres_managed_databases_auto_itemized:
   - |-
     {{
       ({
-        'name': privatebin_database_name,
-        'username': privatebin_database_username,
-        'password': privatebin_database_password,
-      } if privatebin_enabled else omit)
+        'name': privatebin_database_postgres_name,
+        'username': privatebin_database_postgres_username,
+        'password': privatebin_database_postgres_password,
+      } if privatebin_enabled and privatebin_database_postgres_hostname == postgres_identifier else omit)
     }}
   # /role-specific:privatebin
 
@@ -4658,6 +4658,17 @@ mash_playbook_mariadb_managed_databases_auto_itemized:
     }}
   # /role-specific:authelia
 
+  # role-specific:privatebin
+  - |-
+    {{
+      ({
+        'name': privatebin_database_mysql_name,
+        'username': privatebin_database_mysql_username,
+        'password': privatebin_database_mysql_password,
+      } if privatebin_enabled and privatebin_database_mysql_hostname == mariadb_identifier else omit)
+    }}
+  # /role-specific:privatebin
+
   # role-specific:wordpress
   - |-
     {{
@@ -5744,24 +5755,38 @@ privatebin_gid: "{{ mash_playbook_gid }}"
 privatebin_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}privatebin"
 
 privatebin_systemd_required_services_list_auto: |
- {{
-    ([postgres_identifier ~ '.service'] if postgres_enabled and privatebin_database_hostname == postgres_identifier else [])
+  {{
+    ([mariadb_identifier ~ '.service'] if mariadb_enabled and privatebin_database_mysql_hostname == mariadb_identifier else [])
+    +
+    ([postgres_identifier ~ '.service'] if postgres_enabled and privatebin_database_postgres_hostname == postgres_identifier else [])
   }}
 
 privatebin_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +
-    ([postgres_container_network] if postgres_enabled | default(false) and privatebin_database_hostname == postgres_identifier and privatebin_container_network != postgres_container_network else [])
+    ([mariadb_container_network] if mariadb_enabled and privatebin_database_mysql_hostname == mariadb_identifier and privatebin_container_network != mariadb_container_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and privatebin_database_postgres_hostname == postgres_identifier and privatebin_container_network != postgres_container_network else [])
   }}
 
 privatebin_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 privatebin_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
+# Note that valid values for "privatebin_config_model" are Filesystem, GoogleCloudStorage, MySQL, SQLite, PostgreSQL, and S3, meaning neither MySQL (MariaDB) nor Postgres would be a must.
+
+# role-specific:mariadb
+# This is activated only if MariaDB is enabled and "privatebin_config_model" is set to "MySQL".
+privatebin_database_mysql_hostname: "{{ mariadb_identifier if mariadb_enabled and privatebin_config_model == 'MySQL' else '' }}"
+privatebin_database_mysql_username: "{{ privatebin_identifier }}"
+privatebin_database_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.privatebinm', rounds=655555) | to_uuid }}"
+# /role-specific:mariadb
+
 # role-specific:postgres
-privatebin_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
-privatebin_database_username: "{{ privatebin_identifier }}"
-privatebin_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authentik', rounds=655555) | to_uuid }}"
+# This is activated only if Postgres is enabled and "privatebin_config_model" is set to "PostgreSQL".
+privatebin_database_postgres_hostname: "{{ postgres_identifier if postgres_enabled and privatebin_config_model == 'PostgreSQL' else '' }}"
+privatebin_database_postgres_username: "{{ privatebin_identifier }}"
+privatebin_database_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.privatebinp', rounds=655555) | to_uuid }}"
 # /role-specific:postgres
 
 # role-specific:traefik

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5774,6 +5774,7 @@ privatebin_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_en
 privatebin_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
 # Note that valid values for "privatebin_config_model" are Filesystem, GoogleCloudStorage, MySQL, SQLite, PostgreSQL, and S3, meaning neither MySQL (MariaDB) nor Postgres would be a must.
+privatebin_config_model: PostgreSQL
 
 # role-specific:mariadb
 # This is activated only if MariaDB is enabled and "privatebin_config_model" is set to "MySQL".

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -511,6 +511,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (postgres_backup_identifier + '.service'), 'priority': 5000, 'groups': ['mash', 'backup', 'postgres-backup']} if postgres_backup_enabled else omit) }}
   # /role-specific:postgres_backup
 
+  # role-specific:privatebin
+  - |-
+    {{ ({'name': (privatebin_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'privatebin']} if privatebin_enabled else omit) }}
+  # /role-specific:privatebin
+
   # role-specific:prometheus
   - |-
     {{ ({'name': (prometheus_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'metrics', 'prometheus']} if prometheus_enabled else omit) }}
@@ -1049,6 +1054,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
       } if plausible_enabled else omit)
     }}
   # /role-specific:plausible
+
+  # role-specific:privatebin
+  - |-
+    {{
+      ({
+        'name': privatebin_database_name,
+        'username': privatebin_database_username,
+        'password': privatebin_database_password,
+      } if privatebin_enabled else omit)
+    }}
+  # /role-specific:privatebin
 
   # role-specific:prometheus_postgres_exporter
   - |-
@@ -3281,6 +3297,16 @@ hubsite_service_peertube_description: "Watch and upload videos"
 hubsite_service_peertube_priority: 1000
 # /role-specific:peertube
 
+# role-specific:privatebin
+# PrivateBin
+hubsite_service_privatebin_enabled: "{{ privatebin_enabled }}"
+hubsite_service_privatebin_name: PrivateBin
+hubsite_service_privatebin_url: "{{ privatebin_scheme }}://{{ privatebin_hostname }}{{ privatebin_path_prefix }}"
+hubsite_service_privatebin_logo_location: ""
+hubsite_service_privatebin_description: "Minimalist, open source online pastebin where the server has zero knowledge of pasted data."
+hubsite_service_privatebin_priority: 1000
+# /role-specific:privatebin
+
 # role-specific:radicale
 # Radicale
 hubsite_service_radicale_enabled: "{{ radicale_enabled }}"
@@ -3740,6 +3766,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_peertube_enabled else omit)
     }}
   # /role-specific:peertube
+
+  # role-specific:privatebin
+  - |-
+    {{
+      ({
+        'name': hubsite_service_privatebin_name,
+        'url': hubsite_service_privatebin_url,
+        'logo_location': hubsite_service_privatebin_logo_location,
+        'description': hubsite_service_privatebin_description,
+        'priority': hubsite_service_privatebin_priority,
+      } if hubsite_service_privatebin_enabled else omit)
+    }}
+  # /role-specific:privatebin
 
   # role-specific:radicale
   - |-
@@ -5685,6 +5724,57 @@ postgis_managed_databases_auto: |
 #                                                                      #
 ########################################################################
 # /role-specific:postgis
+
+
+
+# role-specific:privatebin
+########################################################################
+#                                                                      #
+# privatebin                                                           #
+#                                                                      #
+########################################################################
+
+privatebin_enabled: false
+
+privatebin_identifier: "{{ mash_playbook_service_identifier_prefix }}privatebin"
+
+privatebin_uid: "{{ mash_playbook_uid }}"
+privatebin_gid: "{{ mash_playbook_gid }}"
+
+privatebin_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}privatebin"
+
+privatebin_systemd_required_services_list_auto: |
+ {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and privatebin_database_hostname == postgres_identifier else [])
+  }}
+
+privatebin_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled | default(false) and privatebin_database_hostname == postgres_identifier and privatebin_container_network != postgres_container_network else [])
+  }}
+
+privatebin_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+privatebin_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+privatebin_database_hostname: "{{ postgres_identifier if postgres_enabled else '' }}"
+privatebin_database_username: "{{ privatebin_identifier }}"
+privatebin_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.authentik', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+privatebin_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+privatebin_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /privatebin                                                          #
+#                                                                      #
+########################################################################
+# /role-specific:privatebin
 
 
 

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -5756,18 +5756,18 @@ privatebin_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 
 privatebin_systemd_required_services_list_auto: |
   {{
-    ([mariadb_identifier ~ '.service'] if mariadb_enabled and privatebin_database_mysql_hostname == mariadb_identifier else [])
+    ([mariadb_identifier ~ '.service'] if mariadb_enabled | default(false) and privatebin_database_mysql_hostname == mariadb_identifier else [])
     +
-    ([postgres_identifier ~ '.service'] if postgres_enabled and privatebin_database_postgres_hostname == postgres_identifier else [])
+    ([postgres_identifier ~ '.service'] if postgres_enabled | default(false) and privatebin_database_postgres_hostname == postgres_identifier else [])
   }}
 
 privatebin_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
     +
-    ([mariadb_container_network] if mariadb_enabled and privatebin_database_mysql_hostname == mariadb_identifier and privatebin_container_network != mariadb_container_network else [])
+    ([mariadb_container_network] if mariadb_enabled | default(false) and privatebin_database_mysql_hostname == mariadb_identifier and privatebin_container_network != mariadb_container_network else [])
     +
-    ([postgres_container_network] if postgres_enabled and privatebin_database_postgres_hostname == postgres_identifier and privatebin_container_network != postgres_container_network else [])
+    ([postgres_container_network] if postgres_enabled | default(false) and privatebin_database_postgres_hostname == postgres_identifier and privatebin_container_network != postgres_container_network else [])
   }}
 
 privatebin_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
@@ -5777,14 +5777,14 @@ privatebin_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_pr
 
 # role-specific:mariadb
 # This is activated only if MariaDB is enabled and "privatebin_config_model" is set to "MySQL".
-privatebin_database_mysql_hostname: "{{ mariadb_identifier if mariadb_enabled and privatebin_config_model == 'MySQL' else '' }}"
+privatebin_database_mysql_hostname: "{{ mariadb_identifier if mariadb_enabled | default(false) and privatebin_config_model == 'MySQL' else '' }}"
 privatebin_database_mysql_username: "{{ privatebin_identifier }}"
 privatebin_database_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.privatebinm', rounds=655555) | to_uuid }}"
 # /role-specific:mariadb
 
 # role-specific:postgres
 # This is activated only if Postgres is enabled and "privatebin_config_model" is set to "PostgreSQL".
-privatebin_database_postgres_hostname: "{{ postgres_identifier if postgres_enabled and privatebin_config_model == 'PostgreSQL' else '' }}"
+privatebin_database_postgres_hostname: "{{ postgres_identifier if postgres_enabled | default(false) and privatebin_config_model == 'PostgreSQL' else '' }}"
 privatebin_database_postgres_username: "{{ privatebin_identifier }}"
 privatebin_database_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.privatebinp', rounds=655555) | to_uuid }}"
 # /role-specific:postgres

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -335,6 +335,10 @@
   version: v17-3
   name: postgres_backup
   activation_prefix: postgres_backup_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-privatebin.git
+  version: v1.7.6-1
+  name: privatebin
+  activation_prefix: privatebin_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus.git
   version: v2.55.1-3
   name: prometheus

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -371,6 +371,10 @@
     - role: galaxy/postgis
     # /role-specific:postgis
 
+    # role-specific:privatebin
+    - role: galaxy/privatebin
+    # /role-specific:privatebin
+
     # role-specific:prometheus
     - role: galaxy/prometheus
     # /role-specific:prometheus


### PR DESCRIPTION
This PR intends to add [PrivateBin](https://privatebin.info/) ([ansible-role-privatebin](https://github.com/mother-of-all-self-hosting/ansible-role-privatebin)) to the playbook.

I've tested several scenarios (File system, MariaDB, PostgreSQL, with and without YOURLS, themes, file upload feature, under default domain with `/bin` and with its dedicated domain `bin.example.com`). 