### PR TITLE
Upgrade Forgejo Runner to 6.4.0-2

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2910,6 +2910,8 @@ forgejo_runner_systemd_required_systemd_services_list: |
     ([devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [])
   }}
 
+forgejo_runner_docker_endpoint_is_unix_socket: "{{ false if forgejo_runner_docker_endpoint.startswith('tcp://') else true }}"
+
 ########################################################################
 #                                                                      #
 # /forgejo_runner                                                      #

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -153,7 +153,7 @@
   name: forgejo
   activation_prefix: forgejo_
 - src: git+https://git.sergiodj.net/sergiodj/ansible-role-forgejo-runner.git
-  version: v6.4.0-0
+  version: v6.4.0-2
   name: forgejo_runner
   activation_prefix: forgejo_runner_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-freescout.git


### PR DESCRIPTION
This version comes with better handling of the Docker socket.