### PR TITLE
Replace "neko" with "Neko"

### DIFF
--- a/docs/services/neko.md
+++ b/docs/services/neko.md
@@ -1,9 +1,9 @@
-# n.eko
+# Neko
 
-[n.eko](https://neko.m1k1o.net/) is a self-hosted virtual browser, that this playbook can install, powered by the [mother-of-all-self-hosting/ansible-role-neko](https://github.com/mother-of-all-self-hosting/ansible-role-neko) Ansible role.
+[Neko](https://neko.m1k1o.net/) is a self-hosted virtual browser, that this playbook can install, powered by the [mother-of-all-self-hosting/ansible-role-neko](https://github.com/mother-of-all-self-hosting/ansible-role-neko) Ansible role.
 
 > [!WARNING]
-> The neko service will run in a container with root privileges, no dropped capabilities and will be able to write inside the container. This seems to be a neccessary deviation from the usual security standards in this playbook.
+> The Neko service will run in a container with root privileges, no dropped capabilities and will be able to write inside the container. This seems to be a neccessary deviation from the usual security standards in this playbook.
 
 ## Dependencies
 
@@ -37,11 +37,10 @@ neko_password_admin: 'SUPER_SECURE_PASSWORD'
 
 ## Advanced configuration
 
-There are different flavours of neko and while `firefox` is the default, you can try others by setting
+There are different flavours of Neko and while `firefox` is the default, you can try others by setting
 
 ```yaml
 neko_version: "kde"
 ```
 
 All available tags can be found on [Dockerhub](https://hub.docker.com/r/m1k1o/neko/tags)
-

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -89,7 +89,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Mosquitto](https://mosquitto.org/) | An open-source MQTT broker | [Link](services/mosquitto.md) |
 | [n8n](https://n8n.io/) | Workflow automation for technical people. | [Link](services/n8n.md) |
 | [Navidrome](https://www.navidrome.org/) | [Subsonic-API](http://www.subsonic.org/pages/api.jsp) compatible music server | [Link](services/navidrome.md)
-| [n.eko](https://neko.m1k1o.net/) | A self-hosted virtual browser or even desktop environment | [Link](services/neko.md) |
+| [Neko](https://neko.m1k1o.net/) | A self-hosted virtual browser or even desktop environment | [Link](services/neko.md) |
 | [NetBox](https://docs.netbox.dev/en/stable/) | Web application that provides [IP address management (IPAM)](https://en.wikipedia.org/wiki/IP_address_management) and [data center infrastructure management (DCIM)](https://en.wikipedia.org/wiki/Data_center_management#Data_center_infrastructure_management) functionality | [Link](services/netbox.md) |
 | [Nextcloud](https://nextcloud.com/) | The most popular self-hosted collaboration solution for tens of millions of users at thousands of organizations across the globe. | [Link](services/nextcloud.md) |
 | [Notfellchen](https://codeberg.org/moanos/notfellchen) | Self-hosted tool to list animals available for adoption to increase their chance of finding a forever-home | [Link](services/notfellchen.md) |


### PR DESCRIPTION
While on the GitHub repository it is called inconsistently as "n.eko", "neko", and "Neko", it is called consistently as "Neko" on its official website (except its title), so it should be sensible to call it as "Neko" following the latter.