### PR TITLE
Upgrade FMD Server (v0.10.0-5 → v0.11.0-0)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2698,8 +2698,9 @@ fmd_server_identifier: "{{ mash_playbook_service_identifier_prefix }}findmydevic
 
 fmd_server_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}findmydeviceserver"
 
-fmd_server_uid: "{{ mash_playbook_uid }}"
-fmd_server_gid: "{{ mash_playbook_gid }}"
+# Running with mash_playbook_uid and mash_playbook_gid returns permission errors.
+fmd_server_uid: 1000
+fmd_server_gid: 1000
 
 fmd_server_container_additional_networks_auto: |
   {{

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -137,7 +137,7 @@
   name: firezone
   activation_prefix: firezone_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-fmd-server.git
-  version: v0.10.0-5
+  version: v0.11.0-0
   name: fmd_server
   activation_prefix: fmd_server_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-focalboard.git


### PR DESCRIPTION
I managed to have the upgraded version run with UID and GID set to 1000, but due to my lack of knowledge I am not sure if it is optimal or not.

Relevant information:
- https://gitlab.com/fmd-foss/fmd-server/-/commit/61dd086eb28b26eef54503df3dd60dd44eb46b54
- https://gitlab.com/fmd-foss/fmd-server#self-hosting-with-docker-compose

Please let me know if there is another better way.