### PR TITLE
Downgrade rumqttd (v0.21.0-0 → v0.19.0-1)

### DIFF
--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -437,7 +437,7 @@
   name: roundcube
   activation_prefix: roundcube_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-rumqttd.git
-  version: v0.21.0-0
+  version: v0.19.0-1
   name: rumqttd
   activation_prefix: rumqttd_
 - src: git+https://git.sergiodj.net/sergiodj/ansible-role-searxng.git


### PR DESCRIPTION
See https://github.com/mother-of-all-self-hosting/ansible-role-rumqttd/commit/7d6be1f17c34562c82d923b2c8d3b43c5f943992 and https://hub.docker.com/r/bytebeamio/rumqttd/tags