### PR TITLE
Add Excalidraw's collaboration server (ansible-role-excalidraw-room)

### DIFF
--- a/docs/services/excalidraw-room.md
+++ b/docs/services/excalidraw-room.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Excalidraw
+
+The playbook can install and configure the [Excalidraw](https://excalidraw.com/) client for you.
+
+Excalidraw is a free and open source virtual whiteboard for sketching hand-drawn like diagrams. It saves data locally on the browser, and the data is end-to-end encrypted.
+
+See the project's [documentation](https://docs.excalidraw.com/) to learn what it does and why it might be useful to you.
+
+For details about configuring the [Ansible role for the server](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw/blob/main/docs/configuring-excalidraw.md) online
+- 📁 `roles/galaxy/excalidraw/docs/configuring-excalidraw.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# excalidraw                                                           #
+#                                                                      #
+########################################################################
+
+excalidraw_enabled: true
+
+excalidraw_hostname: excalidraw.example.com
+
+########################################################################
+#                                                                      #
+# /excalidraw                                                          #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting Excalidraw client under a subpath (by configuring the `excalidraw_path_prefix` variable) does not seem to be possible due to Excalidraw's technical limitations.
+
+## Usage
+
+After installation, the Excalidraw client becomes available at the URL specified with `excalidraw_hostname`.
+
+>[!NOTE]
+> At the moment, self-hosting your own instance doesn't support sharing or collaboration features (see [here](https://docs.excalidraw.com/docs/introduction/development#self-hosting)).
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw/blob/main/docs/configuring-excalidraw.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/excalidraw-room.md
+++ b/docs/services/excalidraw-room.md
@@ -71,3 +71,7 @@ To use the collaboration server, you need to set up an Excalidraw instance built
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room/blob/main/docs/configuring-excalidraw-room.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Excalidraw](excalidraw.md) — Free and open source virtual whiteboard for sketching hand-drawn like diagrams

--- a/docs/services/excalidraw-room.md
+++ b/docs/services/excalidraw-room.md
@@ -17,17 +17,20 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Excalidraw
+# Excalidraw collaboration server
 
-The playbook can install and configure the [Excalidraw](https://excalidraw.com/) client for you.
+The playbook can install and configure an [example collaboration server](https://github.com/excalidraw/excalidraw-room) for [Excalidraw](https://excalidraw.com/) for you.
 
-Excalidraw is a free and open source virtual whiteboard for sketching hand-drawn like diagrams. It saves data locally on the browser, and the data is end-to-end encrypted.
+It enables to self-host the collaboration server for your Excalidraw's instance, which by default is configured to connect to the Excalidraw's server at `oss-collab.excalidraw.com`.
 
-See the project's [documentation](https://docs.excalidraw.com/) to learn what it does and why it might be useful to you.
+See the project's [documentation](https://github.com/excalidraw/excalidraw-room/blob/master/README.md) to learn what it does and why it might be useful to you.
 
-For details about configuring the [Ansible role for the server](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw/blob/main/docs/configuring-excalidraw.md) online
-- 📁 `roles/galaxy/excalidraw/docs/configuring-excalidraw.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for the server](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room/blob/main/docs/configuring-excalidraw-room.md) online
+- 📁 `roles/galaxy/excalidraw_room/docs/configuring-excalidraw-room.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+>[!NOTE]
+> The role is configured to build the Docker image by default, as it is not provided by the upstream project. Before proceeding, make sure that the machine which you are going to run the Ansible commands against has sufficient computing power to build it.
 
 ## Dependencies
 
@@ -42,30 +45,29 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# excalidraw                                                           #
+# excalidraw_room                                                      #
 #                                                                      #
 ########################################################################
 
-excalidraw_enabled: true
+excalidraw_room_enabled: true
 
-excalidraw_hostname: excalidraw.example.com
+excalidraw_room_hostname: "excalidraw-room.example.com"
 
 ########################################################################
 #                                                                      #
-# /excalidraw                                                          #
+# /excalidraw_room                                                     #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Excalidraw client under a subpath (by configuring the `excalidraw_path_prefix` variable) does not seem to be possible due to Excalidraw's technical limitations.
+**Note**: hosting Excalidraw collaboration server client under a subpath (by configuring the `excalidraw_room_path_prefix` variable) does not seem to be possible due to Excalidraw collaboration server's technical limitations.
 
 ## Usage
 
-After installation, the Excalidraw client becomes available at the URL specified with `excalidraw_hostname`.
+After installation, the Excalidraw collaboration server becomes available at the URL specified with `excalidraw_room_hostname`.
 
->[!NOTE]
-> At the moment, self-hosting your own instance doesn't support sharing or collaboration features (see [here](https://docs.excalidraw.com/docs/introduction/development#self-hosting)).
+To use the collaboration server, you need to set up an Excalidraw instance built for the collaboration server. See [this page](excalidraw.md) for the instruction to set up the instance with this playbook.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw/blob/main/docs/configuring-excalidraw.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room/blob/main/docs/configuring-excalidraw-room.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/excalidraw.md
+++ b/docs/services/excalidraw.md
@@ -81,3 +81,4 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ex
 ## Related services
 
 - [Docmost](docmost.md) — Open-source collaborative wiki and documentation software
+- [Excalidraw collaboration server](excalidraw-room.md) — Self-hosted collaboration server for Excalidraw instance

--- a/docs/services/excalidraw.md
+++ b/docs/services/excalidraw.md
@@ -63,8 +63,16 @@ excalidraw_hostname: excalidraw.example.com
 
 After installation, the Excalidraw client becomes available at the URL specified with `excalidraw_hostname`.
 
+### Enable a collaboration server (optional)
+
+It is optionally possible to self-host an [example collaboration server](https://github.com/excalidraw/excalidraw-room) for your instance, which by default is configured to connect to the Excalidraw's server at `oss-collab.excalidraw.com`.
+
+To set up the collaboration server with this playbook, see [this page](excalidraw-room.md) for the instruction.
+
 >[!NOTE]
-> At the moment, self-hosting your own instance doesn't support sharing or collaboration features (see [here](https://docs.excalidraw.com/docs/introduction/development#self-hosting)).
+> By enabling the collaboration server along with the Excalidraw instance, the Docker image for the instance will be built instead of downloading it — This case there will be two images to be built; one for the Excalidraw instance and the other for the collaboration server itself.
+>
+> Before enabling it, make sure that the machine which you are going to run the Ansible commands against has sufficient computing power to build it.
 
 ## Troubleshooting
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -47,6 +47,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [etcd](https://etcd.io/) | A distributed, reliable key-value store for the most critical data of a distributed system | [Link](services/etcd.md) |
 | [Etherpad](https://etherpad.org) | Open source collaborative text editor | [Link](services/etherpad.md) |
 | [Excalidraw](https://excalidraw.com/) | Virtual whiteboard for sketching hand-drawn like diagrams | [Link](services/excalidraw.md) |
+| [Excalidraw collaboration server](https://github.com/excalidraw/excalidraw-room) | Self-hosted collaboration server for Excalidraw instance | [Link](services/excalidraw-room.md) |
 | [exim-relay](https://github.com/devture/exim-relay) | A lightweight [Exim](https://www.exim.org/) SMTP mail relay server | [Link](services/exim-relay.md) |
 | [Firezone](https://www.firezone.dev/) | A self-hosted VPN server (based on [WireGuard](https://www.wireguard.com/)) with a Web UI | [Link](services/firezone.md) |
 | [FMD Server](https://gitlab.com/fmd-foss/fmd-server) | Official server for FMD (FindMyDevice) | [Link](services/fmd-server.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -234,6 +234,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (excalidraw_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'excalidraw']} if excalidraw_enabled else omit) }}
   # /role-specific:excalidraw
 
+  # role-specific:excalidraw_room
+  - |-
+    {{ ({'name': (excalidraw_room_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'excalidraw_room']} if excalidraw_room_enabled else omit) }}
+  # /role-specific:excalidraw_room
+
   # role-specific:exim_relay
   - |-
     {{ ({'name': (exim_relay_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'exim-relay']} if exim_relay_enabled else omit) }}
@@ -2657,6 +2662,10 @@ excalidraw_container_additional_networks_auto: |
 excalidraw_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
 excalidraw_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
 
+# role-specific:excalidraw_room
+excalidraw_container_image_self_build: true # Building the image is necessary for using the self-hosted collaboration server
+# /role-specific:excalidraw_room
+
 # role-specific:traefik
 excalidraw_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 excalidraw_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
@@ -2668,6 +2677,44 @@ excalidraw_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_p
 #                                                                      #
 ########################################################################
 # /role-specific:excalidraw
+
+
+
+# role-specific:excalidraw_room
+########################################################################
+#                                                                      #
+# excalidraw_room                                                      #
+#                                                                      #
+########################################################################
+
+excalidraw_room_enabled: false
+
+excalidraw_room_identifier: "{{ mash_playbook_service_identifier_prefix }}excalidraw-room"
+
+excalidraw_room_uid: "{{ mash_playbook_uid }}"
+excalidraw_room_gid: "{{ mash_playbook_gid }}"
+
+excalidraw_room_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}excalidraw-room"
+
+excalidraw_room_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+excalidraw_room_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+excalidraw_room_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+excalidraw_room_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+excalidraw_room_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /excalidraw_room                                                     #
+#                                                                      #
+########################################################################
+# /role-specific:excalidraw_room
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -128,6 +128,10 @@
   version: v2025.6.15-0
   name: excalidraw
   activation_prefix: excalidraw_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room.git
+  version: v2023.12.15-0
+  name: excalidraw_room
+  activation_prefix: excalidraw_room_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
   version: v4.98.1-r0-2-0
   name: exim_relay

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -205,6 +205,10 @@
     - role: galaxy/excalidraw
     # /role-specific:excalidraw
 
+    # role-specific:excalidraw_room
+    - role: galaxy/excalidraw_room
+    # /role-specific:excalidraw_room
+
     # role-specific:firezone
     - role: galaxy/firezone
     # /role-specific:firezone


### PR DESCRIPTION
This intends to add Excalidraw's collaboration server, [whose role](https://github.com/mother-of-all-self-hosting/ansible-role-excalidraw-room/) was implemented referring to an unofficial instruction at https://github.com/excalidraw/excalidraw/issues/4993#issuecomment-1783669768.

Note that enabling the collaboration server has two Docker images self-built on the machine — one for the Excalidraw and the other for the collaboration server itself. Some tiny machines might struggle to build them.