### PR TITLE
Add Homarr

### DIFF
--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# AnonymousOverflow
+
+The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+
+AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+
+See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+
+For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
+- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# anonymousoverflow                                                    #
+#                                                                      #
+########################################################################
+
+anonymousoverflow_enabled: true
+
+anonymousoverflow_hostname: anonymousoverflow.example.com
+
+########################################################################
+#                                                                      #
+# /anonymousoverflow                                                   #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+
+## Usage
+
+After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -59,6 +59,29 @@ homarr_hostname: homarr.example.com
 
 **Note**: hosting Homarr under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
 
+### Set 32-byte hex digits for secret key
+
+You also need to specify **32-byte hex digits** to encrypt integration secrets on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
+
+```yaml
+homarr_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
+```
+
+>[!NOTE]
+> Other type of values such as one generated with `pwgen -s 64 1` does not work.
+
+### Mount a directory for storing data
+
+The service requires a Docker volume to be mounted, so that the directory for storing files is shared with the host machine.
+
+To add the volume, prepare a directory on the host machine and add the following configuration to your `vars.yml` file, setting the directory path to `src`:
+
+```yaml
+homarr_data_path: /path/on/the/host
+```
+
+Make sure permissions of the directory specified to `src` (`/path/on/the/host`).
+
 ## Usage
 
 After running the command for installation, Homarr becomes available at the specified hostname like `https://homarr.example.com`.

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -25,9 +25,9 @@ Homarr allows you to view StackOverflow threads without exposing your IP address
 
 See the project's [documentation](https://github.com/httpjamesm/Homarr/blob/main/README.md) to learn what Homarr does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
-- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md) online
+- 📁 `roles/galaxy/homarr/docs/configuring-homarr.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -42,31 +42,31 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# anonymousoverflow                                                    #
+# homarr                                                               #
 #                                                                      #
 ########################################################################
 
-anonymousoverflow_enabled: true
+homarr_enabled: true
 
-anonymousoverflow_hostname: anonymousoverflow.example.com
+homarr_hostname: homarr.example.com
 
 ########################################################################
 #                                                                      #
-# /anonymousoverflow                                                   #
+# /homarr                                                              #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Homarr under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
+**Note**: hosting Homarr under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
 
 ## Usage
 
-After running the command for installation, Homarr becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Homarr becomes available at the specified hostname like `https://homarr.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Homarr. See [this section](https://github.com/httpjamesm/Homarr/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Homarr. See [this section](https://github.com/httpjamesm/Homarr/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-homarr-automatically) on the official documentation for more information.
 
 If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Homarr) to add yours to [`instances.json`](https://github.com/httpjamesm/Homarr/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -88,6 +88,20 @@ After running the command for installation, Homarr becomes available at the spec
 
 You can open the page with a web browser to start the onboarding process. See [this official guide](https://homarr.dev/docs/getting-started/after-the-installation/) for details.
 
+### Playbook's services on Homarr
+
+On Homarr's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), [PrivateBin](privatebin.md), [Syncthing](syncthing.md), etc.
+
+Homarr also integrates with various software, to which you can connect your applications to interact via widgets. Here is a list of integrations which are also available on this playbook:
+
+- **Torrent client**: [qBittorent](qbittorrent.md)
+- **Media server**: [Plex](plex.md)
+- **Media collection managers**: [Sonarr](sonarr.md) and [Radarr](radarr.md)
+- **Media request manager**: [Overseerr](overseerr.md)
+- **DNS ad-blocker**: [AdGuard Home](adguard-home.md)
+
+See [this page](https://homarr.dev/docs/category/integrations) on the official documentation for the latest information about integrations.
+
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -19,11 +19,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Homarr
 
-The playbook can install and configure [Homarr](https://github.com/httpjamesm/Homarr) for you.
+The playbook can install and configure [Homarr](https://homarr.dev) for you.
 
-Homarr allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Homarr is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
 
-See the project's [documentation](https://github.com/httpjamesm/Homarr/blob/main/README.md) to learn what Homarr does and why it might be useful to you.
+See the project's [documentation](https://homarr.dev/docs/getting-started) to learn what Homarr does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md) online

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -86,9 +86,7 @@ Make sure permissions of the directory specified to `src` (`/path/on/the/host`).
 
 After running the command for installation, Homarr becomes available at the specified hostname like `https://homarr.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Homarr. See [this section](https://github.com/httpjamesm/Homarr/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-homarr-automatically) on the official documentation for more information.
-
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Homarr) to add yours to [`instances.json`](https://github.com/httpjamesm/Homarr/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+You can open the page with a web browser to start the onboarding process. See [this official guide](https://homarr.dev/docs/getting-started/after-the-installation/) for details.
 
 ## Troubleshooting
 

--- a/docs/services/homarr.md
+++ b/docs/services/homarr.md
@@ -17,15 +17,15 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# AnonymousOverflow
+# Homarr
 
-The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+The playbook can install and configure [Homarr](https://github.com/httpjamesm/Homarr) for you.
 
-AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Homarr allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
 
-See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+See the project's [documentation](https://github.com/httpjamesm/Homarr/blob/main/README.md) to learn what Homarr does and why it might be useful to you.
 
-For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
 - 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
@@ -57,15 +57,15 @@ anonymousoverflow_hostname: anonymousoverflow.example.com
 ########################################################################
 ```
 
-**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+**Note**: hosting Homarr under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
 
 ## Usage
 
-After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Homarr becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Homarr. See [this section](https://github.com/httpjamesm/Homarr/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Homarr) to add yours to [`instances.json`](https://github.com/httpjamesm/Homarr/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 

--- a/docs/services/hubsite.md
+++ b/docs/services/hubsite.md
@@ -39,3 +39,6 @@ hubsite_subtitle: "Just click on a service to use it"
 ```
 
 You can SSO-protect this website with the help of [Authelia](authelia.md) or [OAuth2-Proxy](oauth2-proxy.md) (connected to any OIDC provider).
+
+>[!NOTE]
+> You might be also interested in setting up [Homarr](homarr.md), a customizable dashboard for managing your favorite applications and services.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -59,6 +59,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Grafana Loki](https://grafana.com/docs/loki/latest/) | Open-source log aggregation system that helps collect, store, and analyze logs in a scalable and efficient manner | [Link](services/grafana-loki.md) |
 | [Headscale](https://headscale.net/) | A Tailscale-compatible control server for managing Tailscale devices | [Link](services/headscale.md) |
 | [Healthchecks](https://healthchecks.io/) | A simple and Effective Cron Job Monitoring solution | [Link](services/healthchecks.md) |
+| [Homarr](https://homarr.dev/) | Highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system | [Link](services/homarr.md) |
 | [Hubsite](https://github.com/moan0s/hubsite) | A simple, static site that shows an overview of the available services | [Link](services/hubsite.md) |
 | [Ihatemoney](https://github.com/spiral-project/ihatemoney) | An open source shared budget manager. | [Link](services/ihatemoney.md) |
 | [ILMO](https://github.com/moan0s/ILMO2) | An open source library management tool. | [Link](services/ilmo.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -302,6 +302,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (healthchecks_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'healthchecks']} if healthchecks_enabled else omit) }}
   # /role-specific:healthchecks
 
+  # role-specific:homarr
+  - |-
+    {{ ({'name': (homarr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'homarr']} if homarr_enabled else omit) }}
+  # /role-specific:homarr
+
   # role-specific:hubsite
   - |-
     {{ ({'name': (hubsite_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'hubsite']} if hubsite_enabled else omit) }}
@@ -3231,6 +3236,46 @@ healthchecks_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver
 #                                                                      #
 ########################################################################
 # /role-specific:healthchecks
+
+
+
+# role-specific:homarr
+########################################################################
+#                                                                      #
+# homarr                                                               #
+#                                                                      #
+########################################################################
+
+homarr_enabled: false
+
+homarr_identifier: "{{ mash_playbook_service_identifier_prefix }}homarr"
+
+homarr_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}homarr"
+
+homarr_uid: "{{ mash_playbook_uid }}"
+homarr_gid: "{{ mash_playbook_gid }}"
+
+homarr_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+homarr_environment_variables_auth_secret: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'homarr', rounds=655555) | to_uuid }}"
+
+homarr_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+homarr_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+homarr_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+homarr_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /homarr                                                              #
+#                                                                      #
+########################################################################
+# /role-specific:homarr
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -180,6 +180,10 @@
   version: v3.9-2
   name: healthchecks
   activation_prefix: healthchecks_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-homarr.git
+  version: v1.17.0-1
+  name: homarr
+  activation_prefix: homarr_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-hubsite.git
   version: v1.27.4-1
   name: hubsite

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -269,6 +269,10 @@
     - role: galaxy/headscale
     # /role-specific:headscale
 
+    # role-specific:homarr
+    - role: galaxy/homarr
+    # /role-specific:homarr
+
     # role-specific:hubsite
     - role: galaxy/hubsite
     # /role-specific:hubsite


### PR DESCRIPTION
Homarr is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications. On Homarr's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook.

I've installed it on my own server and tested it with a couple of integrations (Sonarr), including adding applications to a board.

![after](https://github.com/user-attachments/assets/66bb6799-94f2-4aed-9bf3-43f5451feac1)

