### PR TITLE
Update renovate.json: replace versioning=semver with versioning=loose

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "packageRules": [
     {
       "ignoreUnstable": false,
-      "versioning": "semver",
+      "versioning": "loose",
       "matchSourceUrls": [
         "https://github.com/devture/com.devture.ansible.role{/,}**",
         "https://github.com/mother-of-all-self-hosting{/,}**"


### PR DESCRIPTION
On renovate.json are there roles which do not follow SemVer strictly, and it has stopped the likes of `clickhouse` and `radicale` from being correctly detected. The documentation at Renovate explains that `loose` versioning could be used as a fallback for SemVer. With `loose`, it also looks like roles which do not have .PATCH version can be detected as well, such as `healthchecks` (v3.10-2) and `jitsi` (v10314-1).

References:
- https://docs.renovatebot.com/modules/versioning/loose/
- https://docs.renovatebot.com/configuration-options/#versioning

Here is the list of roles to be detected with this PR:

<details><summary>ansible-galaxy</summary>
<blockquote>

<details><summary>templates/requirements.yml</summary>

 - `adguard_home v0.107.63-0`
 - `anonymousoverflow v2024.8.23-5`
 - `apisix_dashboard v3.0.1-5`
 - `apisix_gateway v3.8.0-7`
 - `appsmith v1.53.1-5`
 - `authelia v4.37.5-5`
 - `authentik v2025.6.3-0`
 - `autobrr v1.63.1-0`
 - `auxiliary v1.0.0-5`
 - `backup_borg v1.4.1-1.9.14-0`
 - `calibre-web v0.6.24-1`
 - `changedetection v0.50.5-0`
 - `clickhouse v25.6.2.5-0`
 - `container_socket_proxy v0.3.0-5`
 - `convertx v0.14.1-0`
 - `couchdb v3.4.3-0`
 - `docker 7.4.7`
 - `docker_registry v2.8.3-10`
 - `docker_registry_browser v1.8.3-2`
 - `docker_registry_proxy v1.2.7-1`
 - `docker_registry_purger v1.0.0-1`
 - `docmost v0.21.0-0`
 - `dokuwiki v2025-05-14a-1`
 - `echoip v0.0.0-5`
 - `endlessh v2024.1106.0-4`
 - `etcd v3.6.1-0`
 - `etherpad v2.3.0-2`
 - `excalidraw v2025.4.15-3`
 - `exim_relay v4.98.1-r0-2-0`
 - `firezone v0.7.36-3`
 - `fmd_server v0.11.0-3`
 - `focalboard v7.10.4-6`
 - `forgejo v11.0.2-0`
 - `forgejo_runner v6.3.1-0`
 - `freescout v1.17.124-0`
 - `freshrss v2.6.0`
 - `funkwhale v1.4.0-9`
 - `ghostfolio v2.175.0-0`
 - `gitea v1.23.8-0`
 - `gotosocial v0.19.1-4`
 - `grafana v11.6.3-0`
 - `headscale v0.26.1-0`
 - `healthchecks v3.10-2`
 - `homarr v1.26.0-0`
 - `hubsite v1.29.0-1`
 - `ihatemoney v6.1.5-10`
 - `ilmo v1.0.4-0`
 - `infisical v0.43.19-0`
 - `influxdb v2.7.6-1`
 - `jackett v0.22.2029-0`
 - `jellyfin v10.10.7-0`
 - `jitsi v10314-1`
 - `joplin_server v3.3.13-2`
 - `keycloak v26.2.5-1`
 - `keydb v6.3.4-6`
 - `labelstudio v1.0.0-4`
 - `lago v0.50.0-1`
 - `languagetool v6.6-1`
 - `linkding v1.41.0-1`
 - `listmonk v4.1.0-3`
 - `loki v3.5.1-1`
 - `mariadb v11.4.4-2`
 - `matomo v5.3.1-1`
 - `matterbridge v1.26.0-4`
 - `minecraft v2025.4.2-0`
 - `miniflux v2.2.10-0`
 - `mobilizon v4.1.0-0`
 - `mongodb v7.0.4-1`
 - `mosquitto v2.0.21-3`
 - `mrs v0.1.0-8`
 - `n8n v1.4.2`
 - `navidrome v0.56.1-0`
 - `neko v3.0.6-0`
 - `netbox v3.7.0-2.8.0-0`
 - `nextcloud v31.0.6-0`
 - `notfellchen v0.4.0-0`
 - `ntfy v2.11.0-8`
 - `oauth2_proxy v7.6.0-4`
 - `outline v0.84.0-1`
 - `overseerr v1.34.0-0`
 - `owncast v0.2.3-1`
 - `oxitraffic v0.10.4-3`
 - `paperless v2.15.3-2`
 - `peertube v7.1.1-3`
 - `plausible v3.0.1-3`
 - `plex v1.41.8-0`
 - `postgis v15-3.3-0`
 - `postgres v17.4-0`
 - `postgres_backup v17-4`
 - `privatebin v1.7.7-0`
 - `prometheus v3.4.2-0`
 - `prometheus_blackbox_exporter v0.26.0-5`
 - `prometheus_node_exporter v1.9.1-7`
 - `prometheus_postgres_exporter v0.17.1-4`
 - `prometheus_ssh_exporter v1.5.0-7`
 - `promtail v3.5.1-2`
 - `qbittorrent v5.1.0-2`
 - `radarr v5.26.2-0`
 - `radicale v3.5.4.0-0`
 - `reactflux v2025.6.2-2`
 - `readeck v0.19.2-0`
 - `redis v7.4.2-0`
 - `redlib v2025.4.9-3`
 - `redmine v6.0.5-0`
 - `roundcube v1.6.10-4`
 - `rumqttd v0.19.0-4`
 - `searxng v1.0-0`
 - `semaphore v2.9.56-4`
 - `send v3.4.25-4`
 - `soft_serve v0.4.7-5`
 - `sonarr v4.0.14-1`
 - `stirling_pdf v0.45.5-0`
 - `syncthing v1.29.7-0`
 - `systemd_docker_base v1.4.0-0`
 - `systemd_service_manager v1.0.0-4`
 - `tandoor v1.5.34-1`
 - `telegraf v1.30.2-4`
 - `timesync v1.0.0-0`
 - `traefik v3.4.3-0`
 - `tsdproxy v1.4.7-0`
 - `uptime_kuma v1.23.16-4`
 - `valkey v8.1.2-0`
 - `vaultwarden v1.34.1-1`
 - `versatiles v0.15.3-0`
 - `wetty v2.5-0`
 - `wg_easy v15.0.0-0`
 - `woodpecker_ci_agent v3.7.0-0`
 - `woodpecker_ci_server v3.7.0-0`
 - `wordpress v6.8.1-0`
 - `writefreely v0.15.0-1`
 - `yourls v1.10.1-3`

</details>

</blockquote>
</details>

Please note that roles whose version contains leading zeros had not been detected and they cannot be detected even with `loose`, such as `v25.04.2.2.1-0` for `collabora_online`.