### PR TITLE
Upgrade echoip (v0.0.0-1 → v0.0.0-2)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2417,11 +2417,6 @@ echoip_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_d
 echoip_uid: "{{ mash_playbook_uid }}"
 echoip_gid: "{{ mash_playbook_gid }}"
 
-echoip_systemd_required_services_list: |
-  {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-  }}
-
 echoip_container_additional_networks: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -105,7 +105,7 @@
   name: dokuwiki
   activation_prefix: dokuwiki_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-echoip.git
-  version: v0.0.0-1
+  version: v0.0.0-2
   name: echoip
   activation_prefix: echoip_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-endlessh.git


### PR DESCRIPTION
`echoip_systemd_required_services_list` is taken care of by https://github.com/mother-of-all-self-hosting/ansible-role-echoip/blob/468e73a8ca61eaa8a253fb536b41cc23fc7172af/defaults/main.yml#L157.