### PR TITLE
Update forgejo.md

### DIFF
--- a/docs/services/forgejo.md
+++ b/docs/services/forgejo.md
@@ -33,14 +33,6 @@ To enable this service, add the following configuration to your `vars.yml` file 
 
 forgejo_enabled: true
 
-# Forgejo uses port 22 by default.
-# We recommend that you move your regular SSH server to another port,
-# and stick to this default.
-#
-# If you wish to use another port, uncomment the variable below
-# and adjust the port as you see fit.
-# forgejo_ssh_port: 222
-
 forgejo_hostname: mash.example.com
 forgejo_path_prefix: /forgejo
 
@@ -55,6 +47,17 @@ In the example configuration above, we configure the service to be hosted at `ht
 
 You can remove the `forgejo_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
 
+### Configure SSH port for Forgejo (optional)
+
+Forgejo uses port 22 for its SSH feature by default.
+
+We recommend you to move your regular SSH server to another port, and stick to this default for your Forgejo instace.
+
+If you wish to have the instance listen to another port, add the following configuration to your `vars.yml` file and adjust the port as you see fit.
+
+```yaml
+forgejo_ssh_port: 222
+```
 
 ## Usage
 

--- a/docs/services/forgejo.md
+++ b/docs/services/forgejo.md
@@ -43,9 +43,7 @@ forgejo_path_prefix: /forgejo
 ########################################################################
 ```
 
-In the example configuration above, we configure the service to be hosted at `https://mash.example.com/forgejo`.
-
-You can remove the `forgejo_path_prefix` variable definition, to make it default to `/`, so that the service is served at `https://mash.example.com/`.
+You can remove the `forgejo_path_prefix` variable definition, to make it default to `/`, so that the service is served at https://mash.example.com/.
 
 ### Configure SSH port for Forgejo (optional)
 
@@ -61,17 +59,15 @@ forgejo_ssh_port: 222
 
 ## Usage
 
-After installation, you should be able to access your new Forgejo instance at the configured URL (see above).
+After installation, you should be able to access your new Forgejo instance at the configured URL, specified as https://mash.example.com/forgejo in the example configuration above.
 
 Going there, you'll be taken to the initial setup wizard, which will let you assign some paswords and other configuration.
-
 
 ## Recommended other services
 
 You may also wish to look into [Woodpecker CI](woodpecker-ci.md) and [Forgejo Runner](forgejo-runner.md), which can integrate nicely with Forgejo.
 
-
-## Integration with Woodpecker CI
+### Integration with Woodpecker CI
 
 If you want to integrate Forgejo with [Woodpecker CI](woodpecker-ci.md), and if you plan to serve Woodpecker CI under a subpath on the same host as Forgejo (e.g., Forgejo lives at `https://mash.example.com` and Woodpecker CI lives at `https://mash.example.com/ci`), then you need to configure Forgejo to use the host's external IP when invoking webhooks from Woodpecker CI. You can do it by setting the following variables:
 


### PR DESCRIPTION
- Move the instruction for SSH configuration to its own section — I've missed the description when setting up a Forgejo instance for the first time
- Organize section hierarchy