### PR TITLE
Add versioning=semver to renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   "packageRules": [
     {
       "ignoreUnstable": false,
+      "versioning": "semver",
       "matchSourceUrls": [
         "https://github.com/devture/com.devture.ansible.role{/,}**",
         "https://github.com/mother-of-all-self-hosting{/,}**"


### PR DESCRIPTION
Semver is specified to versioning, as it allows to denote a pre-release version by appending a hyphen. See the commit's comment for details.

Please note that it often causes rate-limiting by Renovate side to avoid creating a bunch PRs. In this case it should be wise to run agru to update requirements.yml locally.