### PR TITLE
Add Tinyauth (ansible-role-tinyauth)

### DIFF
--- a/docs/services/authelia.md
+++ b/docs/services/authelia.md
@@ -204,3 +204,4 @@ To get started, open the URL with a web browser, and log in to the portal websit
 - [authentik](authentik.md) — Open-source identity provider focused on flexibility and versatility
 - [Keycloak](keycloak.md) — Open source identity and access management solution
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/authentik.md
+++ b/docs/services/authentik.md
@@ -250,3 +250,4 @@ When it comes to this playbook, tested configuration examples are described on t
 - [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
 - [Keycloak](keycloak.md) — Open source identity and access management solution
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/keycloak.md
+++ b/docs/services/keycloak.md
@@ -66,3 +66,4 @@ On each start after that, Keycloak will attempt to create the user again and rep
 - [authentik](authentik.md) — Open-source identity provider focused on flexibility and versatility
 - [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/tinyauth.md
+++ b/docs/services/tinyauth.md
@@ -17,17 +17,17 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# AnonymousOverflow
+# Tinyauth
 
-The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+The playbook can install and configure [Tinyauth](https://github.com/httpjamesm/Tinyauth) for you.
 
-AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+Tinyauth allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
 
-See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+See the project's [documentation](https://github.com/httpjamesm/Tinyauth/blob/main/README.md) to learn what Tinyauth does and why it might be useful to you.
 
-For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
-- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Tinyauth](https://github.com/mother-of-all-self-hosting/ansible-role-tinyauth), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-tinyauth/blob/main/docs/configuring-tinyauth.md) online
+- 📁 `roles/galaxy/tinyauth/docs/configuring-tinyauth.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -42,34 +42,34 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# anonymousoverflow                                                    #
+# tinyauth                                                             #
 #                                                                      #
 ########################################################################
 
-anonymousoverflow_enabled: true
+tinyauth_enabled: true
 
-anonymousoverflow_hostname: anonymousoverflow.example.com
+tinyauth_hostname: tinyauth.example.com
 
 ########################################################################
 #                                                                      #
-# /anonymousoverflow                                                   #
+# /tinyauth                                                            #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+**Note**: hosting Tinyauth under a subpath (by configuring the `tinyauth_path_prefix` variable) does not seem to be possible due to Tinyauth's technical limitations.
 
 ## Usage
 
-After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+After running the command for installation, Tinyauth becomes available at the specified hostname like `https://tinyauth.example.com`.
 
-[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to Tinyauth. See [this section](https://github.com/httpjamesm/Tinyauth/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-tinyauth-automatically) on the official documentation for more information.
 
-If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/Tinyauth) to add yours to [`instances.json`](https://github.com/httpjamesm/Tinyauth/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-tinyauth/blob/main/docs/configuring-tinyauth.md#troubleshooting) on the role's documentation for details.
 
 ## Related services
 

--- a/docs/services/tinyauth.md
+++ b/docs/services/tinyauth.md
@@ -29,6 +29,22 @@ For details about configuring the [Ansible role for Tinyauth](https://codeberg.o
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-tinyauth/src/branch/master/docs/configuring-tinyauth.md) online
 - 📁 `roles/galaxy/tinyauth/docs/configuring-tinyauth.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
+## Prerequisites
+
+💡 *If you intend to enable logging in via OAuth only, you can skip this step.*
+
+The Tinyauth service requires at least one user to have been created and specified for a successful launch, unless logging in with a user is disabled in favor of OAuth.
+
+You can generate a first user with its TOTP secret by running the command below:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=create-user-tinyauth -e username=USERNAME_HERE -e password=RAW_PASSWORD_HERE
+```
+
+Then, specify the output to the `tinyauth_environment_variables_users` environment variable on your `vars.yml` file.
+
+Refer to [this section](https://codeberg.org/acioustick/ansible-role-tinyauth/src/branch/master/docs/configuring-tinyauth.md#prerequisites) on the role's documentation for details.
+
 ## Dependencies
 
 This service requires the following other services:
@@ -60,28 +76,26 @@ tinyauth_hostname: tinyauth.example.com
 ########################################################################
 ```
 
-With this configuration, Tinyauth will set a cookie for `.example.com` for authentication. This means that all your services to be authenticated will need to be under this domain. See [this section](https://tinyauth.app/docs/getting-started/#set-up-the-domains) on the official documentation for details.
+With this configuration, Tinyauth will set a cookie for `.example.com` for authentication. Note that all your services to be authenticated will need to be under this domain. See [this section](https://tinyauth.app/docs/getting-started/#set-up-the-domains) on the official documentation for details.
 
 **Note**: hosting Tinyauth under a subpath (by configuring the `tinyauth_path_prefix` variable) does not seem to be possible due to Tinyauth's technical limitations.
+
+### Configuring OAuth (optional)
+
+If you skipped creating a user to use OAuth authentication only, you can configure authentication with your OAuth provider by following the instruction available on [this section](https://codeberg.org/acioustick/ansible-role-tinyauth/src/branch/master/docs/configuring-tinyauth.md#oauth) of the role's documentation.
+
+>[!NOTE]
+> When setting OAuth configuration, make sure to set the `OAUTH_WHITELIST` environment variable to limit who is allowed to log in with OAuth. Enabling OAuth solely will not activate authorization!
 
 ## Usage
 
 After running the command for installation, the Tinyauth instance becomes available at the URL specified with `tinyauth_hostname`. With the configuration above, the service is hosted at `https://tinyauth.example.com`.
 
-Both default username and password are set to `mash`. Note that you will get a warning after finishing the installation command about the credential specified by default until setting yours, unless logging in via OAuth only is enabled.
+Open the URL `https://tinyauth.example.com` and confirm that you can log in to Tinyauth with the generated credentials or via your OAuth provider if it is enabled.
 
-See [this section](https://codeberg.org/acioustick/ansible-role-tinyauth/src/branch/master/docs/configuring-tinyauth.md#creating-a-user) on the role's documentation for details about how to create a user. Note that by default generating a time-based one-time password (TOTP) is enabled.
+### Add Traefik's labels
 
-### OAuth
-
-Tinyauth supports OAuth with Google, GitHub, and other generic OAuth providers. See [this section](https://codeberg.org/acioustick/ansible-role-tinyauth/src/branch/master/docs/configuring-tinyauth.md#oauth) on the role's documentation for details.
-
->[!NOTE]
-> When setting OAuth configuration, make sure to set the `OAUTH_WHITELIST` environment variable to limit who is allowed to log in with OAuth.
-
-### Configuring Traefik
-
-After creating the user, you can enable Tinyauth for a service by simply adding a Traefik label as below:
+You can enable Tinyauth for a service by simply adding a Traefik label as below:
 
 ```txt
 traefik.http.routers.YOUR_ROUTER_HERE.middlewares={{ tinyauth_identifier }}

--- a/docs/services/tinyauth.md
+++ b/docs/services/tinyauth.md
@@ -73,5 +73,6 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-an
 
 ## Related services
 
-- [Mozhi](mozhi.md) — Frontend for translation engines
-- [Redlib](redlib.md) — Frontend for Reddit
+- [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
+- [authentik](authentik.md) — Open-source identity provider focused on flexibility and versatility
+- [Keycloak](keycloak.md) — Open source identity and access management solution

--- a/docs/services/tinyauth.md
+++ b/docs/services/tinyauth.md
@@ -1,0 +1,77 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# AnonymousOverflow
+
+The playbook can install and configure [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow) for you.
+
+AnonymousOverflow allows you to view StackOverflow threads without exposing your IP address, browsing habits, and other browser fingerprinting data to the website.
+
+See the project's [documentation](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md) to learn what AnonymousOverflow does and why it might be useful to you.
+
+For details about configuring the [Ansible role for AnonymousOverflow](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md) online
+- 📁 `roles/galaxy/anonymousoverflow/docs/configuring-anonymousoverflow.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# anonymousoverflow                                                    #
+#                                                                      #
+########################################################################
+
+anonymousoverflow_enabled: true
+
+anonymousoverflow_hostname: anonymousoverflow.example.com
+
+########################################################################
+#                                                                      #
+# /anonymousoverflow                                                   #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting AnonymousOverflow under a subpath (by configuring the `anonymousoverflow_path_prefix` variable) does not seem to be possible due to AnonymousOverflow's technical limitations.
+
+## Usage
+
+After running the command for installation, AnonymousOverflow becomes available at the specified hostname like `https://anonymousoverflow.example.com`.
+
+[Libredirect](https://libredirect.github.io/), an extension for Firefox and Chromium-based desktop browsers, has support for redirections to AnonymousOverflow. See [this section](https://github.com/httpjamesm/AnonymousOverflow/blob/main/README.md#how-to-make-stack-overflow-links-take-you-to-anonymousoverflow-automatically) on the official documentation for more information.
+
+If you would like to publish your instance so that it can be used by anyone including Libredirect, please consider to send a PR to the [upstream project](https://github.com/httpjamesm/AnonymousOverflow) to add yours to [`instances.json`](https://github.com/httpjamesm/AnonymousOverflow/blob/main/instances.json), which Libredirect automatically fetches using a script (see [this FAQ entry](https://libredirect.github.io/faq.html#where_the_hell_are_those_instances_coming_from)).
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-anonymousoverflow/blob/main/docs/configuring-anonymousoverflow.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Mozhi](mozhi.md) — Frontend for translation engines
+- [Redlib](redlib.md) — Frontend for Reddit

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -740,6 +740,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (telegraf_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'telegraf']} if telegraf_enabled else omit) }}
   # /role-specific:telegraf
 
+  # role-specific:tinyauth
+  - |-
+    {{ ({'name': (tinyauth_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'tinyauth']} if tinyauth_enabled else omit) }}
+  # /role-specific:tinyauth
+
   # role-specific:traefik
   - |-
     {{ ({'name': (traefik_identifier + '.service'), 'priority': 250, 'groups': ['mash', 'traefik', 'reverse-proxies']} if traefik_enabled else omit) }}
@@ -8263,6 +8268,46 @@ telegraf_systemd_required_services_list_auto: |
 #                                                                      #
 ########################################################################
 # /role-specific:telegraf
+
+
+
+# role-specific:tinyauth
+########################################################################
+#                                                                      #
+# tinyauth                                                             #
+#                                                                      #
+########################################################################
+
+tinyauth_enabled: false
+
+tinyauth_identifier: "{{ mash_playbook_service_identifier_prefix }}tinyauth"
+
+tinyauth_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}tinyauth"
+
+tinyauth_uid: "{{ mash_playbook_uid }}"
+tinyauth_gid: "{{ mash_playbook_gid }}"
+
+tinyauth_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+tinyauth_environment_variables_secret: "{{ ('%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'tinyauth.s', rounds=655555)) | b64encode | truncate(length=32, killwords=True, end='', leeway=None) }}"
+
+tinyauth_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+tinyauth_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:traefik
+tinyauth_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+tinyauth_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /tinyauth                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:tinyauth
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -533,7 +533,7 @@
   name: timesync
   activation_prefix: devture_timesync_
 - src: git+https://codeberg.org/acioustick/ansible-role-tinyauth.git
-  version: v3.6.2-0
+  version: v3.6.2-1
   name: tinyauth
   activation_prefix: tinyauth_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-traefik.git

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -532,6 +532,10 @@
   version: v1.1.0-0
   name: timesync
   activation_prefix: devture_timesync_
+- src: git+https://codeberg.org/acioustick/ansible-role-tinyauth.git
+  version: v3.6.2-0
+  name: tinyauth
+  activation_prefix: tinyauth_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-traefik.git
   version: v3.5.1-0
   name: traefik

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -565,6 +565,10 @@
     - role: galaxy/telegraf
     # /role-specific:telegraf
 
+    # role-specific:tinyauth
+    - role: galaxy/tinyauth
+    # /role-specific:tinyauth
+
     # role-specific:tsdproxy
     - role: galaxy/tsdproxy
     # /role-specific:tsdproxy


### PR DESCRIPTION
This intends to add [Tinyauth](https://tinyauth.app/docs/about/), a pretty simple authentication middleware which supports TOTP, OAuth, and LDAP and does not require a database or some sort of add-ons.