### PR TITLE
Replace `roundcube_systemd_required_systemd_services_list`

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -7130,10 +7130,8 @@ roundcube_gid: "0"
 
 roundcube_database_type: "{{ 'postgresql' if postgres_enabled else 'sqlite' }}"
 
-roundcube_systemd_required_systemd_services_list: |
+roundcube_systemd_required_services_list_auto: |
   {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
     ([postgres_identifier ~ '.service'] if postgres_enabled and roundcube_database_hostname == postgres_identifier else [])
   }}
 


### PR DESCRIPTION
Replace `roundcube_systemd_required_systemd_services_list` with `roundcube_systemd_required_services_list_auto`

`roundcube_systemd_required_systemd_services_list` does not seem to have been used.