### PR TITLE
Replace `focalboard_systemd_required_systemd_services_list_auto` with `focalboard_systemd_required_services_list_auto`

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2729,7 +2729,7 @@ focalboard_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 focalboard_uid: "{{ mash_playbook_uid }}"
 focalboard_gid: "{{ mash_playbook_gid }}"
 
-focalboard_systemd_required_systemd_services_list_auto: |
+focalboard_systemd_required_services_list_auto: |
   {{
     ([postgres_identifier ~ '.service'] if postgres_enabled and focalboard_database_hostname == postgres_identifier else [])
   }}


### PR DESCRIPTION
Ref: https://github.com/mother-of-all-self-hosting/ansible-role-focalboard/commit/de33b362f895765400054c0fa7fd00146652142b.

Blocks on the new release over there.