### PR TITLE
Add renovate.json for packages released under Devture and MASH

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommitsDisabled"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "ignoreUnstable": false,
+      "matchSourceUrls": [
+        "https://github.com/devture/com.devture.ansible.role{/,}**",
+        "https://github.com/mother-of-all-self-hosting{/,}**"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Not tested, but hopefully it should work like https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/4328.

It might be probably worth documenting that this would only detect updates released under  `https://github.com/devture/com.devture.ansible.role/` and `https://github.com/mother-of-all-self-hosting/`, along with the hint that URLs for repositories outside of them could be included to `matchSourceUrls` if Renovate should find updates for the external repositories too.

