### PR TITLE
Update developer-documentation.md: not all roles use AGPLv3

### DIFF
--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -52,7 +52,7 @@ When it comes to the structure of roles, you can follow existing roles such as [
     ├── LICENSE
     └── README.md
     ```
-- You will also need to decide on a licence. Otherwise ansible-galaxy won't work. We recommend AGPLv3, as all roles of the MASH playbook.
+- You will also need to decide on a licence. Otherwise ansible-galaxy won't work. We recommend AGPLv3, as it is adoped by the most roles of the MASH playbook.
 - If you are committed to free software, you might probably be interested in publishing the role based on [REUSE](https://reuse.software/), an initiative by [FSFE](https://fsfe.org/).
 
 ### 3. Update the MASH playbook to support your created Ansible role


### PR DESCRIPTION
There is actually a couple of exceptions such as ansible-role-changedetection, which adopts Apache 2.0