### PR TITLE
Upgrade OxiTraffic (v0.10.1-0 → v0.10.1-1)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -6151,10 +6151,8 @@ oxitraffic_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_ba
 oxitraffic_uid: "{{ mash_playbook_uid }}"
 oxitraffic_gid: "{{ mash_playbook_gid }}"
 
-oxitraffic_systemd_required_services_list: |
+oxitraffic_systemd_required_services_list_auto: |
   {{
-    ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
-    +
     ([postgres_identifier ~ '.service'] if postgres_enabled and oxitraffic_database_hostname == postgres_identifier else [])
   }}
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -337,7 +337,7 @@
   name: owncast
   activation_prefix: owncast_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-oxitraffic.git
-  version: v0.10.1-0
+  version: v0.10.1-1
   name: oxitraffic
   activation_prefix: oxitraffic_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-paperless.git


### PR DESCRIPTION
- Use `oxitraffic_systemd_required_services_list_auto` on `group_vars_mash_servers`