### PR TITLE
Document SSO integration with Headscale and authentik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@
 
 /group_vars/*
 !/group_vars/.gitkeep
-
-# Local Python virtual env
-.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 /group_vars/*
 !/group_vars/.gitkeep
+
+# Local Python virtual env
+.venv/

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -41,13 +41,13 @@ headscale_hostname: headscale.example.com
 
 ### Single-Sign-On (SSO) integration
 
-Headscale supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [authelia](authelia.md) or [tinyauth](tinyauth.md) needs to be set up.
-As Headscale's built in authentication is somewhat manual, setting up ODIC can provide a smoother user experience.
+Headscale supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [Authelia](authelia.md) or [Tinyauth](tinyauth.md) needs to be set up.
 
-For example, you can enable SSO with authentik via OIDC by following the steps below:
+As Headscale's built-in authentication is somewhat manual, setting up OIDC can provide a smoother user experience.
 
-Here, we are using ansible vault to supply both our `domain` as well as `client_id` and `client_secret`, you would add the following configuration to your vars.yml.
-This assume that you pick the slug `headscale` in authentik when adding headscale as an application in authentik. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`
+For example, you can enable SSO with authentik via OIDC by following the steps below.
+
+Here, we are using Ansible Vault to supply both our `domain` as well as `client_id` and `client_secret`. Add the following configuration to your `vars.yml` file. This assumes that you picked the slug `headscale` in authentik when adding Headscale as an application. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`.
 
 ```yaml
 headscale_configuration_extension:
@@ -61,13 +61,14 @@ headscale_configuration_extension:
       enabled: true
       method: S256
 ```
-You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [authentik](https://integrations.goauthentik.io/networking/headscale/ ).
-Note that Headscale's documentation doesn't explicitly cover authentik.
+
+You can find more details about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [authentik](https://integrations.goauthentik.io/networking/headscale/). Note that Headscale's documentation doesn't explicitly cover authentik.
 
 ## Role
+
 Take a look at:
 
-- [authentik](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/)'s [`defaults/main.yml`](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/blob/main/defaults/main.yml) for additional variables that you can customize via your `vars.yml` file.
+- The [Headscale role](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/)'s [`defaults/main.yml`](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/blob/main/defaults/main.yml) for additional variables that you can customize via your `vars.yml` file.
 
 ## Usage
 

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -39,6 +39,36 @@ headscale_hostname: headscale.example.com
 ########################################################################
 ```
 
+### Single-Sign-On (SSO) integration
+
+Nextcloud supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [authelia](authelia.md) or [tinyauth](tinyauth.md) needs to be set up.
+As Headscale's built in authentication is somewhat manual, setting up ODIC can provide a smoother user experience.
+
+For example, you can enable SSO with authentik via OIDC by following the steps below:
+
+Here, we are using ansible vault to supply both our `domain` as well as `client_id` and `client_secret`, you would add the following configuration to your vars.yml. 
+This assume that you pick the slug `headscale` in Authentik when adding headscale as an application in Authentik. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`
+
+```yaml
+headscale_configuration_extension:
+  oidc:
+    only_start_if_oidc_is_available: true
+    issuer: "https://authentik.{{ domain }}/application/o/headscale/"
+    client_id: "{{ vault_headscale_client_id }}"
+    client_secret: "{{ vault_headscale_client_secret }}"
+    scope: ["openid", "profile", "email"]
+    pkce:
+      enabled: true
+      method: S256
+```
+You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [Authentik](https://integrations.goauthentik.io/networking/headscale/ ).
+Note that Headscale's documentation don't explicitly cover Authentik. 
+
+## Role
+Take a look at:
+
+- [authentik](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/)'s [`defaults/main.yml`](https://github.com/mother-of-all-self-hosting/ansible-role-headscale/blob/main/defaults/main.yml) for additional variables that you can customize via your `vars.yml` file.
+
 ## Usage
 
 After running the command for installation, the Headscale instance becomes available at the URL specified with `headscale_hostname` and `headscale_path_prefix`. With the configuration above, the service is hosted at `https://headscale.example.com`.

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -41,7 +41,7 @@ headscale_hostname: headscale.example.com
 
 ### Single-Sign-On (SSO) integration
 
-Headscale supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [Authelia](authelia.md) or [Tinyauth](tinyauth.md) needs to be set up.
+Headscale supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [Authelia](authelia.md), [Keycloak](keycloak.md) or [Tinyauth](tinyauth.md) needs to be set up.
 
 As Headscale's built-in authentication is somewhat manual, setting up OIDC can provide a smoother user experience.
 

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -41,7 +41,7 @@ headscale_hostname: headscale.example.com
 
 ### Single-Sign-On (SSO) integration
 
-Nextcloud supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [authelia](authelia.md) or [tinyauth](tinyauth.md) needs to be set up.
+Headscale supports Single-Sign-On (SSO) via OIDC. To make use of it, an Identity Provider (IdP) like [authentik](authentik.md), [authelia](authelia.md) or [tinyauth](tinyauth.md) needs to be set up.
 As Headscale's built in authentication is somewhat manual, setting up ODIC can provide a smoother user experience.
 
 For example, you can enable SSO with authentik via OIDC by following the steps below:

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -47,7 +47,7 @@ As Headscale's built in authentication is somewhat manual, setting up ODIC can p
 For example, you can enable SSO with authentik via OIDC by following the steps below:
 
 Here, we are using ansible vault to supply both our `domain` as well as `client_id` and `client_secret`, you would add the following configuration to your vars.yml.
-This assume that you pick the slug `headscale` in Authentik when adding headscale as an application in Authentik. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`
+This assume that you pick the slug `headscale` in authentik when adding headscale as an application in authentik. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`
 
 ```yaml
 headscale_configuration_extension:
@@ -61,8 +61,8 @@ headscale_configuration_extension:
       enabled: true
       method: S256
 ```
-You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [Authentik](https://integrations.goauthentik.io/networking/headscale/ ).
-Note that Headscale's documentation doesn't explicitly cover Authentik.
+You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [authentik](https://integrations.goauthentik.io/networking/headscale/ ).
+Note that Headscale's documentation doesn't explicitly cover authentik.
 
 ## Role
 Take a look at:

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -62,7 +62,7 @@ headscale_configuration_extension:
       method: S256
 ```
 You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [Authentik](https://integrations.goauthentik.io/networking/headscale/ ).
-Note that Headscale's documentation don't explicitly cover Authentik. 
+Note that Headscale's documentation doesn't explicitly cover Authentik. 
 
 ## Role
 Take a look at:

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -64,7 +64,9 @@ headscale_configuration_extension:
 
 You can find more details about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [authentik](https://integrations.goauthentik.io/networking/headscale/). Note that Headscale's documentation doesn't explicitly cover authentik.
 
-## Role
+### Extending the configuration
+
+There are some additional things you may wish to configure about the component.
 
 Take a look at:
 

--- a/docs/services/headscale.md
+++ b/docs/services/headscale.md
@@ -46,7 +46,7 @@ As Headscale's built in authentication is somewhat manual, setting up ODIC can p
 
 For example, you can enable SSO with authentik via OIDC by following the steps below:
 
-Here, we are using ansible vault to supply both our `domain` as well as `client_id` and `client_secret`, you would add the following configuration to your vars.yml. 
+Here, we are using ansible vault to supply both our `domain` as well as `client_id` and `client_secret`, you would add the following configuration to your vars.yml.
 This assume that you pick the slug `headscale` in Authentik when adding headscale as an application in Authentik. If not, replace `headscale` in `issuer: "https://authentik.{{ domain }}/application/o/headscale/"`
 
 ```yaml
@@ -62,7 +62,7 @@ headscale_configuration_extension:
       method: S256
 ```
 You can find more details reading about configuring OIDC by referring to the documentation at both [Headscale](https://headscale.net/stable/ref/oidc/?h=oidc) and [Authentik](https://integrations.goauthentik.io/networking/headscale/ ).
-Note that Headscale's documentation doesn't explicitly cover Authentik. 
+Note that Headscale's documentation doesn't explicitly cover Authentik.
 
 ## Role
 Take a look at:


### PR DESCRIPTION
Added documentation for Single-Sign-On (SSO) integration using OIDC with Headscale and authentik.

I struggled a bit with figuring out how to use the headscale role to set the OIDC settings, as `headscale_configuration_extension_yaml: |` apparently don't work when using variables/vault secrets as part of the configuration. 

Further, I also think it's also helpful to explicitly mention and link the role's main.yml file, as it's already done for some other services. 

@luixxiul If there's something you think should be done different, I'll be happy to adjust of course. 