### PR TITLE
Rename `vaultwarden_systemd_*_systemd_services_list_auto`

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -7653,12 +7653,12 @@ vaultwarden_gid: "{{ mash_playbook_gid }}"
 
 vaultwarden_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}vaultwarden"
 
-vaultwarden_systemd_required_systemd_services_list_auto: |
+vaultwarden_systemd_required_services_list_auto: |
   {{
     ([postgres_identifier ~ '.service'] if postgres_enabled and vaultwarden_database_hostname == postgres_identifier else [])
   }}
 
-vaultwarden_systemd_wanted_systemd_services_list_auto: |
+vaultwarden_systemd_wanted_services_list_auto: |
   {{
     ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if (exim_relay_enabled | default(false) and vaultwarden_config_smtp_host == exim_relay_identifier | default('mash-exim-relay')) else [])
   }}


### PR DESCRIPTION
Requires https://github.com/mother-of-all-self-hosting/ansible-role-vaultwarden/pull/8 and a new release over there.