### PR TITLE
Add Pocket ID

### DIFF
--- a/docs/services/authelia.md
+++ b/docs/services/authelia.md
@@ -204,4 +204,5 @@ To get started, open the URL with a web browser, and log in to the portal websit
 - [authentik](authentik.md) — Open-source Identity Provider (IdP) focused on flexibility and versatility
 - [Keycloak](keycloak.md) — Open source identity and access management solution
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Pocket ID](pocket-id.md) — Simple OIDC provider for passkey-only authentication
 - [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/authentik.md
+++ b/docs/services/authentik.md
@@ -250,4 +250,5 @@ When it comes to this playbook, tested configuration examples are described on t
 - [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
 - [Keycloak](keycloak.md) — Open source identity and access management solution
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Pocket ID](pocket-id.md) — Simple OIDC provider for passkey-only authentication
 - [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -184,7 +184,7 @@ grafana_dashboard_download_urls: |
 
 ### Single-Sign-On
 
-Grafana supports Single-Sign-On (SSO) via OAUTH. To make use of this you'll need an Identity Provider (IdP) like [authentik](authentik.md), [Keycloak](keycloak.md) or [Authelia](authelia.md).
+Grafana supports Single-Sign-On (SSO) via OAUTH. To make use of this you'll need an Identity Provider (IdP) like [authentik](authentik.md), [Authelia](authelia.md), [Keycloak](keycloak.md) or [Pocket ID](pocket-id.md).
 
 Below, you can find some examples for Grafana configuration.
 

--- a/docs/services/grafana.md
+++ b/docs/services/grafana.md
@@ -248,6 +248,10 @@ grafana_environment_variables_additional_variables: |
   GF_AUTH_GENERIC_OAUTH_USE_PKCE=true
 ```
 
+#### Single-Sign-On / Pocket ID
+
+Refer to [this page](https://pocket-id.org/docs/client-examples/grafana) on Pocket ID's documentation for the instruction.
+
 ## Usage
 
 After running the command for installation, the Grafana instance becomes available at the URL specified with `grafana_hostname` and `grafana_path_prefix`. With the configuration above, the service is hosted at `https://mash.example.com/grafana`.

--- a/docs/services/keycloak.md
+++ b/docs/services/keycloak.md
@@ -66,4 +66,5 @@ On each start after that, Keycloak will attempt to create the user again and rep
 - [authentik](authentik.md) — Open-source Identity Provider (IdP) focused on flexibility and versatility
 - [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
 - [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+- [Pocket ID](pocket-id.md) — Simple OIDC provider for passkey-only authentication
 - [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -162,3 +162,4 @@ Take a look at [its `default/main.yml` file](https://github.com/mother-of-all-se
 - [authentik](authentik.md) — An open-source Identity Provider (IdP) focused on flexibility and versatility.
 - [Keycloak](keycloak.md) — An open source identity and access management solution
 - [Authelia](authelia.md) — An open-source authentication and authorization server that can work as a companion to [common reverse proxies](https://www.authelia.com/overview/prologue/supported-proxies/) (like [Traefik](traefik.md) frequently used by this playbook)
+- [Pocket ID](pocket-id.md) — Simple OIDC provider for passkey-only authentication

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -17,15 +17,15 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Homarr
+# Pocket ID
 
-The playbook can install and configure [Homarr](https://homarr.dev) for you.
+The playbook can install and configure [Pocket ID](https://homarr.dev) for you.
 
-Homarr is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
+Pocket ID is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
 
-See the project's [documentation](https://homarr.dev/docs/getting-started) to learn what Homarr does and why it might be useful to you.
+See the project's [documentation](https://homarr.dev/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
+For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md) online
 - 📁 `roles/galaxy/homarr/docs/configuring-homarr.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
@@ -34,7 +34,7 @@ For details about configuring the [Ansible role for Homarr](https://github.com/m
 This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
-- (optional) [Postgres](postgres.md) / MySQL database — Homarr will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+- (optional) [Postgres](postgres.md) / MySQL database — Pocket ID will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
 
 >[!NOTE]
 > Currently (as of v1.35.0) MariaDB is not supported but planned. See [this issue at GitHub](https://github.com/homarr-labs/homarr/issues/2305) for the latest information.
@@ -61,7 +61,7 @@ homarr_hostname: homarr.example.com
 ########################################################################
 ```
 
-**Note**: hosting Homarr under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
+**Note**: hosting Pocket ID under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Pocket ID's technical limitations.
 
 ### Set 32-byte hex digits for secret key
 
@@ -76,7 +76,7 @@ homarr_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
 
 ### Select database to use (optional)
 
-By default Homarr is configured to use Postgres, but you can choose other database such as SQLite and MySQL.
+By default Pocket ID is configured to use Postgres, but you can choose other database such as SQLite and MySQL.
 
 To use SQLite, add the following configuration to your `vars.yml` file:
 
@@ -88,15 +88,15 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ho
 
 ## Usage
 
-After running the command for installation, the Homarr instance becomes available at the URL specified with `homarr_hostname`. With the configuration above, the service is hosted at `https://homarr.example.com`.
+After running the command for installation, the Pocket ID instance becomes available at the URL specified with `homarr_hostname`. With the configuration above, the service is hosted at `https://homarr.example.com`.
 
 You can open the page with a web browser to start the onboarding process. See [this official guide](https://homarr.dev/docs/getting-started/after-the-installation/) for details.
 
-### Playbook's services on Homarr
+### Playbook's services on Pocket ID
 
-On Homarr's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), [PrivateBin](privatebin.md), [Syncthing](syncthing.md), etc.
+On Pocket ID's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), [PrivateBin](privatebin.md), [Syncthing](syncthing.md), etc.
 
-Homarr also integrates with various software, to which you can connect your applications to interact via widgets. Here is a list of integrations which are also available on this playbook:
+Pocket ID also integrates with various software, to which you can connect your applications to interact via widgets. Here is a list of integrations which are also available on this playbook:
 
 - **Torrent client**: [qBittorent](qbittorrent.md)
 - **Media server**: [Plex](plex.md)

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -89,3 +89,10 @@ See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/br
 ## Troubleshooting
 
 See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [authentik](authentik.md) — Open-source Identity Provider (IdP) focused on flexibility and versatility
+- [Authelia](authelia.md) — Open-source authentication and authorization server that can work as a companion to common reverse proxies like Traefik
+- [Keycloak](keycloak.md) — Open source identity and access management solution
+- [Tinyauth](tinyauth.md) — Simple authentication middleware that adds a login screen or OAuth with Google, Github, and any provider to your Docker services

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -34,10 +34,10 @@ For details about configuring the [Ansible role for Pocket ID](https://codeberg.
 This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
-- (optional) [Postgres](postgres.md) / MySQL database — Pocket ID will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+- (optional) [Postgres](postgres.md) — Pocket ID will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
 
 >[!NOTE]
-> Currently (as of v1.35.0) MariaDB is not supported but planned. See [this issue at GitHub](https://github.com/pocket_id-labs/pocket_id/issues/2305) for the latest information.
+> It is not recommended to store a SQLite database inside a networked filesystem, such as a NFS or SMB share. See [this section](https://pocket-id.org/docs/configuration/environment-variables#database-connection-string) on the official documentation for details.
 
 ## Adjusting the playbook configuration
 

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -19,15 +19,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Pocket ID
 
-The playbook can install and configure [Pocket ID](https://homarr.dev) for you.
+The playbook can install and configure [Pocket ID](https://pocket_id.dev) for you.
 
 Pocket ID is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
 
-See the project's [documentation](https://homarr.dev/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
+See the project's [documentation](https://pocket_id.dev/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md) online
-- 📁 `roles/galaxy/homarr/docs/configuring-homarr.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md) online
+- 📁 `roles/galaxy/pocket_id/docs/configuring-pocket_id.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -37,7 +37,7 @@ This service requires the following other services:
 - (optional) [Postgres](postgres.md) / MySQL database — Pocket ID will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
 
 >[!NOTE]
-> Currently (as of v1.35.0) MariaDB is not supported but planned. See [this issue at GitHub](https://github.com/homarr-labs/homarr/issues/2305) for the latest information.
+> Currently (as of v1.35.0) MariaDB is not supported but planned. See [this issue at GitHub](https://github.com/pocket_id-labs/pocket_id/issues/2305) for the latest information.
 
 ## Adjusting the playbook configuration
 
@@ -46,29 +46,29 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# homarr                                                               #
+# pocket_id                                                            #
 #                                                                      #
 ########################################################################
 
-homarr_enabled: true
+pocket_id_enabled: true
 
-homarr_hostname: homarr.example.com
+pocket_id_hostname: pocket_id.example.com
 
 ########################################################################
 #                                                                      #
-# /homarr                                                              #
+# /pocket_id                                                           #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Pocket ID under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Pocket ID's technical limitations.
+**Note**: hosting Pocket ID under a subpath (by configuring the `pocket_id_path_prefix` variable) does not seem to be possible due to Pocket ID's technical limitations.
 
 ### Set 32-byte hex digits for secret key
 
 You also need to specify **32-byte hex digits** to encrypt integration secrets on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
 
 ```yaml
-homarr_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
+pocket_id_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
 ```
 
 >[!NOTE]
@@ -84,13 +84,13 @@ To use SQLite, add the following configuration to your `vars.yml` file:
 forgejo_database_type: better-sqlite3
 ```
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#specify-database-optional) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md#specify-database-optional) on the role's documentation for details.
 
 ## Usage
 
-After running the command for installation, the Pocket ID instance becomes available at the URL specified with `homarr_hostname`. With the configuration above, the service is hosted at `https://homarr.example.com`.
+After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocket_id.example.com`.
 
-You can open the page with a web browser to start the onboarding process. See [this official guide](https://homarr.dev/docs/getting-started/after-the-installation/) for details.
+You can open the page with a web browser to start the onboarding process. See [this official guide](https://pocket_id.dev/docs/getting-started/after-the-installation/) for details.
 
 ### Playbook's services on Pocket ID
 
@@ -104,8 +104,8 @@ Pocket ID also integrates with various software, to which you can connect your a
 - **Media request manager**: [Overseerr](overseerr.md)
 - **DNS ad-blocker**: [AdGuard Home](adguard-home.md)
 
-See [this page](https://homarr.dev/docs/category/integrations) on the official documentation for the latest information about integrations.
+See [this page](https://pocket_id.dev/docs/category/integrations) on the official documentation for the latest information about integrations.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -21,9 +21,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 The playbook can install and configure [Pocket ID](https://pocket-id.org) for you.
 
-Pocket ID is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
+Pocket ID is a simple OpenID Connect (OIDC) provider (Identity Provider, IdP) that allows users to authenticate with their passkeys to your services.
 
-See the project's [documentation](https://pocket-id.org/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
+See the project's [documentation](https://pocket-id.org/docs/) to learn what Pocket ID does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Pocket ID](https://codeberg.org/acioustick/ansible-role-pocket-id), you can check them via:
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md) online

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -82,21 +82,9 @@ See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/br
 
 After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocketid.example.com`.
 
-You can open the page with a web browser to start the onboarding process. See [this official guide](https://pocket-id.org/docs/getting-started/after-the-installation/) for details.
+To get started, open the URL `https://example.com/setup` on a web browser to create and sign in with an admin account.
 
-### Playbook's services on Pocket ID
-
-On Pocket ID's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), [PrivateBin](privatebin.md), [Syncthing](syncthing.md), etc.
-
-Pocket ID also integrates with various software, to which you can connect your applications to interact via widgets. Here is a list of integrations which are also available on this playbook:
-
-- **Torrent client**: [qBittorent](qbittorrent.md)
-- **Media server**: [Plex](plex.md)
-- **Media collection managers**: [Sonarr](sonarr.md) and [Radarr](radarr.md)
-- **Media request manager**: [Overseerr](overseerr.md)
-- **DNS ad-blocker**: [AdGuard Home](adguard-home.md)
-
-See [this page](https://pocket-id.org/docs/category/integrations) on the official documentation for the latest information about integrations.
+See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#usage) on the role's documentation for details about how to use Pocket ID.
 
 ## Troubleshooting
 

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -63,28 +63,9 @@ pocket_id_hostname: pocketid.example.com
 
 **Note**: hosting Pocket ID under a subpath (by configuring the `pocket_id_path_prefix` variable) does not seem to be possible due to Pocket ID's technical limitations.
 
-### Set 32-byte hex digits for secret key
-
-You also need to specify **32-byte hex digits** to encrypt integration secrets on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
-
-```yaml
-pocket_id_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
-```
-
->[!NOTE]
-> Other type of values such as one generated with `pwgen -s 64 1` does not work.
-
 ### Select database to use (optional)
 
-By default Pocket ID is configured to use Postgres, but you can choose other database such as SQLite and MySQL.
-
-To use SQLite, add the following configuration to your `vars.yml` file:
-
-```yaml
-forgejo_database_type: better-sqlite3
-```
-
-See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
+By default Pocket ID is configured to use Postgres, but you can choose SQLite. See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
 
 ## Usage
 

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -25,9 +25,9 @@ Pocket ID is a highly customizable dashboard for management of your favorite app
 
 See the project's [documentation](https://pocket-id.org/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md) online
-- 📁 `roles/galaxy/pocket_id/docs/configuring-pocket_id.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md) online
+- 📁 `roles/galaxy/pocket_id/docs/configuring-pocket-id.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
@@ -84,7 +84,7 @@ To use SQLite, add the following configuration to your `vars.yml` file:
 forgejo_database_type: better-sqlite3
 ```
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md#specify-database-optional) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
 
 ## Usage
 
@@ -108,4 +108,4 @@ See [this page](https://pocket-id.org/docs/category/integrations) on the officia
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -67,6 +67,17 @@ pocket_id_hostname: pocketid.example.com
 
 By default Pocket ID is configured to use Postgres, but you can choose SQLite. See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
 
+### Configuring additional settings with environment variables (optional)
+
+The Pocket ID instance's additional settings can be specified with *either its UI or environment variables*.
+
+By default, this playbook enables configuring them on the UI, which therefore disables doing so with environment variables.
+
+>[!NOTE]
+> Basic settings can still be configured with environment variables.
+
+See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#enable-or-disable-overriding-ui-configuration-with-environment-variables) on the role's documentation for details about what needs specifying.
+
 ## Usage
 
 After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocketid.example.com`.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -52,7 +52,7 @@ To enable this service, add the following configuration to your `vars.yml` file 
 
 pocket_id_enabled: true
 
-pocket_id_hostname: pocket_id.example.com
+pocket_id_hostname: pocketid.example.com
 
 ########################################################################
 #                                                                      #
@@ -88,7 +88,7 @@ See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/br
 
 ## Usage
 
-After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocket_id.example.com`.
+After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocketid.example.com`.
 
 You can open the page with a web browser to start the onboarding process. See [this official guide](https://pocket-id.org/docs/getting-started/after-the-installation/) for details.
 

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -25,8 +25,8 @@ Pocket ID is a highly customizable dashboard for management of your favorite app
 
 See the project's [documentation](https://pocket-id.org/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md) online
+For details about configuring the [Ansible role for Pocket ID](https://codeberg.org/acioustick/ansible-role-pocket-id), you can check them via:
+- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md) online
 - 📁 `roles/galaxy/pocket_id/docs/configuring-pocket-id.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
@@ -84,7 +84,7 @@ To use SQLite, add the following configuration to your `vars.yml` file:
 forgejo_database_type: better-sqlite3
 ```
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
+See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#specify-database-optional) on the role's documentation for details.
 
 ## Usage
 
@@ -108,4 +108,4 @@ See [this page](https://pocket-id.org/docs/category/integrations) on the officia
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-pocket-id/blob/main/docs/configuring-pocket-id.md#troubleshooting) on the role's documentation for details.
+See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -86,6 +86,8 @@ To get started, open the URL `https://example.com/setup` on a web browser to cre
 
 See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#usage) on the role's documentation for details about how to use Pocket ID.
 
+If you are interested in integrating Pocket ID with [Tinyauth](https://tinyauth.app), you might also be interested in having a look at [this section](tinyauth.md#integrating-with-pocket-id).
+
 ## Troubleshooting
 
 See [this section](https://codeberg.org/acioustick/ansible-role-pocket-id/src/branch/master/docs/configuring-pocket-id.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -1,0 +1,111 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Homarr
+
+The playbook can install and configure [Homarr](https://homarr.dev) for you.
+
+Homarr is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
+
+See the project's [documentation](https://homarr.dev/docs/getting-started) to learn what Homarr does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Homarr](https://github.com/mother-of-all-self-hosting/ansible-role-homarr), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md) online
+- 📁 `roles/galaxy/homarr/docs/configuring-homarr.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+- (optional) [Postgres](postgres.md) / MySQL database — Homarr will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+
+>[!NOTE]
+> Currently (as of v1.35.0) MariaDB is not supported but planned. See [this issue at GitHub](https://github.com/homarr-labs/homarr/issues/2305) for the latest information.
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# homarr                                                               #
+#                                                                      #
+########################################################################
+
+homarr_enabled: true
+
+homarr_hostname: homarr.example.com
+
+########################################################################
+#                                                                      #
+# /homarr                                                              #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting Homarr under a subpath (by configuring the `homarr_path_prefix` variable) does not seem to be possible due to Homarr's technical limitations.
+
+### Set 32-byte hex digits for secret key
+
+You also need to specify **32-byte hex digits** to encrypt integration secrets on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
+
+```yaml
+homarr_environment_variables_secret_encryption_key: YOUR_SECRET_KEY_HERE
+```
+
+>[!NOTE]
+> Other type of values such as one generated with `pwgen -s 64 1` does not work.
+
+### Select database to use (optional)
+
+By default Homarr is configured to use Postgres, but you can choose other database such as SQLite and MySQL.
+
+To use SQLite, add the following configuration to your `vars.yml` file:
+
+```yaml
+forgejo_database_type: better-sqlite3
+```
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#specify-database-optional) on the role's documentation for details.
+
+## Usage
+
+After running the command for installation, the Homarr instance becomes available at the URL specified with `homarr_hostname`. With the configuration above, the service is hosted at `https://homarr.example.com`.
+
+You can open the page with a web browser to start the onboarding process. See [this official guide](https://homarr.dev/docs/getting-started/after-the-installation/) for details.
+
+### Playbook's services on Homarr
+
+On Homarr's board it is possible to create and add icons of many services, including the ones which can be installed with this playbook such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), [PrivateBin](privatebin.md), [Syncthing](syncthing.md), etc.
+
+Homarr also integrates with various software, to which you can connect your applications to interact via widgets. Here is a list of integrations which are also available on this playbook:
+
+- **Torrent client**: [qBittorent](qbittorrent.md)
+- **Media server**: [Plex](plex.md)
+- **Media collection managers**: [Sonarr](sonarr.md) and [Radarr](radarr.md)
+- **Media request manager**: [Overseerr](overseerr.md)
+- **DNS ad-blocker**: [AdGuard Home](adguard-home.md)
+
+See [this page](https://homarr.dev/docs/category/integrations) on the official documentation for the latest information about integrations.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-homarr/blob/main/docs/configuring-homarr.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/pocket-id.md
+++ b/docs/services/pocket-id.md
@@ -19,11 +19,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Pocket ID
 
-The playbook can install and configure [Pocket ID](https://pocket_id.dev) for you.
+The playbook can install and configure [Pocket ID](https://pocket-id.org) for you.
 
 Pocket ID is a highly customizable dashboard for management of your favorite applications and services with a drag-and-drop grid system, which integrates with various self-hosted applications.
 
-See the project's [documentation](https://pocket_id.dev/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
+See the project's [documentation](https://pocket-id.org/docs/getting-started) to learn what Pocket ID does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Pocket ID](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-pocket_id/blob/main/docs/configuring-pocket_id.md) online
@@ -90,7 +90,7 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-po
 
 After running the command for installation, the Pocket ID instance becomes available at the URL specified with `pocket_id_hostname`. With the configuration above, the service is hosted at `https://pocket_id.example.com`.
 
-You can open the page with a web browser to start the onboarding process. See [this official guide](https://pocket_id.dev/docs/getting-started/after-the-installation/) for details.
+You can open the page with a web browser to start the onboarding process. See [this official guide](https://pocket-id.org/docs/getting-started/after-the-installation/) for details.
 
 ### Playbook's services on Pocket ID
 
@@ -104,7 +104,7 @@ Pocket ID also integrates with various software, to which you can connect your a
 - **Media request manager**: [Overseerr](overseerr.md)
 - **DNS ad-blocker**: [AdGuard Home](adguard-home.md)
 
-See [this page](https://pocket_id.dev/docs/category/integrations) on the official documentation for the latest information about integrations.
+See [this page](https://pocket-id.org/docs/category/integrations) on the official documentation for the latest information about integrations.
 
 ## Troubleshooting
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -109,6 +109,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [PeerTube](https://joinpeertube.org/) | A tool for sharing online videos | [Link](services/peertube.md) |
 | [Plausible Analytics](https://plausible.io/) | Intuitive, lightweight and open source web analytics | [Link](services/plausible.md) |
 | [Plex](https://www.plex.tv/) | A personal media server | [Link](services/plex.md) |
+| [Pocket ID](https://pocket-id.org/) | Simple OIDC provider for passkey-only authentication | [Link](services/pocket-id.md) |
 | [Postgis](https://postgis.net/) | A spatial database extender for PostgreSQL object-relational database | [Link](services/postgis.md) |
 | [Postgres](https://www.postgresql.org) | A powerful, open source object-relational database system | [Link](services/postgres.md) |
 | [Postgres Backup](https://github.com/prodrigestivill/docker-postgres-backup-local) | A solution for backing up PostgreSQL to local filesystem with periodic backups. | [Link](services/postgres-backup.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -586,6 +586,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (plex_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'plex']} if plex_enabled else omit) }}
   # /role-specific:plex
 
+  # role-specific:pocket_id
+  - |-
+    {{ ({'name': (pocket_id_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'pocket-id']} if pocket_id_enabled else omit) }}
+  # /role-specific:pocket_id
+
   # role-specific:postgis
   - |-
     {{ ({'name': (postgis_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'metrics', 'postgis']} if postgis_enabled else omit) }}
@@ -1226,6 +1231,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
       } if plausible_enabled and plausible_database_hostname == postgres_connection_hostname else omit)
     }}
   # /role-specific:plausible
+
+  # role-specific:pocket_id
+  - |-
+    {{
+      ({
+        'name': pocket_id_database_name,
+        'username': pocket_id_database_username,
+        'password': pocket_id_database_password,
+      } if pocket_id_enabled and pocket_id_database_hostname == postgres_connection_hostname and pocket_id_database_type == 'postgres' else omit)
+    }}
+  # /role-specific:pocket_id
 
   # role-specific:privatebin
   - |-
@@ -7096,6 +7112,82 @@ plex_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary
 ########################################################################
 # /role-specific:plex
 
+
+
+# role-specific:pocket_id
+########################################################################
+#                                                                      #
+# pocket_id                                                            #
+#                                                                      #
+########################################################################
+
+pocket_id_enabled: false
+
+pocket_id_identifier: "{{ mash_playbook_service_identifier_prefix }}pocket-id"
+
+pocket_id_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}pocket-id"
+
+pocket_id_uid: "{{ mash_playbook_uid }}"
+pocket_id_gid: "{{ mash_playbook_gid }}"
+
+pocket_id_systemd_required_services_list: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled | default(false) and pocket_id_database_hostname == postgres_connection_hostname and pocket_id_database_type == 'postgres' else [])
+  }}
+
+pocket_id_systemd_wanted_services_list_auto: |
+  {{
+    ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if (exim_relay_enabled | default(false) and pocket_id_environment_variable_smtp_host == exim_relay_identifier | default('mash-exim-relay')) else [])
+  }}
+
+pocket_id_container_additional_networks_auto: |
+  {{
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and pocket_id_environment_variable_smtp_host == exim_relay_identifier | default('mash-exim-relay') and pocket_id_container_network != exim_relay_container_network) else [])
+    +
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled | default(false) and pocket_id_database_hostname == postgres_connection_hostname and pocket_id_container_network != postgres_container_network and pocket_id_database_type == 'postgres' else [])
+  }}
+
+pocket_id_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+pocket_id_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+pocket_id_database_type: "{{ 'postgres' if postgres_enabled | default(false) else 'sqlite' }}"
+
+# Set `false` to enable telemetry for analytics
+pocket_id_environment_variable_analytics_disabled: true
+
+pocket_id_environment_variable_encryption_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'd.pocketid', rounds=655555) | to_uuid }}"
+
+# Set `true` to disable additional configuration on Pocket ID's UI and allow it with environment variables only.
+pocket_id_environment_variable_ui_config_disabled: false
+
+# role-specific:exim_relay
+pocket_id_mailer_enabled: "{{ exim_relay_enabled }}"
+# Note these settings are automatically applied only if `pocket_id_environment_variable_ui_config_disabled` is set to `true`.
+# Otherwise, it is still possible to configure SMTP mailer on the Pocket ID's UI.
+pocket_id_environment_variable_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+pocket_id_environment_variable_smtp_port: 8025
+pocket_id_environment_variable_smtp_from: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
+# role-specific:postgres
+pocket_id_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+pocket_id_database_port: "{{ postgres_connection_port if postgres_enabled else '5432' }}"
+pocket_id_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.pocketid', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+pocket_id_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+pocket_id_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# pocket_id                                                            #
+#                                                                      #
+########################################################################
+# /role-specific:pocket_id
 
 
 # role-specific:postgis

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -396,6 +396,10 @@
   version: v15-3.3-0
   name: postgis
   activation_prefix: postgis_
+- src: git+https://codeberg.org/acioustick/ansible-role-pocket-id.git
+  version: v1.10.0-0
+  name: pocket_id
+  activation_prefix: pocket_id_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-postgres.git
   version: v17.6-3
   name: postgres

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -449,6 +449,10 @@
     - role: galaxy/plex
     # /role-specific:plex
 
+    # role-specific:pocket_id
+    - role: galaxy/pocket_id
+    # /role-specific:pocket_id
+
     # role-specific:postgis
     - role: galaxy/postgis
     # /role-specific:postgis


### PR DESCRIPTION
This intends to add [Pocket ID](https://pocket-id.org), an OIDC provider for passkey-only authentication which can be used with Traefik with a plugin, Caddy, OAuth2-Proxy, Tinyauth, etc. I have tested it with echoip for passkey authentication via Tinyauth.