### PR TITLE
Replace `woodpecker_ci_server_systemd_required_systemd_services_list`

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -7872,10 +7872,8 @@ woodpecker_ci_server_gid: "{{ mash_playbook_gid }}"
 
 woodpecker_ci_server_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}woodpecker-ci/server"
 
-woodpecker_ci_server_systemd_required_systemd_services_list: |
+woodpecker_ci_server_systemd_required_services_list_auto: |
   {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
     ([postgres_identifier ~ '.service'] if postgres_enabled and woodpecker_ci_server_database_datasource_hostname == postgres_identifier else [])
   }}
 


### PR DESCRIPTION
Replace `woodpecker_ci_server_systemd_required_systemd_services_list` with `woodpecker_ci_server_systemd_required_services_list_auto`

Requires https://github.com/mother-of-all-self-hosting/ansible-role-woodpecker-ci-server/pull/5 and its new release.