### PR TITLE
Add Misskey

### DIFF
--- a/docs/services/funkwhale.md
+++ b/docs/services/funkwhale.md
@@ -1,7 +1,18 @@
 <!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
 SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
-SPDX-FileCopyrightText: 2023-2024 Slavi Pantaleev
-SPDX-FileCopyrightText: 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -232,3 +243,9 @@ just run-tags funkwhale-add-superuser --extra-vars=username=USERNAME --extra-var
 ```
 
 Log in to the web UI with the superuser to create other users.
+
+## Related services
+
+- [GoToSocial](gotosocial.md) — Self-hosted ActivityPub social network server
+- [Misskey](misskey.md) — Free decentralized microblogging platform based on the ActivityPub protocol
+- [PeerTube](peertube.md) — Tool for sharing online videos

--- a/docs/services/gotosocial.md
+++ b/docs/services/gotosocial.md
@@ -104,3 +104,9 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-go
 You can migrate your existing GoToSocial instance to the server which you manage with the MASH playbook. It is also possible to migrate on the same server (from an existing GoToSocial instance to the new one to start managing it with the MASH playbook, for example).
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial/blob/main/docs/configuring-gotosocial.md#migrate-an-existing-instance) on the role's documentation for details.
+
+## Related services
+
+- [Funkwhale](funkwhale.md) — Community-driven project that lets you listen and share music and audio in the Fediverse
+- [Misskey](misskey.md) — Free decentralized microblogging platform based on the ActivityPub protocol
+- [PeerTube](peertube.md) — Tool for sharing online videos

--- a/docs/services/misskey.md
+++ b/docs/services/misskey.md
@@ -252,4 +252,6 @@ See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-mi
 
 ## Related services
 
-- [Excalidraw](excalidraw.md) — Free and open source virtual whiteboard for sketching hand-drawn like diagrams
+- [Funkwhale](funkwhale.md) — Community-driven project that lets you listen and share music and audio in the Fediverse
+- [GoToSocial](gotosocial.md) — Self-hosted ActivityPub social network server
+- [PeerTube](peertube.md) — Tool for sharing online videos

--- a/docs/services/misskey.md
+++ b/docs/services/misskey.md
@@ -17,17 +17,17 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Docmost
+# Misskey
 
-The playbook can install and configure [Docmost](https://docmost.com/) for you.
+The playbook can install and configure [Misskey](https://misskey.com/) for you.
 
-Docmost is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+Misskey is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
 
-See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+See the project's [documentation](https://misskey.com/docs/) to learn what Misskey does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Docmost](https://github.com/mother-of-all-self-hosting/ansible-role-docmost), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md) online
-- 📁 `roles/galaxy/docmost/docs/configuring-docmost.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Misskey](https://github.com/mother-of-all-self-hosting/ansible-role-misskey), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md) online
+- 📁 `roles/galaxy/misskey/docs/configuring-misskey.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 >[!NOTE]
 > - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
@@ -49,56 +49,56 @@ To enable this service, add the following configuration to your `vars.yml` file:
 ```yaml
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# misskey                                                              #
 #                                                                      #
 ########################################################################
 
-docmost_enabled: true
+misskey_enabled: true
 
-docmost_hostname: docmost.example.com
+misskey_hostname: misskey.example.com
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /misskey                                                             #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+**Note**: hosting Misskey under a subpath (by configuring the `misskey_path_prefix` variable) does not seem to be possible due to Misskey's technical limitations.
 
 ### Configure a storage backend
 
 The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Docmost.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Misskey.
 
 ### Configure the mailer
 
-You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server and Postmark.
+You can configure a mailer for functions such as user invitation. Misskey supports a SMTP server and Postmark.
 
 If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service. If it is fine for you, you do not have to add settings for it.
 
-If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
+If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
 
-If you do not want to enable a mailer for Docmost altogether, add the following configuration to your `vars.yml` file:
+If you do not want to enable a mailer for Misskey altogether, add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_mailer_enabled: false
+misskey_mailer_enabled: false
 ```
 
 ### Configure Valkey
 
-Docmost requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
+Misskey requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
 
-If Docmost is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
+If Misskey is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
 
-If you are unsure whether you will install other services along with Docmost or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to Docmost.
+If you are unsure whether you will install other services along with Misskey or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to Misskey.
 
 *See [below](#setting-up-a-shared-valkey-instance) for an instruction to install a shared instance.*
 
 #### Setting up a dedicated Valkey instance
 
-To create a dedicated instance for Docmost, you can follow the steps below:
+To create a dedicated instance for Misskey, you can follow the steps below:
 
 1. Adjust the `hosts` file
 2. Create a new `vars.yml` file for the dedicated instance
@@ -108,7 +108,7 @@ To create a dedicated instance for Docmost, you can follow the steps below:
 
 ##### Adjust `hosts`
 
-At first, you need to adjust `inventory/hosts` file to add a supplementary host for Docmost.
+At first, you need to adjust `inventory/hosts` file to add a supplementary host for Misskey.
 
 The content should be something like below. Make sure to replace `mash.example.com` with your hostname and `YOUR_SERVER_IP_ADDRESS_HERE` with the IP address of the host, respectively. The same IP address should be set to both, unless the Valkey instance will be served from a different machine.
 
@@ -119,7 +119,7 @@ mash_example_com
 
 [mash_example_com]
 mash.example.com ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
-mash.example.com-docmost-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+mash.example.com-misskey-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
 …
 ```
 
@@ -129,12 +129,12 @@ You can just add an entry for the supplementary host to `[mash_example_com]` if 
 
 ##### Create `vars.yml` for the dedicated instance
 
-Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-docmost-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-docmost-deps`.
+Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-misskey-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-misskey-deps`.
 
-After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-docmost-valkey` instance on the new host, setting `/mash/docmost-valkey` to the base directory of the dedicated Valkey instance.
+After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-misskey-valkey` instance on the new host, setting `/mash/misskey-valkey` to the base directory of the dedicated Valkey instance.
 
 ```yaml
-# This is vars.yml for the supplementary host of Docmost.
+# This is vars.yml for the supplementary host of Misskey.
 
 ---
 
@@ -148,8 +148,8 @@ After creating the directory, add a new `vars.yml` file inside it with a content
 mash_playbook_generic_secret_key: ''
 
 # Override service names and directory path prefixes
-mash_playbook_service_identifier_prefix: 'mash-docmost-'
-mash_playbook_service_base_directory_name_prefix: 'docmost-'
+mash_playbook_service_identifier_prefix: 'mash-misskey-'
+mash_playbook_service_base_directory_name_prefix: 'misskey-'
 
 ########################################################################
 #                                                                      #
@@ -180,37 +180,37 @@ Having configured `vars.yml` for the dedicated instance, add the following confi
 ```yaml
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# misskey                                                              #
 #                                                                      #
 ########################################################################
 
 # Add the base configuration as specified above
 
-# Point Docmost to its dedicated Valkey instance
-docmost_redis_hostname: mash-docmost-valkey
+# Point Misskey to its dedicated Valkey instance
+misskey_redis_hostname: mash-misskey-valkey
 
-# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
-docmost_systemd_required_services_list_custom:
-  - "mash-docmost-valkey.service"
+# Make sure the Misskey service (mash-misskey.service) starts after its dedicated Valkey service (mash-misskey-valkey.service)
+misskey_systemd_required_services_list_custom:
+  - "mash-misskey-valkey.service"
 
-# Make sure the Docmost service (mash-docmost.service) is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
-docmost_container_additional_networks_custom:
-  - "mash-docmost-valkey"
+# Make sure the Misskey service (mash-misskey.service) is connected to the container network of its dedicated Valkey service (mash-misskey-valkey)
+misskey_container_additional_networks_custom:
+  - "mash-misskey-valkey"
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /misskey                                                             #
 #                                                                      #
 ########################################################################
 ```
 
-Running the installation command will create the dedicated Valkey instance named `mash-docmost-valkey`.
+Running the installation command will create the dedicated Valkey instance named `mash-misskey-valkey`.
 
 #### Setting up a shared Valkey instance
 
-If you host only Docmost on this server, it is fine to set up a single shared Valkey instance.
+If you host only Misskey on this server, it is fine to set up a single shared Valkey instance.
 
-To install the single instance and hook Docmost to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
+To install the single instance and hook Misskey to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
 
 ```yaml
 ########################################################################
@@ -230,26 +230,26 @@ valkey_enabled: true
 
 ########################################################################
 #                                                                      #
-# docmost                                                              #
+# misskey                                                              #
 #                                                                      #
 ########################################################################
 
 # Add the base configuration as specified above
 
-# Point Docmost to the shared Valkey instance
-docmost_redis_hostname: "{{ valkey_identifier }}"
+# Point Misskey to the shared Valkey instance
+misskey_redis_hostname: "{{ valkey_identifier }}"
 
-# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
-docmost_systemd_required_services_list_custom:
+# Make sure the Misskey service (mash-misskey.service) starts after its dedicated Valkey service (mash-misskey-valkey.service)
+misskey_systemd_required_services_list_custom:
   - "{{ valkey_identifier }}.service"
 
-# Make sure the Docmost container is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
-docmost_container_additional_networks_custom:
+# Make sure the Misskey container is connected to the container network of its dedicated Valkey service (mash-misskey-valkey)
+misskey_container_additional_networks_custom:
   - "{{ valkey_container_network }}"
 
 ########################################################################
 #                                                                      #
-# /docmost                                                             #
+# /misskey                                                             #
 #                                                                      #
 ########################################################################
 ```
@@ -258,29 +258,29 @@ Running the installation command will create the shared Valkey instance named `m
 
 ### Enable Telemetry (optional)
 
-By default this playbook disables Docmost's [telemetry](https://docmost.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Docmost server (see [here](https://github.com/docmost/docmost/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
+By default this playbook disables Misskey's [telemetry](https://misskey.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Misskey server (see [here](https://github.com/misskey/misskey/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
 
 If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
 
 ```yaml
-docmost_environment_variable_disable_telemetry: false
+misskey_environment_variable_disable_telemetry: false
 ```
 
 ## Installation
 
-If you have decided to install the dedicated Valkey instance for Docmost, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-docmost-deps`) first, before running it for the main host (`mash.example.com`).
+If you have decided to install the dedicated Valkey instance for Misskey, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-misskey-deps`) first, before running it for the main host (`mash.example.com`).
 
 Note that running the `just` commands for installation (`just install-all` or `just setup-all`) automatically takes care of the order. See [here](../running-multiple-instances.md#1-adjust-hosts) for more details about it.
 
 ## Usage
 
-After installation, the Docmost instance becomes available at the URL specified with `docmost_hostname`. With the configuration above, the service is hosted at `https://docmost.example.com`.
+After installation, the Misskey instance becomes available at the URL specified with `misskey_hostname`. With the configuration above, the service is hosted at `https://misskey.example.com`.
 
 To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md#troubleshooting) on the role's documentation for details.
 
 ## Related services
 

--- a/docs/services/misskey.md
+++ b/docs/services/misskey.md
@@ -19,19 +19,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Misskey
 
-The playbook can install and configure [Misskey](https://misskey.com/) for you.
+The playbook can install and configure [Misskey](https://misskey-hub.net/en/) for you.
 
-Misskey is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+Misskey is a free decentralized microblogging platform based on the ActivityPub protocol, which can connect to other Fediverse platforms such as Mastodon and PeerTube.
 
-See the project's [documentation](https://misskey.com/docs/) to learn what Misskey does and why it might be useful to you.
+See the project's [documentation](https://misskey-hub.net/en/docs/) to learn what Misskey does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Misskey](https://github.com/mother-of-all-self-hosting/ansible-role-misskey), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md) online
 - 📁 `roles/galaxy/misskey/docs/configuring-misskey.md` locally, if you have [fetched the Ansible roles](../installing.md)
-
->[!NOTE]
-> - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
-> - Excalidraw is available on the playbook. See [here](excalidraw.md) for details about how to install it.
 
 ## Dependencies
 
@@ -40,7 +36,6 @@ This service requires the following other services:
 - [Postgres](postgres.md) database
 - [Traefik](traefik.md) reverse-proxy server
 - [Valkey](valkey.md) data-store; see [below](#configure-valkey) for details about installation
-- (optional) [exim-relay](exim-relay.md) mailer — required on the default configuration
 
 ## Adjusting the playbook configuration
 
@@ -64,27 +59,10 @@ misskey_hostname: misskey.example.com
 ########################################################################
 ```
 
+>[!WARNING]
+> Once the instance has started, changing the hostname will break the instance!
+
 **Note**: hosting Misskey under a subpath (by configuring the `misskey_path_prefix` variable) does not seem to be possible due to Misskey's technical limitations.
-
-### Configure a storage backend
-
-The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
-
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Misskey.
-
-### Configure the mailer
-
-You can configure a mailer for functions such as user invitation. Misskey supports a SMTP server and Postmark.
-
-If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service. If it is fine for you, you do not have to add settings for it.
-
-If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-misskey/blob/main/docs/configuring-misskey.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
-
-If you do not want to enable a mailer for Misskey altogether, add the following configuration to your `vars.yml` file:
-
-```yaml
-misskey_mailer_enabled: false
-```
 
 ### Configure Valkey
 
@@ -256,16 +234,6 @@ misskey_container_additional_networks_custom:
 
 Running the installation command will create the shared Valkey instance named `mash-valkey`.
 
-### Enable Telemetry (optional)
-
-By default this playbook disables Misskey's [telemetry](https://misskey.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Misskey server (see [here](https://github.com/misskey/misskey/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
-
-If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
-
-```yaml
-misskey_environment_variable_disable_telemetry: false
-```
-
 ## Installation
 
 If you have decided to install the dedicated Valkey instance for Misskey, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-misskey-deps`) first, before running it for the main host (`mash.example.com`).
@@ -276,7 +244,7 @@ Note that running the `just` commands for installation (`just install-all` or `j
 
 After installation, the Misskey instance becomes available at the URL specified with `misskey_hostname`. With the configuration above, the service is hosted at `https://misskey.example.com`.
 
-To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
+To get started, open the URL with a web browser, and follow the set up wizard.
 
 ## Troubleshooting
 

--- a/docs/services/misskey.md
+++ b/docs/services/misskey.md
@@ -1,0 +1,287 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Docmost
+
+The playbook can install and configure [Docmost](https://docmost.com/) for you.
+
+Docmost is an free and open-source collaborative wiki and documentation software, designed for seamless real-time collaboration. It can be used to manage a wiki, a knowledge base, project documentation, etc. It has various functions such as granular permissions management system, page history to track changes of articles, etc. It also supports diagramming tools like Draw.io, Excalidraw and Mermaid.
+
+See the project's [documentation](https://docmost.com/docs/) to learn what Docmost does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Docmost](https://github.com/mother-of-all-self-hosting/ansible-role-docmost), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md) online
+- 📁 `roles/galaxy/docmost/docs/configuring-docmost.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+>[!NOTE]
+> - The role is based on Node.js docker image, and is currently expected to run with uid 1000.
+> - Excalidraw is available on the playbook. See [here](excalidraw.md) for details about how to install it.
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Postgres](postgres.md) database
+- [Traefik](traefik.md) reverse-proxy server
+- [Valkey](valkey.md) data-store; see [below](#configure-valkey) for details about installation
+- (optional) [exim-relay](exim-relay.md) mailer — required on the default configuration
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file:
+
+```yaml
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+docmost_enabled: true
+
+docmost_hostname: docmost.example.com
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting Docmost under a subpath (by configuring the `docmost_path_prefix` variable) does not seem to be possible due to Docmost's technical limitations.
+
+### Configure a storage backend
+
+The service provides these storage backend options: local filesystem (default) and Amazon S3 compatible object storage.
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-a-storage-backend) on the role's documentation for details about how to set up Amazon S3 compatible object storage for Docmost.
+
+### Configure the mailer
+
+You can configure a mailer for functions such as user invitation. Docmost supports a SMTP server and Postmark.
+
+If you enable the [exim-relay](exim-relay.md) service in your inventory configuration, the playbook will automatically configure it as a mailer for the service. If it is fine for you, you do not have to add settings for it.
+
+If you will use another SMTP server or Postmark, see [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#configure-the-mailer) on the role's documentation for details about configuring the mailer.
+
+If you do not want to enable a mailer for Docmost altogether, add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_mailer_enabled: false
+```
+
+### Configure Valkey
+
+Docmost requires a Valkey data-store to work. This playbook supports it, and you can set up a Valkey instance by enabling it on `vars.yml`.
+
+If Docmost is the sole service which requires Valkey on your server, it is fine to set up just a single Valkey instance. However, **it is not recommended if there are other services which require it, because sharing the Valkey instance has security concerns and possibly causes data conflicts**, as described on the [documentation for configuring Valkey](valkey.md). In this case, you should install a dedicated Valkey instance for each of them.
+
+If you are unsure whether you will install other services along with Docmost or you have already set up services which need Valkey (such as [Nextcloud](nextcloud.md), [PeerTube](peertube.md), and [Funkwhale](funkwhale.md)), it is recommended to install a Valkey instance dedicated to Docmost.
+
+*See [below](#setting-up-a-shared-valkey-instance) for an instruction to install a shared instance.*
+
+#### Setting up a dedicated Valkey instance
+
+To create a dedicated instance for Docmost, you can follow the steps below:
+
+1. Adjust the `hosts` file
+2. Create a new `vars.yml` file for the dedicated instance
+3. Edit the existing `vars.yml` file for the main host
+
+*See [this page](../running-multiple-instances.md) for details about configuring multiple instances of Valkey on the same server.*
+
+##### Adjust `hosts`
+
+At first, you need to adjust `inventory/hosts` file to add a supplementary host for Docmost.
+
+The content should be something like below. Make sure to replace `mash.example.com` with your hostname and `YOUR_SERVER_IP_ADDRESS_HERE` with the IP address of the host, respectively. The same IP address should be set to both, unless the Valkey instance will be served from a different machine.
+
+```ini
+[mash_servers]
+[mash_servers:children]
+mash_example_com
+
+[mash_example_com]
+mash.example.com ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+mash.example.com-docmost-deps ansible_host=YOUR_SERVER_IP_ADDRESS_HERE
+…
+```
+
+`mash_example_com` can be any string and does not have to match with the hostname.
+
+You can just add an entry for the supplementary host to `[mash_example_com]` if there are other entries there already.
+
+##### Create `vars.yml` for the dedicated instance
+
+Then, create a new directory where `vars.yml` for the supplementary host is stored. If `mash.example.com` is your main host, name the directory as `mash.example.com-docmost-deps`. Its path therefore will be `inventory/host_vars/mash.example.com-docmost-deps`.
+
+After creating the directory, add a new `vars.yml` file inside it with a content below. It will have running the playbook create a `mash-docmost-valkey` instance on the new host, setting `/mash/docmost-valkey` to the base directory of the dedicated Valkey instance.
+
+```yaml
+# This is vars.yml for the supplementary host of Docmost.
+
+---
+
+########################################################################
+#                                                                      #
+# Playbook                                                             #
+#                                                                      #
+########################################################################
+
+# Put a strong secret below, generated with `pwgen -s 64 1` or in another way
+mash_playbook_generic_secret_key: ''
+
+# Override service names and directory path prefixes
+mash_playbook_service_identifier_prefix: 'mash-docmost-'
+mash_playbook_service_base_directory_name_prefix: 'docmost-'
+
+########################################################################
+#                                                                      #
+# /Playbook                                                            #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# valkey                                                               #
+#                                                                      #
+########################################################################
+
+valkey_enabled: true
+
+########################################################################
+#                                                                      #
+# /valkey                                                              #
+#                                                                      #
+########################################################################
+```
+
+##### Edit the main `vars.yml` file
+
+Having configured `vars.yml` for the dedicated instance, add the following configuration to `vars.yml` for the main host, whose path should be `inventory/host_vars/mash.example.com/vars.yml` (replace `mash.example.com` with yours).
+
+```yaml
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+# Add the base configuration as specified above
+
+# Point Docmost to its dedicated Valkey instance
+docmost_redis_hostname: mash-docmost-valkey
+
+# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
+docmost_systemd_required_services_list_custom:
+  - "mash-docmost-valkey.service"
+
+# Make sure the Docmost service (mash-docmost.service) is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
+docmost_container_additional_networks_custom:
+  - "mash-docmost-valkey"
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+Running the installation command will create the dedicated Valkey instance named `mash-docmost-valkey`.
+
+#### Setting up a shared Valkey instance
+
+If you host only Docmost on this server, it is fine to set up a single shared Valkey instance.
+
+To install the single instance and hook Docmost to it, add the following configuration to `inventory/host_vars/mash.example.com/vars.yml`:
+
+```yaml
+########################################################################
+#                                                                      #
+# valkey                                                               #
+#                                                                      #
+########################################################################
+
+valkey_enabled: true
+
+########################################################################
+#                                                                      #
+# /valkey                                                              #
+#                                                                      #
+########################################################################
+
+
+########################################################################
+#                                                                      #
+# docmost                                                              #
+#                                                                      #
+########################################################################
+
+# Add the base configuration as specified above
+
+# Point Docmost to the shared Valkey instance
+docmost_redis_hostname: "{{ valkey_identifier }}"
+
+# Make sure the Docmost service (mash-docmost.service) starts after its dedicated Valkey service (mash-docmost-valkey.service)
+docmost_systemd_required_services_list_custom:
+  - "{{ valkey_identifier }}.service"
+
+# Make sure the Docmost container is connected to the container network of its dedicated Valkey service (mash-docmost-valkey)
+docmost_container_additional_networks_custom:
+  - "{{ valkey_container_network }}"
+
+########################################################################
+#                                                                      #
+# /docmost                                                             #
+#                                                                      #
+########################################################################
+```
+
+Running the installation command will create the shared Valkey instance named `mash-valkey`.
+
+### Enable Telemetry (optional)
+
+By default this playbook disables Docmost's [telemetry](https://docmost.com/docs/self-hosting/environment-variables#telemetry) which collects information about the active version, user count, page count, space and workspace count, and sends to the Docmost server (see [here](https://github.com/docmost/docmost/blob/main/apps/server/src/integrations/telemetry/telemetry.service.ts)).
+
+If you are fine with sending such information and want to help developers, add the following configuration to your `vars.yml` file:
+
+```yaml
+docmost_environment_variable_disable_telemetry: false
+```
+
+## Installation
+
+If you have decided to install the dedicated Valkey instance for Docmost, make sure to run the [installing](../installing.md) command for the supplementary host (`mash.example.com-docmost-deps`) first, before running it for the main host (`mash.example.com`).
+
+Note that running the `just` commands for installation (`just install-all` or `just setup-all`) automatically takes care of the order. See [here](../running-multiple-instances.md#1-adjust-hosts) for more details about it.
+
+## Usage
+
+After installation, the Docmost instance becomes available at the URL specified with `docmost_hostname`. With the configuration above, the service is hosted at `https://docmost.example.com`.
+
+To get started, open the URL with a web browser, and create a first workspace by inputting required information. For an email address, make sure to input your own email address, not the one of the mailer.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-docmost/blob/main/docs/configuring-docmost.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Excalidraw](excalidraw.md) — Free and open source virtual whiteboard for sketching hand-drawn like diagrams

--- a/docs/services/peertube.md
+++ b/docs/services/peertube.md
@@ -1,6 +1,18 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
-SPDX-FileCopyrightText: 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -249,3 +261,9 @@ You should then be able to log in with:
 
 - username: `root`
 - password: the password you've set in `peertube_config_root_user_initial_password` in `vars.yml`
+
+## Related services
+
+- [Funkwhale](funkwhale.md) — Community-driven project that lets you listen and share music and audio in the Fediverse
+- [GoToSocial](gotosocial.md) — Self-hosted ActivityPub social network server
+- [Misskey](misskey.md) — Free decentralized microblogging platform based on the ActivityPub protocol

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -96,6 +96,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Matterbridge](https://github.com/42wim/matterbridge) | Bridges Messenger Chatrooms | [Link](services/matterbridge.md) |
 | [Minecraft](https://docker-minecraft-server.readthedocs.io) | The popular voxel-based sandbox game | [Link](services/minecraft.md) |
 | [Miniflux](https://miniflux.app/) | Minimalist and opinionated feed reader. | [Link](services/miniflux.md) |
+| [Misskey](https://misskey-hub.net/en/) | Free decentralized microblogging platform based on the ActivityPub protocol | [Link](services/misskey.md) |
 | [Mobilizon](https://joinmobilizon.org/en/) | An ActivityPub/Fediverse server to create and share events. | [Link](services/mobilizon.md) |
 | [MongoDB](https://www.mongodb.com/) | A source-available cross-platform document-oriented (NoSQL) database program. | [Link](services/mongodb.md) |
 | [Mosquitto](https://mosquitto.org/) | An open-source MQTT broker | [Link](services/mosquitto.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -480,6 +480,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (mariadb_identifier + '.service'), 'priority': 500, 'groups': ['mash', 'mariadb']} if mariadb_enabled else omit) }}
   # /role-specific:mariadb
 
+  # role-specific:misskey
+  - |-
+    {{ ({'name': (misskey_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'misskey']} if misskey_enabled else omit) }}
+  # /role-specific:misskey
+
   # role-specific:matomo
   - |-
     {{ ({'name': (matomo_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'matomo']} if matomo_enabled else omit) }}
@@ -1198,6 +1203,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
       } if lldap_enabled and lldap_database_postgres_hostname == postgres_connection_hostname and lldap_database_type == 'postgres' else omit)
     }}
   # /role-specific:lldap
+
+  # role-specific:misskey
+  - |-
+    {{
+      ({
+        'name': misskey_database_name,
+        'username': misskey_database_username,
+        'password': misskey_database_password,
+      } if misskey_enabled and misskey_database_hostname == postgres_connection_hostname else omit)
+    }}
+  # /role-specific:misskey
 
   # role-specific:miniflux
   - |-
@@ -6365,6 +6381,64 @@ mariadb_managed_databases_auto: "{{ mash_playbook_mariadb_managed_databases_auto
 #                                                                      #
 ########################################################################
 # /role-specific:mariadb
+
+
+
+# role-specific:misskey
+########################################################################
+#                                                                      #
+# misskey                                                              #
+#                                                                      #
+########################################################################
+
+misskey_enabled: false
+
+misskey_identifier: "{{ mash_playbook_service_identifier_prefix }}misskey"
+
+misskey_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}misskey"
+
+misskey_uid: "{{ mash_playbook_uid }}"
+misskey_gid: "{{ mash_playbook_gid }}"
+
+misskey_systemd_required_services_list_auto: |
+  {{
+    ([postgres_identifier ~ '.service'] if postgres_enabled and misskey_database_hostname == postgres_connection_hostname else [])
+  }}
+
+misskey_systemd_wanted_services_list_auto: |
+  {{
+    ([(exim_relay_identifier | default('mash-exim-relay')) ~ '.service'] if exim_relay_enabled | default(false) else [])
+  }}
+
+misskey_container_additional_networks_auto: |
+  {{
+    ([exim_relay_container_network | default('mash-exim-relay')] if exim_relay_enabled | default(false) and misskey_container_network != exim_relay_container_network else [])
+    +
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled and misskey_database_hostname == postgres_connection_hostname and misskey_container_network != postgres_container_network else [])
+  }}
+
+misskey_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+misskey_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:postgres
+misskey_database_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+misskey_database_port: "{{ postgres_connection_port if postgres_enabled else '5432' }}"
+misskey_database_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'misskey.db', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+misskey_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+misskey_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /misskey                                                             #
+#                                                                      #
+########################################################################
+# /role-specific:misskey
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -308,6 +308,10 @@
   version: v12.0.2-3
   name: mariadb
   activation_prefix: mariadb_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-misskey.git
+  version: v2025.9.0-0
+  name: misskey
+  activation_prefix: misskey_
 - src: git+https://github.com/acterglobal/ansible-role-matomo.git
   version: v5.3.1-1
   name: matomo

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -377,6 +377,10 @@
     - role: galaxy/mariadb
     # /role-specific:mariadb
 
+    # role-specific:misskey
+    - role: galaxy/misskey
+    # /role-specific:misskey
+
     # role-specific:matomo
     - role: galaxy/matomo
     # /role-specific:matomo


### PR DESCRIPTION
This PR intends to add [Misskey](https://misskey-hub.net/), a microblogging software as popular as (or more than?) Mastodon in Japan. I have tested the role to start up the instance and confirmed basic functions worked as expected (sending "notes", boosting them, following external server's Mastodon users, etc.) I did not test Exim-relay but hopefully it should work as it is wired.