### PR TITLE
Update variable authentik_redis_hostname` in authentik.md

### DIFF
--- a/docs/services/authentik.md
+++ b/docs/services/authentik.md
@@ -151,7 +151,7 @@ Having configured `vars.yml` for the dedicated instance, add the following confi
 # Add the base configuration as specified above
 
 # Point authentik to its dedicated Valkey instance
-authentik_redis_hostname: mash-authentik-valkey
+authentik_config_redis_hostname: mash-authentik-valkey
 
 # Make sure the authentik service (mash-authentik.service) starts after its dedicated Valkey service (mash-authentik-valkey.service)
 authentik_systemd_required_services_list_custom:
@@ -201,7 +201,7 @@ valkey_enabled: true
 # Add the base configuration as specified above
 
 # Point authentik to the shared Valkey instance
-authentik_redis_hostname: "{{ valkey_identifier }}"
+authentik_config_redis_hostname: "{{ valkey_identifier }}"
 
 # Make sure the authentik service (mash-authentik.service) starts after the shared Valkey service (mash-valkey.service)
 authentik_systemd_required_services_list_custom:


### PR DESCRIPTION
Replace `authentik_redis_hostname` in documentation in MASH with `authentik_config_redis_hostname` to match role variable.

I just got the following error when running install-all:

`failed: [thewrt.com] (item=authentik_config_redis_hostname) => {"ansible_loop_var": "item", "changed": false, "item": "authentik_config_redis_hostname", "msg": "You need to define a required configuration setting (`authentik_config_redis_hostname`)."}`

I don't know why this is only an issue now, it's not been long since I last ran an install-all, but it seems the documentation simply wasn't matching the actual variable used in the role:

https://github.com/mother-of-all-self-hosting/ansible-role-authentik/blob/main/tasks/validate_config.yml#L29
https://github.com/mother-of-all-self-hosting/ansible-role-authentik/blob/main/defaults/main.yml#L61C1-L61C32

https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/authentik.md?plain=1#L154
https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/authentik.md?plain=1#L204
