### PR TITLE
Add Duplicati

### DIFF
--- a/docs/services/backup-borg.md
+++ b/docs/services/backup-borg.md
@@ -17,3 +17,7 @@ BorgBackup is a deduplicating backup program with optional compression and encry
 The [Ansible role for BorgBackup](https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg) is developed and maintained by the MASH project. For details about configuring BorgBackup, you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-backup_borg/blob/main/docs/configuring-backup-borg.md) online
 - 📁 `roles/galaxy/backup_borg/docs/configuring-backup-borg.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Related services
+
+- [Duplicati](duplicati.md) — Backup software that securely stores encrypted, incremental, compressed backups on local storage, cloud storage services and remote file servers

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# AnonymousOverflow
+
+The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+
+AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+
+See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+
+For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
+- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# anonymousoverflow                                                    #
+#                                                                      #
+########################################################################
+
+anonymousoverflow_enabled: true
+
+anonymousoverflow_hostname: anonymousoverflow.example.com
+
+########################################################################
+#                                                                      #
+# /anonymousoverflow                                                   #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+
+## Usage
+
+After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -19,15 +19,20 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Duplicati
 
-The playbook can install and configure [Duplicati](https://github.com/httpjamesm/Duplicati) for you.
+The playbook can install and configure [Duplicati](https://duplicati.com) for you.
 
-Duplicati allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Duplicati is a backup software that securely stores encrypted, incremental, compressed backups on local storage, cloud storage services and remote file servers. It works with standard protocols like FTP, SSH, WebDAV as well as popular services like Microsoft OneDrive, Amazon S3 (compatible) Object Storage, Google Drive, box.com, Mega, B2, and many others.
 
-See the project's [documentation](https://github.com/httpjamesm/Duplicati/blob/main/README.md) to learn what Duplicati does and why it might be useful to you.
+See the project's [documentation](https://docs.duplicati.com) to learn what Duplicati does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Duplicati](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md) online
 - 📁 `roles/galaxy/duplicati/docs/configuring-duplicati.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+>[!NOTE]
+> As the Duplicati instance runs as the Docker container, it is necessary to mount the directory which includes files to back up on the host machine. Note that it is not able for the container to access files **outside of the mounted directory**.
+>
+> If you wish to manage a backup of directories on the machine without such restriction, you might probably want to consider to install Duplicati directly on the host machine. See [this page on the official documentation](https://docs.duplicati.com/getting-started/installation) for details.
 
 ## Dependencies
 
@@ -59,13 +64,39 @@ duplicati_hostname: duplicati.example.com
 
 **Note**: hosting Duplicati under a subpath (by configuring the `duplicati_path_prefix` variable) does not seem to be possible due to Duplicati's technical limitations.
 
+### Mount a directory for files to backup
+
+You can mount the directory by adding the following configuration to your `vars.yml` file:
+
+```yaml
+duplicati_source_path: /path/on/the/host
+```
+
+Make sure permissions and owner of the directory specified to `duplicati_source_path`.
+
+For example, you can mount the default directory used by the playbook (`/mash`) by adding the following configuration:
+
+```yaml
+duplicati_source_path: /mash
+```
+
+### Set a password for the UI
+
+You also need to set a log in password on the web UI by adding the following configuration to your `vars.yml` file:
+
+```yaml
+duplicati_environment_variable_duplicati__webservice_password: YOUR_WEBUI_PASSWORD_HERE
+```
+
+Replace `YOUR_WEBUI_PASSWORD_HERE` with your own value.
+
 ## Usage
 
 After running the command for installation, Duplicati becomes available at the specified hostname like `https://duplicati.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Duplicati. See [this section](https://github.com/httpjamesm/Duplicati/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-duplicati-automatically) on the official documentation for more information.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md#usage) for details about setting up a backup task.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Duplicati) to add yours to [`instances.json`](https://github.com/httpjamesm/Duplicati/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+⚠️ When setting the Source Data option, **choose `source` or directories inside it** as the backup source.
 
 ## Troubleshooting
 

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -17,17 +17,17 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# AnonymousOverflow
+# Duplicati
 
-The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+The playbook can install and configure [Duplicati](https://github.com/httpjamesm/Duplicati) for you.
 
-AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Duplicati allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
 
-See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+See the project's [documentation](https://github.com/httpjamesm/Duplicati/blob/main/README.md) to learn what Duplicati does and why it might be useful to you.
 
-For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
-- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Duplicati](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md) online
+- 📁 `roles/galaxy/duplicati/docs/configuring-duplicati.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -42,31 +42,31 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# anonymousoverflow                                                    #
+# duplicati                                                            #
 #                                                                      #
 ########################################################################
 
-anonymousoverflow_enabled: true
+duplicati_enabled: true
 
-anonymousoverflow_hostname: anonymousoverflow.example.com
+duplicati_hostname: duplicati.example.com
 
 ########################################################################
 #                                                                      #
-# /anonymousoverflow                                                   #
+# /duplicati                                                           #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+**Note**: hosting Duplicati under a subpath (by configuring the `duplicati_path_prefix` variable) does not seem to be possible due to Duplicati's technical limitations.
 
 ## Usage
 
-After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Duplicati becomes available at the specified hostname like `https://duplicati.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Duplicati. See [this section](https://github.com/httpjamesm/Duplicati/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-duplicati-automatically) on the official documentation for more information.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Duplicati) to add yours to [`instances.json`](https://github.com/httpjamesm/Duplicati/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -120,3 +120,7 @@ Since the default report message is fairly verbose, you might probably want to c
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [BorgBackup](backup-borg.md) — Deduplicating backup program with optional compression and encryption

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -98,6 +98,25 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-du
 
 ⚠️ When setting the Source Data option, **choose `source` or directories inside it** as the backup source.
 
+### Configure the SMTP mailer (optional)
+
+On Duplicati you can set up the mailer to have it send reports about backup status. **You can use Exim-relay as the mailer, which is enabled on this playbook by default.** See [this page about Exim-relay configuration](exim-relay.md) for details about how to set it up.
+
+As the Duplicati instance does not support configuring the mailer with environment variables, you can add default options for it on its UI (and override them with options for each job). Refer to [this page](https://docs.duplicati.com/detailed-descriptions/sending-reports-via-email/sending-reports-with-email) on the official documentation as well about how to configure it.
+
+To set the default options, open `https://duplicati.example.com/ngax/index.html#/settings` to add the following configuration to "Default options" area (adapt to your needs):
+
+```txt
+--send-mail-from=noreply@mash.example.com
+--send-mail-to=RECIPIENT_ADDRESS_HERE
+--send-mail-url=smtp://mash-exim-relay:8025
+--send-mail-level=Warning,Error
+```
+
+Replace `noreply@mash.example.com` and `RECIPIENT_ADDRESS_HERE` with the email address which should send and receive reports, respectively. If the default Exim-relay is used, `noreply@mash.example.com` should be replaced with the one specified on your `vars.yml` file.
+
+Since the default report message is fairly verbose, you might probably want to customize it with the `send-mail-body` option.
+
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-duplicati/blob/main/docs/configuring-duplicati.md#troubleshooting) on the role's documentation for details.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -42,6 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Docker Registry Purger](https://github.com/devture/docker-registry-purger) | A small tool used for purging a private Docker Registry's old tags | [Link](services/docker-registry-purger.md) |
 | [Docmost](https://docmost.com/) | Open-source collaborative wiki and documentation software | [Link](services/docmost.md) |
 | [DokuWiki](https://dokuwiki.org/) | A lightweight, file-based wiki engine with intuitive syntax and no database requirements | [Link](services/dokuwiki.md) |
+| [Duplicati](https://duplicati.com) | Backup software that securely stores encrypted, incremental, compressed backups on local storage, cloud storage services and remote file servers | [Link](services/duplicati.md) |
 | [Echo IP](https://github.com/mpolden/echoip) | A simple service for looking up your IP address | [Link](services/echoip.md) |
 | [Endlessh-go](https://github.com/shizunge/endlessh-go) | A golang implementation of Endlessh, an SSH tarpit | [Link](services/endlessh.md) |
 | [etcd](https://etcd.io/) | A distributed, reliable key-value store for the most critical data of a distributed system | [Link](services/etcd.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2504,6 +2504,8 @@ duplicati_gid: "{{ mash_playbook_gid }}"
 duplicati_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and duplicati_container_network != exim_relay_container_network) else [])
   }}
 
 duplicati_environment_variable_settings_encryption_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.duplicati', rounds=655555) }}"

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -209,6 +209,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (dokuwiki_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'dokuwiki']} if dokuwiki_enabled else omit) }}
   # /role-specific:dokuwiki
 
+  # role-specific:duplicati
+  - |-
+    {{ ({'name': (duplicati_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'duplicati']} if duplicati_enabled else omit) }}
+  # /role-specific:duplicati
+
   # role-specific:echoip
   - |-
     {{ ({'name': (echoip_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'echoip']} if echoip_enabled else omit) }}
@@ -2477,6 +2482,46 @@ dokuwiki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:dokuwiki
+
+
+
+# role-specific:duplicati
+########################################################################
+#                                                                      #
+# duplicati                                                            #
+#                                                                      #
+########################################################################
+
+duplicati_enabled: false
+
+duplicati_identifier: "{{ mash_playbook_service_identifier_prefix }}duplicati"
+
+duplicati_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}duplicati"
+
+duplicati_uid: "{{ mash_playbook_uid }}"
+duplicati_gid: "{{ mash_playbook_gid }}"
+
+duplicati_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+duplicati_environment_variable_settings_encryption_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.duplicati', rounds=655555) }}"
+
+duplicati_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+duplicati_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+duplicati_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+duplicati_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /duplicati                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:duplicati
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -108,6 +108,10 @@
   version: v2025-05-14a-1
   name: dokuwiki
   activation_prefix: dokuwiki_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-duplicati.git
+  version: v2.1.0-0
+  name: duplicati
+  activation_prefix: duplicati_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-echoip.git
   version: v0.0.0-7
   name: echoip

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -185,6 +185,10 @@
     - role: galaxy/dokuwiki
     # /role-specific:dokuwiki
 
+    # role-specific:duplicati
+    - role: galaxy/duplicati
+    # /role-specific:duplicati
+
     # role-specific:echoip
     - role: galaxy/echoip
     # /role-specific:echoip


### PR DESCRIPTION
This intends to add [Duplicati](https://docs.duplicati.com/getting-started/set-up-a-backup-in-the-ui) (ansible-role-duplicati). I've tested it on a remote machine and confirmed its basic functions like backing up data from the server to a S3 compatible provider and sending status reports with Exim-relay. I've used Duplicati locally since some years as my personal backup solution and found it is pretty stable.

Note that the UI of Duplicati installed locally is very different from the one at app.duplicati.com whose screenshot is displayed at top page of duplicati.com — The screenshot of the former is available at https://docs.duplicati.com/getting-started/set-up-a-backup-in-the-ui.