### PR TITLE
Add asciinema server

### DIFF
--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -39,7 +39,7 @@ This service requires the following other services:
 
 ## Adjusting the playbook configuration
 
-To enable this service, add the following configuration to your `vars.yml` file:
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
 
 ```yaml
 ########################################################################
@@ -50,7 +50,7 @@ To enable this service, add the following configuration to your `vars.yml` file:
 
 asciinema_server_enabled: true
 
-asciinema_server_hostname: asciinema_server.example.com
+asciinema_server_hostname: asciinema-server.example.com
 
 ########################################################################
 #                                                                      #
@@ -61,19 +61,19 @@ asciinema_server_hostname: asciinema_server.example.com
 
 **Note**: hosting asciinema server under a subpath (by configuring the `asciinema_server_path_prefix` variable) does not seem to be possible due to asciinema server's technical limitations.
 
-### Configure a storage backend
+### Set a random string for secret key base
 
-The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
+You also need to set a random string used for cryptographic operations, such as signing and verification of session cookies. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `pwgen -s 64 1` or in another way.
 
-See [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for asciinema server.
+```yaml
+asciinema_server_environment_variable_secret_key_base: YOUR_SECRET_KEY_HERE
+```
 
 ### Configure the mailer
 
-You can configure a mailer for functions such as user invitation. asciinema server supports a SMTP server and Postmark.
+You can configure a SMTP mailer for functions such as sending links for logging in.
 
 **You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for asciinema server, you do not have to add settings for them, as asciinema server is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
-
-If you will use another SMTP server or Postmark, see [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 
 If you do not want to enable a mailer for asciinema server altogether, add the following configuration to your `vars.yml` file:
 
@@ -81,191 +81,24 @@ If you do not want to enable a mailer for asciinema server altogether, add the f
 asciinema_server_mailer_enabled: false
 ```
 
-### Configure Valkey
+>[!NOTE]
+> If a SMTP server is not configured, you'll need to obtain such a link from the server container logs *every time* to log in.
 
-asciinema server requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
+### Enabling signing up
 
-If asciinema server is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
-
-If you are unsure whether you will install other services along with asciinema server or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to asciinema server.
-
-*See [below](#setting-up-a-shared-valkey-instance) for an instruction to install a shared instance.*
-
-#### Setting up a dedicated Valkey instance
-
-To create a dedicated instance for asciinema server, you can follow the steps below:
-
-1. Adjust the `hosts` file
-2. Create a new `vars.yml` file for the dedicated instance
-3. Edit the existing `vars.yml` file for the main host
-
-*See [this page](../running-multiple-instances.md) for details about configuring multiple instances of Valkey on the same server.*
-
-##### Adjust `hosts`
-
-At first, you need to adjust `inventory/hosts` file to add a supplementary host for asciinema server.
-
-The content should be something like below. Make sure to replace `mash.example.com` with your hostname and `YOUR_SERVER_IP_ADDRESS_HERE` with the IP address of the host, respectively. The same IP address should be set to both, unless the Valkey instance will be served from a different machine.
-
-```ini
-[mash_servers]
-[mash_servers:children]
-mash_example_com
-
-[mash_example_com]
-mash.example.com ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
-mash.example.com-asciinema_server-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
-…
-```
-
-`mash_example_com` can be any string and does not have to match with the hostname.
-
-You can just add an entry for the supplementary host to `[mash_example_com]` if there are other entries there already.
-
-##### Create `vars.yml` for the dedicated instance
-
-Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-asciinema_server-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-asciinema_server-deps`.
-
-After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-asciinema_server-valkey` instance on the new host, setting `/mash/asciinema_server-valkey` to the base directory of the dedicated Valkey instance.
+By default account registration for the service is disabled. To enable it, add the following configuration to your `vars.yml` file:
 
 ```yaml
-# This is vars.yml for the supplementary host of asciinema server.
-
----
-
-########################################################################
-#                                                                      #
-# Playbook                                                             #
-#                                                                      #
-########################################################################
-
-# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
-mash_playbook_generic_secret_key: ''
-
-# Override service names and directory path prefixes
-mash_playbook_service_identifier_prefix: 'mash-asciinema_server-'
-mash_playbook_service_base_directory_name_prefix: 'asciinema_server-'
-
-########################################################################
-#                                                                      #
-# /Playbook                                                            #
-#                                                                      #
-########################################################################
-
-
-########################################################################
-#                                                                      #
-# valkey                                                               #
-#                                                                      #
-########################################################################
-
-valkey_enabled: true
-
-########################################################################
-#                                                                      #
-# /valkey                                                              #
-#                                                                      #
-########################################################################
+asciinema_server_environment_variable_sign_up_disabled: false
 ```
 
-##### Edit the main `vars.yml` file
+### Requiring authentication on uploading
 
-Having configured `vars.yml` for the dedicated instance, add the following configuration to `vars.yml` for the main host, whose path should be `inventory/host_vars/mash.example.com/vars.yml` (replace `mash.example.com` with yours).
+By default uploading recordings with `asciinema upload` requires authentication with `asciinema auth`. To disable it and allow anyone to upload them, add the following configuration to your `vars.yml` file:
 
 ```yaml
-########################################################################
-#                                                                      #
-# asciinema_server                                                     #
-#                                                                      #
-########################################################################
-
-# Add the base configuration as specified above
-
-# Point asciinema server to its dedicated Valkey instance
-asciinema_server_redis_hostname: mash-asciinema_server-valkey
-
-# Make sure the asciinema server service (mash-asciinema_server.service) starts after its dedicated Valkey service (mash-asciinema_server-valkey.service)
-asciinema_server_systemd_required_services_list_custom:
-  - "mash-asciinema_server-valkey.service"
-
-# Make sure the asciinema server service (mash-asciinema_server.service) is connected to the container network of its dedicated Valkey service (mash-asciinema_server-valkey)
-asciinema_server_container_additional_networks_custom:
-  - "mash-asciinema_server-valkey"
-
-########################################################################
-#                                                                      #
-# /asciinema_server                                                    #
-#                                                                      #
-########################################################################
+asciinema_server_environment_variable_upload_auth_required: false
 ```
-
-Running the installation command will create the dedicated Valkey instance named `mash-asciinema_server-valkey`.
-
-#### Setting up a shared Valkey instance
-
-If you host only asciinema server on this server, it is fine to set up a single shared Valkey instance.
-
-To install the single instance and hook asciinema server to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
-
-```yaml
-########################################################################
-#                                                                      #
-# valkey                                                               #
-#                                                                      #
-########################################################################
-
-valkey_enabled: true
-
-########################################################################
-#                                                                      #
-# /valkey                                                              #
-#                                                                      #
-########################################################################
-
-
-########################################################################
-#                                                                      #
-# asciinema_server                                                     #
-#                                                                      #
-########################################################################
-
-# Add the base configuration as specified above
-
-# Point asciinema server to the shared Valkey instance
-asciinema_server_redis_hostname: "{{ valkey_identifier }}"
-
-# Make sure the asciinema server service (mash-asciinema_server.service) starts after its dedicated Valkey service (mash-asciinema_server-valkey.service)
-asciinema_server_systemd_required_services_list_custom:
-  - "{{ valkey_identifier }}.service"
-
-# Make sure the asciinema server container is connected to the container network of its dedicated Valkey service (mash-asciinema_server-valkey)
-asciinema_server_container_additional_networks_custom:
-  - "{{ valkey_container_network }}"
-
-########################################################################
-#                                                                      #
-# /asciinema_server                                                    #
-#                                                                      #
-########################################################################
-```
-
-Running the installation command will create the shared Valkey instance named `mash-valkey`.
-
-### Enable Telemetry (optional)
-
-By default this playbook disables asciinema server's [telemetry](https://github.com/asciinema/asciinema-server/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the asciinema server server (see [here](https://github.com/asciinema_server/asciinema_server/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
-
-If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
-
-```yaml
-asciinema_server_environment_variable_disable_telemetry: false
-```
-
-## Installation
-
-If you have decided to install the dedicated Valkey instance for asciinema server, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-asciinema_server-deps`) first, before running it for the main host (`mash.example.com`).
-
-Note that running the `just` commands for installation (`just install-all` or `just setup-all`) automatically takes care of the order. See [here](../running-multiple-instances.md#1-adjust-hosts) for more details about it.
 
 ## Usage
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -21,17 +21,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 The playbook can install and configure [asciinema server](https://github.com/asciinema/asciinema-server/) for you.
 
-asciinema server is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+asciinema server is a server-side component of the asciinema system, a suite of tools for recording, streaming, and sharing terminal sessions. The [asciinema CLI](https://docs.asciinema.org/manual/cli/) can be configured to upload recordings to the server this role sets up, so that users can host and share them on it, instead of the default asciinema server (<https://asciinema.org>).
 
-See the project's [documentation](https://docs.asciinema.org/) to learn what asciinema server does and why it might be useful to you.
+See the project's [documentation](https://docs.asciinema.org/) to learn what asciinema does and why it might be useful to you.
 
 For details about configuring the [Ansible role for asciinema server](https://codeberg.org/acioustick/ansible-role-asciinema-server), you can check them via:
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md) online
 - 📁 `roles/galaxy/asciinema_server/docs/configuring-asciinema-server.md` locally, if you have [fetched the Ansible roles](../installing.md)
-
->[!NOTE]
-> - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
-> - Excalidraw is available on the playbook. See [here](excalidraw.md) for details about how to install it.
 
 ## Dependencies
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -35,7 +35,6 @@ This service requires the following other services:
 
 - [Postgres](postgres.md) database
 - [Traefik](traefik.md) reverse-proxy server
-- [Valkey](valkey.md) data-store; see [below](#configure-valkey) for details about installation
 - (optional) [exim-relay](exim-relay.md) mailer — required on the default configuration
 
 ## Adjusting the playbook configuration

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -102,9 +102,13 @@ asciinema_server_environment_variable_upload_auth_required: false
 
 ## Usage
 
-After installation, the asciinema server instance becomes available at the URL specified with `asciinema_server_hostname`. With the configuration above, the service is hosted at `https://asciinema_server.example.com`.
+After installation, the asciinema server instance becomes available at the URL specified with `asciinema_server_hostname`. With the configuration above, the service is hosted at `https://asciinema-server.example.com`.
 
-To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
+To get started, install the asciinema CLI on your local computer, and then point it to the server, so that the CLI will upload your recordings to it. The basic flow to use the CLI from recording a terminal session to upload the recording to your server is available on [this page](https://docs.asciinema.org/getting-started/).
+
+Since account registration is disabled by default, you might want to enable it first by setting `asciinema_server_environment_variable_sign_up_disabled` to `false` temporarily in order to create your own account.
+
+Adding an authentication proxy service like [Keycloak](keycloak.md) and [Tinyauth](tinyauth.md) in front of the asciinema server to limit who can access to its web interface is also worth considering.
 
 ## Troubleshooting
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -1,0 +1,287 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Docmost
+
+The playbook can install and configure [Docmost](https://docmost.com/) for you.
+
+Docmost is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+
+See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Docmost](https://github.com/mother-of-all-self-hosting/ansible-role-docmost), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md) online
+- 📁 `roles/galaxy/docmost/docs/configuring-docmost.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+>[!NOTE]
+> - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
+> - Excalidraw is available on the playbook. See [here](excalidraw.md) for details about how to install it.
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Postgres](postgres.md) database
+- [Traefik](traefik.md) reverse-proxy server
+- [Valkey](valkey.md) data-store; see [below](#configure-valkey) for details about installation
+- (optional) [exim-relay](exim-relay.md) mailer — required on the default configuration
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file:
+
+```yaml
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+docmost_enabled: true
+
+docmost_hostname: docmost.example.com
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+
+### Configure a storage backend
+
+The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Docmost.
+
+### Configure the mailer
+
+You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server and Postmark.
+
+**You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for Docmost, you do not have to add settings for them, as Docmost is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
+
+If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
+
+If you do not want to enable a mailer for Docmost altogether, add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_mailer_enabled: false
+```
+
+### Configure Valkey
+
+Docmost requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
+
+If Docmost is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
+
+If you are unsure whether you will install other services along with Docmost or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to Docmost.
+
+*See [below](#setting-up-a-shared-valkey-instance) for an instruction to install a shared instance.*
+
+#### Setting up a dedicated Valkey instance
+
+To create a dedicated instance for Docmost, you can follow the steps below:
+
+1. Adjust the `hosts` file
+2. Create a new `vars.yml` file for the dedicated instance
+3. Edit the existing `vars.yml` file for the main host
+
+*See [this page](../running-multiple-instances.md) for details about configuring multiple instances of Valkey on the same server.*
+
+##### Adjust `hosts`
+
+At first, you need to adjust `inventory/hosts` file to add a supplementary host for Docmost.
+
+The content should be something like below. Make sure to replace `mash.example.com` with your hostname and `YOUR_SERVER_IP_ADDRESS_HERE` with the IP address of the host, respectively. The same IP address should be set to both, unless the Valkey instance will be served from a different machine.
+
+```ini
+[mash_servers]
+[mash_servers:children]
+mash_example_com
+
+[mash_example_com]
+mash.example.com ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+mash.example.com-docmost-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+…
+```
+
+`mash_example_com` can be any string and does not have to match with the hostname.
+
+You can just add an entry for the supplementary host to `[mash_example_com]` if there are other entries there already.
+
+##### Create `vars.yml` for the dedicated instance
+
+Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-docmost-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-docmost-deps`.
+
+After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-docmost-valkey` instance on the new host, setting `/mash/docmost-valkey` to the base directory of the dedicated Valkey instance.
+
+```yaml
+# This is vars.yml for the supplementary host of Docmost.
+
+---
+
+########################################################################
+#                                                                      #
+# Playbook                                                             #
+#                                                                      #
+########################################################################
+
+# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
+mash_playbook_generic_secret_key: ''
+
+# Override service names and directory path prefixes
+mash_playbook_service_identifier_prefix: 'mash-docmost-'
+mash_playbook_service_base_directory_name_prefix: 'docmost-'
+
+########################################################################
+#                                                                      #
+# /Playbook                                                            #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# valkey                                                               #
+#                                                                      #
+########################################################################
+
+valkey_enabled: true
+
+########################################################################
+#                                                                      #
+# /valkey                                                              #
+#                                                                      #
+########################################################################
+```
+
+##### Edit the main `vars.yml` file
+
+Having configured `vars.yml` for the dedicated instance, add the following configuration to `vars.yml` for the main host, whose path should be `inventory/host_vars/mash.example.com/vars.yml` (replace `mash.example.com` with yours).
+
+```yaml
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+# Add the base configuration as specified above
+
+# Point Docmost to its dedicated Valkey instance
+docmost_redis_hostname: mash-docmost-valkey
+
+# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
+docmost_systemd_required_services_list_custom:
+  - "mash-docmost-valkey.service"
+
+# Make sure the Docmost service (mash-docmost.service) is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
+docmost_container_additional_networks_custom:
+  - "mash-docmost-valkey"
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+Running the installation command will create the dedicated Valkey instance named `mash-docmost-valkey`.
+
+#### Setting up a shared Valkey instance
+
+If you host only Docmost on this server, it is fine to set up a single shared Valkey instance.
+
+To install the single instance and hook Docmost to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
+
+```yaml
+########################################################################
+#                                                                      #
+# valkey                                                               #
+#                                                                      #
+########################################################################
+
+valkey_enabled: true
+
+########################################################################
+#                                                                      #
+# /valkey                                                              #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+# Add the base configuration as specified above
+
+# Point Docmost to the shared Valkey instance
+docmost_redis_hostname: "{{ valkey_identifier }}"
+
+# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
+docmost_systemd_required_services_list_custom:
+  - "{{ valkey_identifier }}.service"
+
+# Make sure the Docmost container is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
+docmost_container_additional_networks_custom:
+  - "{{ valkey_container_network }}"
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+Running the installation command will create the shared Valkey instance named `mash-valkey`.
+
+### Enable Telemetry (optional)
+
+By default this playbook disables Docmost's [telemetry](https://docmost.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Docmost server (see [here](https://github.com/docmost/docmost/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
+
+If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_environment_variable_disable_telemetry: false
+```
+
+## Installation
+
+If you have decided to install the dedicated Valkey instance for Docmost, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-docmost-deps`) first, before running it for the main host (`mash.example.com`).
+
+Note that running the `just` commands for installation (`just install-all` or `just setup-all`) automatically takes care of the order. See [here](../running-multiple-instances.md#1-adjust-hosts) for more details about it.
+
+## Usage
+
+After installation, the Docmost instance becomes available at the URL specified with `docmost_hostname`. With the configuration above, the service is hosted at `https://docmost.example.com`.
+
+To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Excalidraw](excalidraw.md) — Free and open source virtual whiteboard for sketching hand-drawn like diagrams

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -113,7 +113,3 @@ Adding an authentication proxy service like [Keycloak](keycloak.md) and [Tinyaut
 ## Troubleshooting
 
 See [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#troubleshooting) on the role's documentation for details.
-
-## Related services
-
-- [Excalidraw](excalidraw.md) — Free and open source virtual whiteboard for sketching hand-drawn like diagrams

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -17,17 +17,17 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Docmost
+# asciinema server
 
-The playbook can install and configure [Docmost](https://docmost.com/) for you.
+The playbook can install and configure [asciinema server](https://asciinema_server.com/) for you.
 
-Docmost is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+asciinema server is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
 
-See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+See the project's [documentation](https://asciinema_server.com/docs/) to learn what asciinema server does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Docmost](https://github.com/mother-of-all-self-hosting/ansible-role-docmost), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md) online
-- 📁 `roles/galaxy/docmost/docs/configuring-docmost.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for asciinema server](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md) online
+- 📁 `roles/galaxy/asciinema_server/docs/configuring-asciinema-server.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 >[!NOTE]
 > - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
@@ -49,56 +49,56 @@ To enable this service, add the following configuration to your `vars.yml` file:
 ```yaml
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# asciinema_server                                                     #
 #                                                                      #
 ########################################################################
 
-docmost_enabled: true
+asciinema_server_enabled: true
 
-docmost_hostname: docmost.example.com
+asciinema_server_hostname: asciinema_server.example.com
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /asciinema_server                                                    #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+**Note**: hosting asciinema server under a subpath (by configuring the `asciinema_server_path_prefix` variable) does not seem to be possible due to asciinema server's technical limitations.
 
 ### Configure a storage backend
 
 The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Docmost.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for asciinema server.
 
 ### Configure the mailer
 
-You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server and Postmark.
+You can configure a mailer for functions such as user invitation. asciinema server supports a SMTP server and Postmark.
 
-**You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for Docmost, you do not have to add settings for them, as Docmost is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
+**You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for asciinema server, you do not have to add settings for them, as asciinema server is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
 
-If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
+If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 
-If you do not want to enable a mailer for Docmost altogether, add the following configuration to your `vars.yml` file:
+If you do not want to enable a mailer for asciinema server altogether, add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_mailer_enabled: false
+asciinema_server_mailer_enabled: false
 ```
 
 ### Configure Valkey
 
-Docmost requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
+asciinema server requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
 
-If Docmost is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
+If asciinema server is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
 
-If you are unsure whether you will install other services along with Docmost or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to Docmost.
+If you are unsure whether you will install other services along with asciinema server or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to asciinema server.
 
 *See [below](#setting-up-a-shared-valkey-instance) for an instruction to install a shared instance.*
 
 #### Setting up a dedicated Valkey instance
 
-To create a dedicated instance for Docmost, you can follow the steps below:
+To create a dedicated instance for asciinema server, you can follow the steps below:
 
 1. Adjust the `hosts` file
 2. Create a new `vars.yml` file for the dedicated instance
@@ -108,7 +108,7 @@ To create a dedicated instance for Docmost, you can follow the steps below:
 
 ##### Adjust `hosts`
 
-At first, you need to adjust `inventory/hosts` file to add a supplementary host for Docmost.
+At first, you need to adjust `inventory/hosts` file to add a supplementary host for asciinema server.
 
 The content should be something like below. Make sure to replace `mash.example.com` with your hostname and `YOUR_SERVER_IP_ADDRESS_HERE` with the IP address of the host, respectively. The same IP address should be set to both, unless the Valkey instance will be served from a different machine.
 
@@ -119,7 +119,7 @@ mash_example_com
 
 [mash_example_com]
 mash.example.com ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
-mash.example.com-docmost-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+mash.example.com-asciinema_server-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
 …
 ```
 
@@ -129,12 +129,12 @@ You can just add an entry for the supplementary host to `[mash_example_com]` if 
 
 ##### Create `vars.yml` for the dedicated instance
 
-Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-docmost-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-docmost-deps`.
+Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-asciinema_server-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-asciinema_server-deps`.
 
-After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-docmost-valkey` instance on the new host, setting `/mash/docmost-valkey` to the base directory of the dedicated Valkey instance.
+After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-asciinema_server-valkey` instance on the new host, setting `/mash/asciinema_server-valkey` to the base directory of the dedicated Valkey instance.
 
 ```yaml
-# This is vars.yml for the supplementary host of Docmost.
+# This is vars.yml for the supplementary host of asciinema server.
 
 ---
 
@@ -148,8 +148,8 @@ After creating the directory, add a new `vars.yml` file inside it with a content
 mash_playbook_generic_secret_key: ''
 
 # Override service names and directory path prefixes
-mash_playbook_service_identifier_prefix: 'mash-docmost-'
-mash_playbook_service_base_directory_name_prefix: 'docmost-'
+mash_playbook_service_identifier_prefix: 'mash-asciinema_server-'
+mash_playbook_service_base_directory_name_prefix: 'asciinema_server-'
 
 ########################################################################
 #                                                                      #
@@ -180,37 +180,37 @@ Having configured `vars.yml` for the dedicated instance, add the following confi
 ```yaml
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# asciinema_server                                                     #
 #                                                                      #
 ########################################################################
 
 # Add the base configuration as specified above
 
-# Point Docmost to its dedicated Valkey instance
-docmost_redis_hostname: mash-docmost-valkey
+# Point asciinema server to its dedicated Valkey instance
+asciinema_server_redis_hostname: mash-asciinema_server-valkey
 
-# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
-docmost_systemd_required_services_list_custom:
-  - "mash-docmost-valkey.service"
+# Make sure the asciinema server service (mash-asciinema_server.service) starts after its dedicated Valkey service (mash-asciinema_server-valkey.service)
+asciinema_server_systemd_required_services_list_custom:
+  - "mash-asciinema_server-valkey.service"
 
-# Make sure the Docmost service (mash-docmost.service) is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
-docmost_container_additional_networks_custom:
-  - "mash-docmost-valkey"
+# Make sure the asciinema server service (mash-asciinema_server.service) is connected to the container network of its dedicated Valkey service (mash-asciinema_server-valkey)
+asciinema_server_container_additional_networks_custom:
+  - "mash-asciinema_server-valkey"
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /asciinema_server                                                    #
 #                                                                      #
 ########################################################################
 ```
 
-Running the installation command will create the dedicated Valkey instance named `mash-docmost-valkey`.
+Running the installation command will create the dedicated Valkey instance named `mash-asciinema_server-valkey`.
 
 #### Setting up a shared Valkey instance
 
-If you host only Docmost on this server, it is fine to set up a single shared Valkey instance.
+If you host only asciinema server on this server, it is fine to set up a single shared Valkey instance.
 
-To install the single instance and hook Docmost to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
+To install the single instance and hook asciinema server to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
 
 ```yaml
 ########################################################################
@@ -230,26 +230,26 @@ valkey_enabled: true
 
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# asciinema_server                                                     #
 #                                                                      #
 ########################################################################
 
 # Add the base configuration as specified above
 
-# Point Docmost to the shared Valkey instance
-docmost_redis_hostname: "{{ valkey_identifier }}"
+# Point asciinema server to the shared Valkey instance
+asciinema_server_redis_hostname: "{{ valkey_identifier }}"
 
-# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
-docmost_systemd_required_services_list_custom:
+# Make sure the asciinema server service (mash-asciinema_server.service) starts after its dedicated Valkey service (mash-asciinema_server-valkey.service)
+asciinema_server_systemd_required_services_list_custom:
   - "{{ valkey_identifier }}.service"
 
-# Make sure the Docmost container is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
-docmost_container_additional_networks_custom:
+# Make sure the asciinema server container is connected to the container network of its dedicated Valkey service (mash-asciinema_server-valkey)
+asciinema_server_container_additional_networks_custom:
   - "{{ valkey_container_network }}"
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /asciinema_server                                                    #
 #                                                                      #
 ########################################################################
 ```
@@ -258,29 +258,29 @@ Running the installation command will create the shared Valkey instance named `m
 
 ### Enable Telemetry (optional)
 
-By default this playbook disables Docmost's [telemetry](https://docmost.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Docmost server (see [here](https://github.com/docmost/docmost/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
+By default this playbook disables asciinema server's [telemetry](https://asciinema_server.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the asciinema server server (see [here](https://github.com/asciinema_server/asciinema_server/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
 
 If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_environment_variable_disable_telemetry: false
+asciinema_server_environment_variable_disable_telemetry: false
 ```
 
 ## Installation
 
-If you have decided to install the dedicated Valkey instance for Docmost, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-docmost-deps`) first, before running it for the main host (`mash.example.com`).
+If you have decided to install the dedicated Valkey instance for asciinema server, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-asciinema_server-deps`) first, before running it for the main host (`mash.example.com`).
 
 Note that running the `just` commands for installation (`just install-all` or `just setup-all`) automatically takes care of the order. See [here](../running-multiple-instances.md#1-adjust-hosts) for more details about it.
 
 ## Usage
 
-After installation, the Docmost instance becomes available at the URL specified with `docmost_hostname`. With the configuration above, the service is hosted at `https://docmost.example.com`.
+After installation, the asciinema server instance becomes available at the URL specified with `asciinema_server_hostname`. With the configuration above, the service is hosted at `https://asciinema_server.example.com`.
 
 To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#troubleshooting) on the role's documentation for details.
 
 ## Related services
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -19,11 +19,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # asciinema server
 
-The playbook can install and configure [asciinema server](https://asciinema_server.com/) for you.
+The playbook can install and configure [asciinema server](https://github.com/asciinema/asciinema-server/) for you.
 
 asciinema server is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
 
-See the project's [documentation](https://asciinema_server.com/docs/) to learn what asciinema server does and why it might be useful to you.
+See the project's [documentation](https://docs.asciinema.org/) to learn what asciinema server does and why it might be useful to you.
 
 For details about configuring the [Ansible role for asciinema server](https://codeberg.org/acioustick/ansible-role-asciinema-server), you can check them via:
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md) online
@@ -258,7 +258,7 @@ Running the installation command will create the shared Valkey instance named `m
 
 ### Enable Telemetry (optional)
 
-By default this playbook disables asciinema server's [telemetry](https://asciinema_server.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the asciinema server server (see [here](https://github.com/asciinema_server/asciinema_server/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
+By default this playbook disables asciinema server's [telemetry](https://github.com/asciinema/asciinema-server/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the asciinema server server (see [here](https://github.com/asciinema_server/asciinema_server/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
 
 If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -25,8 +25,8 @@ asciinema server is an free and open-source collaborative wiki and documentation
 
 See the project's [documentation](https://asciinema_server.com/docs/) to learn what asciinema server does and why it might be useful to you.
 
-For details about configuring the [Ansible role for asciinema server](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md) online
+For details about configuring the [Ansible role for asciinema server](https://codeberg.org/acioustick/ansible-role-asciinema-server), you can check them via:
+- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md) online
 - 📁 `roles/galaxy/asciinema_server/docs/configuring-asciinema-server.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 >[!NOTE]
@@ -70,7 +70,7 @@ asciinema_server_hostname: asciinema_server.example.com
 
 The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for asciinema server.
+See [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for asciinema server.
 
 ### Configure the mailer
 
@@ -78,7 +78,7 @@ You can configure a mailer for functions such as user invitation. asciinema serv
 
 **You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for asciinema server, you do not have to add settings for them, as asciinema server is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
 
-If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
+If you will use another SMTP server or Postmark, see [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 
 If you do not want to enable a mailer for asciinema server altogether, add the following configuration to your `vars.yml` file:
 
@@ -280,7 +280,7 @@ To get started, open the URL with a web browser, and create a first workspace by
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-asciinema-server/blob/main/docs/configuring-asciinema-server.md#troubleshooting) on the role's documentation for details.
+See [this section](https://codeberg.org/acioustick/ansible-role-asciinema-server/src/branch/master/docs/configuring-asciinema-server.md#troubleshooting) on the role's documentation for details.
 
 ## Related services
 

--- a/docs/services/asciinema-server.md
+++ b/docs/services/asciinema-server.md
@@ -71,9 +71,7 @@ asciinema_server_environment_variable_secret_key_base: YOUR_SECRET_KEY_HERE
 
 ### Configure the mailer
 
-You can configure a SMTP mailer for functions such as sending links for logging in.
-
-**You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for asciinema server, you do not have to add settings for them, as asciinema server is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
+You can configure a SMTP mailer for functions such as sending links for logging in. If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 
 If you do not want to enable a mailer for asciinema server altogether, add the following configuration to your `vars.yml` file:
 

--- a/docs/services/calibre-web.md
+++ b/docs/services/calibre-web.md
@@ -155,7 +155,7 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ca
 
 ### Configure the SMTP server (optional)
 
-On Calibre-Web you can set up the SMTP server to have the service send email to terminals like Kindle and Pocketbook. **You can use Exim-relay as the mailer, which is enabled on this playbook by default.** See [this page about Exim-relay configuration](exim-relay.md) for details about how to set it up.
+On Calibre-Web you can set up the SMTP server to have the service send email to terminals like Kindle and Pocketbook. If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 
 As the Calibre-Web instance does not support configuring the mailer with environment variables, you can add default options for it on its UI. Refer to [this page](https://github.com/janeczku/calibre-web/wiki/Setup-Mailserver) on the official documentation as well about how to configure it.
 

--- a/docs/services/docmost.md
+++ b/docs/services/docmost.md
@@ -76,7 +76,7 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-do
 
 You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server and Postmark.
 
-**You can use exim-relay as the mailer, which is enabled on this playbook by default.** If you enable exim-relay on the playbook and will use it for Docmost, you do not have to add settings for them, as Docmost is wired to the mailer automatically. See [here](exim-relay.md) for details about how to set it up.
+If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service. If it is fine for you, you do not have to add settings for it.
 
 If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 

--- a/docs/services/duplicati.md
+++ b/docs/services/duplicati.md
@@ -100,7 +100,7 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-du
 
 ### Configure the SMTP mailer (optional)
 
-On Duplicati you can set up the mailer to have it send reports about backup status. **You can use Exim-relay as the mailer, which is enabled on this playbook by default.** See [this page about Exim-relay configuration](exim-relay.md) for details about how to set it up.
+On Duplicati you can set up the mailer to have it send reports about backup status. If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 
 As the Duplicati instance does not support configuring the mailer with environment variables, you can add default options for it on its UI (and override them with options for each job). Refer to [this page](https://docs.duplicati.com/detailed-descriptions/sending-reports-via-email/sending-reports-with-email) on the official documentation as well about how to configure it.
 

--- a/docs/services/infisical.md
+++ b/docs/services/infisical.md
@@ -256,7 +256,7 @@ infisical_backend_environment_variable_smtp_name: Infisical
 For additional SMTP-related variables, consult the [`defaults/main.yml` file](https://github.com/mother-of-all-self-hosting/ansible-role-infisical/blob/main/defaults/main.yml) in the [ansible-role-infisical](https://github.com/mother-of-all-self-hosting/ansible-role-infisical) Ansible role.
 
 **Notes**:
-- **You can use exim-relay as the mailer, which is enabled on this playbook by default.** See [here](exim-relay.md) for details about how to set it up.
+- If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 - Without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.
 
 ## Installation

--- a/docs/services/joplin-server.md
+++ b/docs/services/joplin-server.md
@@ -72,7 +72,7 @@ Though the mailer is technically not requisite, it is highly recommended to set 
 See [this section](https://codeberg.org/acioustick/ansible-role-joplin-server/src/branch/master/docs/configuring-joplin-server.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 
 **Notes**:
-- **You can use exim-relay as the mailer, which is enabled on this playbook by default.** See [here](exim-relay.md) for details about how to set it up.
+- If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 - Without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.
 
 ## Usage

--- a/docs/services/kutt.md
+++ b/docs/services/kutt.md
@@ -67,7 +67,7 @@ By default Kutt is configured to use Postgres, but you can choose other database
 
 ### Configure the mailer (optional)
 
-On Kutt you can set up a mailer for functions such as sending a password reset mail. **You can use Exim-relay as the mailer, which is enabled on this playbook by default.** See [this page about Exim-relay configuration](exim-relay.md) for details about how to set it up.
+On Kutt you can set up a mailer for functions such as sending a password reset mail. If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 
 >[!NOTE]
 > Without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.

--- a/docs/services/sftpgo.md
+++ b/docs/services/sftpgo.md
@@ -86,7 +86,7 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-sf
 
 ### Configure the mailer (optional)
 
-On SFTPGo you can set up a mailer for functions such as sending a password reset mail. **You can use Exim-relay as the mailer, which is enabled on this playbook by default.** See [this page about Exim-relay configuration](exim-relay.md) for details about how to set it up.
+On SFTPGo you can set up a mailer for functions such as sending a password reset mail. If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service.
 
 >[!NOTE]
 > Without setting an authentication method such as DKIM, SPF, and DMARC for your hostname, emails are most likely to be quarantined as spam at recipient's mail servers. If you have set up a mail server with the [exim-relay Ansible role](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay), you can enable DKIM signing with it. Refer [its documentation](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) for details.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -25,6 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [APISIX Dashboard](https://apisix.apache.org/docs/dashboard/USER_GUIDE/) | A web UI for [APISIX Gateway](services/apisix-gateway.md) | [Link](services/apisix-dashboard.md) |
 | [APISIX Gateway](https://apisix.apache.org/docs/apisix/getting-started/README/) | An API Gateway, Ingress Controller, etc | [Link](services/apisix-gateway.md) |
 | [Appsmith](https://www.appsmith.com/) | Platform for building and deploying custom internal tools and applications without writing code | [Link](services/appsmith.md) |
+| [asciinema server](https://github.com/asciinema/asciinema-server) | Server-side component of the [asciinema](https://docs.asciinema.org/) system, a suite of tools for recording, streaming, and sharing terminal sessions) | [Link](services/asciinema-server.md) |
 | [Authelia](https://www.authelia.com/) | An open-source authentication and authorization server that can work as a companion to [common reverse proxies](https://www.authelia.com/overview/prologue/supported-proxies/) (like [Traefik](services/traefik.md) frequently used by this playbook) | [Link](services/authelia.md) |
 | [authentik](https://goauthentik.io/) | An open-source Identity Provider (IdP) focused on flexibility and versatility. | [Link](services/authentik.md) |
 | [Autobrr](https://autobrr.com/) | Modern, easy to use download automation for torrents and usenet. | [Link](services/autobrr.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -118,6 +118,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (appsmith_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'appsmith']} if appsmith_enabled else omit) }}
   # /role-specific:appsmith
 
+  # role-specific:asciinema_server
+  - |-
+    {{ ({'name': (asciinema_server_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'asciinema-server']} if asciinema_server_enabled else omit) }}
+  # /role-specific:asciinema_server
+
   # role-specific:authelia
   - |-
     {{ ({'name': (authelia_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'authelia']} if authelia_enabled else omit) }}
@@ -864,6 +869,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
   # Dummy entry, which is not role-specific.
   # Ensures there's at least one entry defined in the list.
   - "{{ omit }}"
+
+  # role-specific:asciinema_server
+  - |-
+    {{
+      ({
+        'name': asciinema_server_database_name,
+        'username': asciinema_server_database_username,
+        'password': asciinema_server_database_password,
+      } if asciinema_server_enabled and asciinema_server_database_hostname == postgres_connection_hostname else omit)
+    }}
+  # /role-specific:asciinema_server
 
   # role-specific:authelia
   - |-
@@ -1846,6 +1862,72 @@ appsmith_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pri
 #                                                                      #
 ########################################################################
 # /role-specific:appsmith
+
+
+
+# role-specific:asciinema_server
+########################################################################
+#                                                                      #
+# asciinema_server                                                     #
+#                                                                      #
+########################################################################
+
+asciinema_server_enabled: false
+
+asciinema_server_identifier: "{{ mash_playbook_service_identifier_prefix }}asciinema-server"
+
+asciinema_server_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}asciinema-server"
+
+asciinema_server_uid: "{{ mash_playbook_uid }}"
+asciinema_server_gid: "{{ mash_playbook_gid }}"
+
+asciinema_server_systemd_wanted_services_list_auto: |
+  {{
+    ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if (exim_relay_enabled | default(false) and asciinema_server_environment_variable_smtp_host == exim_relay_identifier | default('mash-exim-relay')) else [])
+  }}
+
+asciinema_server_systemd_required_services_list_auto: |
+ {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and asciinema_server_database_hostname == postgres_connection_hostname else [])
+  }}
+
+asciinema_server_container_additional_networks_auto: |
+  {{
+    ([exim_relay_container_network | default('mash-exim-relay')] if (exim_relay_enabled | default(false) and asciinema_server_environment_variable_smtp_host == exim_relay_identifier | default('mash-exim-relay') and asciinema_server_container_network != exim_relay_container_network) else [])
+    +
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and asciinema_server_database_hostname == postgres_connection_hostname and asciinema_server_container_network != postgres_container_network else [])
+  }}
+
+asciinema_server_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+asciinema_server_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:exim_relay
+asciinema_server_mailer_enabled: "{{ exim_relay_enabled }}"
+asciinema_server_environment_variable_smtp_host: "{{ exim_relay_identifier if exim_relay_enabled else '' }}"
+asciinema_server_environment_variable_smtp_port: "{{ 8025 if exim_relay_enabled else '587' }}"
+asciinema_server_environment_variable_mail_from_address: "{{ exim_relay_sender_address if exim_relay_enabled else '' }}"
+# /role-specific:exim_relay
+
+# role-specific:postgres
+asciinema_server_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+asciinema_server_database_port: "{{ postgres_connection_port if postgres_enabled else '5432' }}"
+asciinema_server_database_user: "{{ asciinema_server_identifier }}"
+asciinema_server_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'db.asciinema', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+asciinema_server_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+asciinema_server_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /asciinema_server                                                    #
+#                                                                      #
+########################################################################
+# /role-specific:asciinema_server
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -24,6 +24,10 @@
   version: v1.73.1-0
   name: appsmith
   activation_prefix: appsmith_
+- src: git+https://codeberg.org/acioustick/ansible-role-asciinema-server.git
+  version: v20250915-0
+  name: asciinema_server
+  activation_prefix: asciinema_server_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-authelia.git
   version: v4.37.5-9
   name: authelia


### PR DESCRIPTION
This intends to add [asciinema server](https://github.com/asciinema/asciinema-server/) so that asciinema CLI can use it instead of its default server. With the server you can self-host terminal sessions (share and livestream) whose text is actually copy-able, unlike videos captured by screen recording software.