### PR TITLE
Add syncstorage-rs (storage server for Firefox Sync)

### DIFF
--- a/docs/services/syncstorage-rs.md
+++ b/docs/services/syncstorage-rs.md
@@ -1,0 +1,107 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# YOURLS
+
+The playbook can install and configure [YOURLS](https://yourls.org) for you.
+
+YOURLS is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
+
+See the project's [documentation](https://yourls.org/docs) to learn what YOURLS does and why it might be useful to you.
+
+For details about configuring the [Ansible role for YOURLS](https://github.com/mother-of-all-self-hosting/ansible-role-yourls), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md) online
+- 📁 `roles/galaxy/yourls/docs/configuring-yourls.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+- MySQL / [MariaDB](mariadb.md) database
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# yourls                                                               #
+#                                                                      #
+########################################################################
+
+yourls_enabled: true
+
+yourls_hostname: yourls.example.com
+
+########################################################################
+#                                                                      #
+# /yourls                                                              #
+#                                                                      #
+########################################################################
+```
+
+**Notes**:
+- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the YOURLS instance is going to be hosted.
+- Hosting YOURLS under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to YOURLS's technical limitations.
+
+### Enable MariaDB
+
+You can enable a MariaDB instance by adding the following configuration:
+
+```yaml
+########################################################################
+#                                                                      #
+# mariadb                                                              #
+#                                                                      #
+########################################################################
+
+mariadb_enabled: true
+
+# Put a strong password below, generated with `pwgen -s 64 1` or in another way
+mariadb_root_password: ''
+
+########################################################################
+#                                                                      #
+# /mariadb                                                             #
+#                                                                      #
+########################################################################
+```
+
+### Set the admin username and password
+
+You also need to create an instance's user to access to the admin UI after installation. To create one, add the following configuration to your `vars.yml` file. Make sure to replace `YOUR_ADMIN_USERNAME_HERE` and `YOUR_ADMIN_PASSWORD_HERE`.
+
+```yaml
+yourls_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
+yourls_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
+```
+
+## Usage
+
+After running the command for installation, YOURLS's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
+
+First, open the page with a web browser to complete installation on the server by clicking "Install YOURLS" button. After that, click the anchor link "YOURLS Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
+
+The help file is available at `yourls.example.com/readme.html`.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/syncstorage-rs.md
+++ b/docs/services/syncstorage-rs.md
@@ -17,17 +17,16 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# YOURLS
+# syncstorage-rs
 
-The playbook can install and configure [YOURLS](https://yourls.org) for you.
+The playbook can install and configure [syncstorage-rs](https://github.com/mozilla-services/syncstorage-rs), Mozilla Sync Storage server in Rust used to power Firefox Sync, for you.
 
-YOURLS is a set of PHP scripts that will allow you to run Your Own URL Shortener, on your server.
+See the project's [documentation](https://github.com/mozilla-services/syncstorage-rs/blob/master/README.md) to learn what syncstorage-rs does and [syncstorage-rs-docker](https://codeberg.org/acioustick/syncstorage-rs-docker)'s documentation about how to set it up.
 
-See the project's [documentation](https://yourls.org/docs) to learn what YOURLS does and why it might be useful to you.
+For details about configuring the [Ansible role for syncstorage-rs](https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker), you can check them via:
 
-For details about configuring the [Ansible role for YOURLS](https://github.com/mother-of-all-self-hosting/ansible-role-yourls), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md) online
-- 📁 `roles/galaxy/yourls/docs/configuring-yourls.md` locally, if you have [fetched the Ansible roles](../installing.md)
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker/blob/main/docs/configuring-syncstorage-rs-docker.md) online
+- 📁 `roles/galaxy/syncstorage_rs_docker/docs/configuring-syncstorage-rs-docker.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -43,65 +42,31 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# yourls                                                               #
+# syncstorage-rs-docker                                                #
 #                                                                      #
 ########################################################################
 
-yourls_enabled: true
+syncstorage_rs_docker_enabled: true
 
-yourls_hostname: yourls.example.com
+syncstorage_rs_docker_hostname: syncstorage.example.com
 
 ########################################################################
 #                                                                      #
-# /yourls                                                              #
+# /syncstorage-rs-docker                                               #
 #                                                                      #
 ########################################################################
 ```
 
 **Notes**:
-- It is optionally possible to use a shorter hostname different from the main one. If doing so, make sure to point a DNS record for the domain to the server where the YOURLS instance is going to be hosted.
-- Hosting YOURLS under a subpath (by configuring the `yourls_path_prefix` variable) does not seem to be possible due to YOURLS's technical limitations.
 
-### Enable MariaDB
-
-You can enable a MariaDB instance by adding the following configuration:
-
-```yaml
-########################################################################
-#                                                                      #
-# mariadb                                                              #
-#                                                                      #
-########################################################################
-
-mariadb_enabled: true
-
-# Put a strong password below, generated with `pwgen -s 64 1` or in another way
-mariadb_root_password: ''
-
-########################################################################
-#                                                                      #
-# /mariadb                                                             #
-#                                                                      #
-########################################################################
-```
-
-### Set the admin username and password
-
-You also need to create an instance's user to access to the admin UI after installation. To create one, add the following configuration to your `vars.yml` file. Make sure to replace `YOUR_ADMIN_USERNAME_HERE` and `YOUR_ADMIN_PASSWORD_HERE`.
-
-```yaml
-yourls_environment_variable_user: YOUR_ADMIN_USERNAME_HERE
-yourls_environment_variable_pass: YOUR_ADMIN_PASSWORD_HERE
-```
+- Hosting syncstorage-rs under a subpath (by configuring the `syncstorage_rs_docker_path_prefix` variable) does not seem to be possible due to syncstorage-rs's technical limitations.
 
 ## Usage
 
-After running the command for installation, YOURLS's admin UI is available at the specified hostname with `/admin/` such as `yourls.example.com/admin/`.
+After running the command for installation, syncstorage-rs becomes available at the specified hostname such as `syncstorage.example.com`.
 
-First, open the page with a web browser to complete installation on the server by clicking "Install YOURLS" button. After that, click the anchor link "YOURLS Administration Page" to log in with the username (`yourls_environment_variable_user`) and password (`yourls_environment_variable_pass`).
-
-The help file is available at `yourls.example.com/readme.html`.
+See [this section](https://codeberg.org/acioustick/syncstorage-rs-docker/src/branch/main#adjusting-firefox-setting) on the documentation for details about how to configure Firefox to have it use your server for data synchronization.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-yourls/blob/main/docs/configuring-yourls.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker/blob/main/docs/configuring-syncstorage-rs-docker.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/syncstorage-rs.md
+++ b/docs/services/syncstorage-rs.md
@@ -28,6 +28,9 @@ For details about configuring the [Ansible role for syncstorage-rs](https://gith
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker/blob/main/docs/configuring-syncstorage-rs-docker.md) online
 - 📁 `roles/galaxy/syncstorage_rs_docker/docs/configuring-syncstorage-rs-docker.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
+>[!NOTE]
+> The role is configured to build the Docker image by default, as it is not provided by the upstream project. Before proceeding, make sure that the machine which you are going to run the Ansible commands against has sufficient computing power to build it.
+
 ## Dependencies
 
 This service requires the following other services:

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -131,6 +131,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Soft Serve](https://github.com/charmbracelet/soft-serve) | A tasty, self-hostable [Git](https://git-scm.com/) server for the command line | [Link](services/soft-serve.md) |
 | [Sonarr](https://sonarr.tv/) | A smart PVR for newsgroup and bittorrent users | [Link](services/sonarr.md) |
 | [Stirling PDF](https://github.com/Stirling-Tools/Stirling-PDF) | A self-hosted PDF converter | [Link](services/stirling-pdf.md) |
+| [syncstorage-rs](https://github.com/mozilla-services/syncstorage-rs) | Mozilla Sync Storage server in Rust, used to power Firefox Sync | [Link](services/syncstorage-rs.md) |
 | [Syncthing](https://syncthing.net/) | A continuous file synchronization program which synchronizes files between two or more computers in real time | [Link](services/syncthing.md) |
 | [Tandoor](https://docs.tandoor.dev/) | The recipe manager that allows you to manage your ever growing collection of digital recipes.| [Link](services/tandoor.md)
 | [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) | An open source server agent to help you collect metrics from your stacks, sensors, and systems. | [Link](services/telegraf.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -700,6 +700,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (stirling_pdf_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'stirling_pdf']} if stirling_pdf_enabled else omit) }}
   # /role-specific:stirling_pdf
 
+  # role-specific:syncstorage_rs_docker
+  - |-
+    {{ ({'name': (syncstorage_rs_docker_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'syncstorage-rs-docker']} if syncstorage_rs_docker_enabled else omit) }}
+  # /role-specific:syncstorage_rs_docker
+
   # role-specific:syncthing
   - |-
     {{ ({'name': (syncthing_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'syncthing']} if syncthing_enabled else omit) }}
@@ -5352,6 +5357,26 @@ mash_playbook_mariadb_managed_databases_auto_itemized:
     }}
   # /role-specific:privatebin
 
+  # role-specific:syncstorage_rs_docker
+  - |-
+    {{
+      ({
+        'name': syncstorage_rs_docker_environment_variable_database_name_syncstorage,
+        'username': syncstorage_rs_docker_environment_variable_database_username,
+        'password': syncstorage_rs_docker_environment_variable_mysql_password,
+      } if syncstorage_rs_docker_enabled and syncstorage_rs_docker_environment_variable_database_hostname == mariadb_identifier else omit)
+    }}
+
+  - |-
+    {{
+      ({
+        'name': syncstorage_rs_docker_environment_variable_database_name_tokenserver,
+        'username': syncstorage_rs_docker_environment_variable_database_username,
+        'password': syncstorage_rs_docker_environment_variable_mysql_password,
+      } if syncstorage_rs_docker_enabled and syncstorage_rs_docker_environment_variable_database_hostname == mariadb_identifier else omit)
+    }}
+  # /role-specific:syncstorage_rs_docker
+
   # role-specific:wordpress
   - |-
     {{
@@ -7570,6 +7595,60 @@ stirling_pdf_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver
 #                                                                      #
 ########################################################################
 # /role-specific:stirling_pdf
+
+
+
+# role-specific:syncstorage_rs_docker
+########################################################################
+#                                                                      #
+# syncstorage-rs-docker                                                #
+#                                                                      #
+########################################################################
+
+syncstorage_rs_docker_enabled: false
+
+syncstorage_rs_docker_identifier: "{{ mash_playbook_service_identifier_prefix }}syncstorage-rs-docker"
+
+syncstorage_rs_docker_uid: "{{ mash_playbook_uid }}"
+syncstorage_rs_docker_gid: "{{ mash_playbook_gid }}"
+
+syncstorage_rs_docker_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}syncstorage-rs-docker"
+
+syncstorage_rs_docker_systemd_required_services_list_auto: |
+  {{
+    ([mariadb_identifier ~ '.service'] if mariadb_enabled and syncstorage_rs_docker_environment_variable_database_hostname == mariadb_identifier else [])
+  }}
+
+syncstorage_rs_docker_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([mariadb_container_network] if mariadb_enabled and syncstorage_rs_docker_environment_variable_database_hostname == mariadb_identifier and syncstorage_rs_docker_container_network != mariadb_container_network else [])
+  }}
+
+syncstorage_rs_docker_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+syncstorage_rs_docker_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+syncstorage_rs_docker_environment_variable_sync_master_secret: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'syncmaster', rounds=655555)) | b64encode | truncate(length=64, killwords=True, end='', leeway=None) }}"
+syncstorage_rs_docker_environment_variable_metrics_hash_secret: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'synchash', rounds=655555)) | b64encode | truncate(length=64, killwords=True, end='', leeway=None) }}"
+
+# role-specific:mariadb
+syncstorage_rs_docker_environment_variable_database_username: "{{ syncstorage_rs_docker_identifier }}"
+syncstorage_rs_docker_environment_variable_database_hostname: "{{ mariadb_identifier if mariadb_enabled else '' }}"
+syncstorage_rs_docker_environment_variable_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.syncstorage', rounds=655555) | to_uuid }}"
+# /role-specific:mariadb
+
+# role-specific:traefik
+syncstorage_rs_docker_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+syncstorage_rs_docker_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /syncstorage-rs-docker                                               #
+#                                                                      #
+########################################################################
+# /role-specific:syncstorage_rs_docker
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -488,6 +488,10 @@
   version: abfb18b6862108bbf24347500446203170324d7f
   name: swap
   activation_prefix: system_swap_
+- src: https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker.git
+  version: v0.18.3-0
+  name: syncstorage_rs_docker
+  activation_prefix: syncstorage_rs_docker_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-syncthing.git
   version: v1.30.0-1
   name: syncthing

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -533,6 +533,10 @@
     - role: galaxy/stirling_pdf
     # /role-specific:stirling_pdf
 
+    # role-specific:syncstorage_rs_docker
+    - role: galaxy/syncstorage_rs_docker
+    # /role-specific:syncstorage_rs_docker
+
     # role-specific:syncthing
     - role: galaxy/syncthing
     # /role-specific:syncthing


### PR DESCRIPTION
This PR intends to add [*syncstorage-rs*](https://github.com/mozilla-services/syncstorage-rs), Mozilla Sync Storage server in Rust used to power Firefox Sync, based on [ansible-role-syncstorage-rs-docker](https://github.com/mother-of-all-self-hosting/ansible-role-syncstorage-rs-docker.git), which implements https://codeberg.org/acioustick/syncstorage-rs-docker (based on https://github.com/dan-r/syncstorage-rs-docker).

Please note that setting up your own Firefox Account server is out of scope of the role, and it seems to require a lot of work to implement it judging from an implementation like https://github.com/jackyzy823/fxa-selfhosting.

I've tested building the image on a VPS and synchronizing data between Firefox profiles on my local computer, logging in to the official Firefox Account server.