### PR TITLE
Revert Paperless (v2.15.2-0 -> v2.13.2-0)

### DIFF
--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -309,7 +309,7 @@
   name: oxitraffic
   activation_prefix: oxitraffic_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-paperless.git
-  version: v2.15.2-0
+  version: v2.13.2-0
   name: paperless
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-peertube.git
   version: v7.0.1-2


### PR DESCRIPTION
Paperless changed from supervisord to s6. 
This changes requires changes in the ansible-role-paperless, to support the newest version. Most likely add /run/s6 as tmpfs, but that is not enough as my testing shows. https://github.com/paperless-ngx/paperless-ngx/pull/8886