### PR TITLE
Add Redlib

### DIFF
--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# AnonymousOverflow
+
+The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+
+AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+
+See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+
+For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
+- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# anonymousoverflow                                                    #
+#                                                                      #
+########################################################################
+
+anonymousoverflow_enabled: true
+
+anonymousoverflow_hostname: anonymousoverflow.example.com
+
+########################################################################
+#                                                                      #
+# /anonymousoverflow                                                   #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+
+## Usage
+
+After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -57,7 +57,11 @@ redlib_hostname: redlib.example.com
 ########################################################################
 ```
 
-**Note**: hosting Redlib under a subpath (by configuring the `redlib_path_prefix` variable) does not seem to be possible due to Redlib's technical limitations.
+**Note**: hosting Redlib under a subpath (by configuring the `redlib_path_prefix` variable) is technically possible but not recommended, as most of the functions do not work as expected due to Redlib's technical limitations (pages and resources are not correctly loaded, and links are broken).
+
+### Configure instance and user settings (optional)
+
+There are various options for the instance and user settings. See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-redlib/blob/main/docs/configuring-redlib.md#configure-instance-and-user-settings-optional) on the role's documentation for details.
 
 ## Usage
 

--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -17,15 +17,15 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# AnonymousOverflow
+# Redlib
 
-The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+The playbook can install and configure [Redlib](https://github.com/httpjamesm/Redlib) for you.
 
-AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Redlib allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
 
-See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+See the project's [documentation](https://github.com/httpjamesm/Redlib/blob/main/README.md) to learn what Redlib does and why it might be useful to you.
 
-For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+For details about configuring the [Ansible role for Redlib](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
 - 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
@@ -57,15 +57,15 @@ anonymousoverflow_hostname: anonymousoverflow.example.com
 ########################################################################
 ```
 
-**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+**Note**: hosting Redlib under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to Redlib's technical limitations.
 
 ## Usage
 
-After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Redlib becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Redlib. See [this section](https://github.com/httpjamesm/Redlib/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Redlib) to add yours to [`instances.json`](https://github.com/httpjamesm/Redlib/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 

--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -25,9 +25,9 @@ Redlib allows you to view StackOverflow threads without exposing your IP address
 
 See the project's [documentation](https://github.com/httpjamesm/Redlib/blob/main/README.md) to learn what Redlib does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Redlib](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
-- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Redlib](https://github.com/mother-of-all-self-hosting/ansible-role-redlib), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-redlib/blob/main/docs/configuring-redlib.md) online
+- 📁 `roles/galaxy/redlib/docs/configuring-redlib.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -42,31 +42,31 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# anonymousoverflow                                                    #
+# redlib                                                               #
 #                                                                      #
 ########################################################################
 
-anonymousoverflow_enabled: true
+redlib_enabled: true
 
-anonymousoverflow_hostname: anonymousoverflow.example.com
+redlib_hostname: redlib.example.com
 
 ########################################################################
 #                                                                      #
-# /anonymousoverflow                                                   #
+# /redlib                                                              #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Redlib under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to Redlib's technical limitations.
+**Note**: hosting Redlib under a subpath (by configuring the `redlib_path_prefix` variable) does not seem to be possible due to Redlib's technical limitations.
 
 ## Usage
 
-After running the command for installation, Redlib becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Redlib becomes available at the specified hostname like `https://redlib.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Redlib. See [this section](https://github.com/httpjamesm/Redlib/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Redlib. See [this section](https://github.com/httpjamesm/Redlib/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-redlib-automatically) on the official documentation for more information.
 
 If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Redlib) to add yours to [`instances.json`](https://github.com/httpjamesm/Redlib/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-redlib/blob/main/docs/configuring-redlib.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -19,11 +19,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Redlib
 
-The playbook can install and configure [Redlib](https://github.com/httpjamesm/Redlib) for you.
+The playbook can install and configure [Redlib](https://github.com/redlib-org/redlib) for you.
 
-Redlib allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Redlib allows you to browse Reddit without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
 
-See the project's [documentation](https://github.com/httpjamesm/Redlib/blob/main/README.md) to learn what Redlib does and why it might be useful to you.
+See the project's [documentation](https://github.com/redlib-org/redlib/blob/main/README.md) to learn what Redlib does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Redlib](https://github.com/mother-of-all-self-hosting/ansible-role-redlib), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-redlib/blob/main/docs/configuring-redlib.md) online

--- a/docs/services/redlib.md
+++ b/docs/services/redlib.md
@@ -67,9 +67,9 @@ There are various options for the instance and user settings. See [this section]
 
 After running the command for installation, Redlib becomes available at the specified hostname like `https://redlib.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Redlib. See [this section](https://github.com/httpjamesm/Redlib/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-redlib-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Redlib.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Redlib) to add yours to [`instances.json`](https://github.com/httpjamesm/Redlib/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+If you would like to make your instance public so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/redlib-org/redlib-instances) to add yours to the list, which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)). See [here](https://github.com/redlib-org/redlib-instances/blob/main/README.md) for details about how to do so.
 
 ## Troubleshooting
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -107,6 +107,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Radicale](https://radicale.org/) | A Free and Open-Source CalDAV and CardDAV Server (solution for hosting contacts and calendars) | [Link](services/radicale.md) |
 | [Readeck](https://readeck.org) | A bookmark manager and a read-later tool combined in one. | [Link](services/readeck.md) |
 | [Redis](https://redis.io/) | An in-memory data store used by millions of developers as a database, cache, streaming engine, and message broker. | [Link](services/redis.md) |
+| [Redlib](https://github.com/redlib-org/redlib) | Browse Reddit without exposing your IP address, browsing habits, and other browser fingerprinting data to the website. | [Link](services/redlib.md) |
 | [Redmine](https://redmine.org/) | A flexible project management web application. | [Link](services/redmine.md) |
 | [Roundcube](https://roundcube.net/) | A browser-based multilingual IMAP client with an application-like user interface | [Link](services/roundcube.md) |
 | [rumqttd](https://github.com/bytebeamio/rumqtt) | A high performance, embeddable [MQTT](https://en.wikipedia.org/wiki/MQTT) broker | [Link](services/rumqttd.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -576,6 +576,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (redis_identifier + '.service'), 'priority': 750, 'groups': ['mash', 'redis']} if redis_enabled else omit) }}
   # /role-specific:redis
 
+  # role-specific:redlib
+  - |-
+    {{ ({'name': (redlib_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'redlib']} if redlib_enabled else omit) }}
+  # /role-specific:redlib
+
   # role-specific:redmine
   - |-
     {{ ({'name': (redmine_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'redmine']} if redmine_enabled else omit) }}
@@ -3360,6 +3365,16 @@ hubsite_service_radicale_description: "Sync contacts and calendars"
 hubsite_service_radicale_priority: 1000
 # /role-specific:radicale
 
+# role-specific:redlib
+# Redlib
+hubsite_service_redlib_enabled: "{{ redlib_enabled }}"
+hubsite_service_redlib_name: Redlib
+hubsite_service_redlib_url: "{{ redlib_scheme }}://{{ redlib_hostname }}{{ redlib_path_prefix }}"
+hubsite_service_redlib_logo_location: ""
+hubsite_service_redlib_description: "Browse Reddit without exposing your IP address, browsing habits, and other browser fingerprinting data to the website."
+hubsite_service_redlib_priority: 1000
+# /role-specific:redlib
+
 # role-specific:send
 # Send
 hubsite_service_send_enabled: "{{ send_enabled }}"
@@ -3835,6 +3850,19 @@ mash_playbook_hubsite_service_list_auto_itemized:
       } if hubsite_service_radicale_enabled else omit)
     }}
   # /role-specific:radicale
+
+  # role-specific:redlib
+  - |-
+    {{
+      ({
+        'name': hubsite_service_redlib_name,
+        'url': hubsite_service_redlib_url,
+        'logo_location': hubsite_service_redlib_logo_location,
+        'description': hubsite_service_redlib_description,
+        'priority': hubsite_service_redlib_priority,
+      } if hubsite_service_redlib_enabled else omit)
+    }}
+  # /role-specific:redlib
 
   # role-specific:send
   - |-
@@ -6325,6 +6353,44 @@ redis_gid: "{{ mash_playbook_gid }}"
 #                                                                      #
 ########################################################################
 # /role-specific:redis
+
+
+
+# role-specific:redlib
+########################################################################
+#                                                                      #
+# redlib                                                               #
+#                                                                      #
+########################################################################
+
+redlib_enabled: false
+
+redlib_identifier: "{{ mash_playbook_service_identifier_prefix }}redlib"
+
+redlib_uid: "{{ mash_playbook_uid }}"
+redlib_gid: "{{ mash_playbook_gid }}"
+
+redlib_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}redlib"
+
+redlib_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+redlib_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+redlib_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+redlib_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+redlib_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /redlib                                                              #
+#                                                                      #
+########################################################################
+# /role-specific:redlib
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -387,6 +387,10 @@
   version: v7.4.2-0
   name: redis
   activation_prefix: redis_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-redlib.git
+  version: v2025.4.9-0
+  name: redlib
+  activation_prefix: redlib_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-redmine.git
   version: v6.0.4-2
   name: redmine

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -427,6 +427,10 @@
     - role: galaxy/redis
     # /role-specific:redis
 
+    # role-specific:redlib
+    - role: galaxy/redlib
+    # /role-specific:redlib
+
     # role-specific:rumqttd
     - role: galaxy/rumqttd
     # /role-specific:rumqttd


### PR DESCRIPTION
Redlib allows you to browse Reddit without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.

Essentially, Redlib to Reddit is what [AnonymousOverflow](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/anonymousoverflow.md) is to StackOverflow.

I tested it on my server including optional settings and confirmed it worked.