### PR TITLE
Add Typesense

### DIFF
--- a/docs/services/typesense.md
+++ b/docs/services/typesense.md
@@ -20,11 +20,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Typesense
 
-The playbook can install and configure [Typesense](https://typesense.app) for you.
+The playbook can install and configure [Typesense](https://typesense.org) for you.
 
-Typesense is a software for displaying photos and videos on your [Immich](https://immich.app) server in highly customizable slideshows that run in browsers and other devices.
+Typesense is a fast and typo-tolerant fulltext search engine like ElasticSearch.
 
-See the project's [documentation](https://docs.typesense.app) to learn what Typesense does and why it might be useful to you.
+See the project's [documentation](https://typesense.org/docs/) to learn what Typesense does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Typesense](https://github.com/mother-of-all-self-hosting/ansible-role-typesense), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md) online
@@ -34,7 +34,6 @@ For details about configuring the [Ansible role for Typesense](https://github.co
 
 This service requires the following other services:
 
-- [Immich](immich.md)
 - (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Typesense publicly
 
 ## Adjusting the playbook configuration
@@ -57,13 +56,9 @@ typesense_enabled: true
 ########################################################################
 ```
 
-### Set the Immich's API key and URLs
-
-It is also necessary to specify the API key and URLs of the Immich's instance. See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#set-the-immich-instances-api-key) on the role's documentation for details.
-
 ### Expose the instance publicly (optional)
 
-By default, the Typesense is not exposed externally, as it is mainly intended to be used in the internal network, connected to the Immich server.
+By default, the Typesense instance is not exposed externally, as it is mainly intended to be used in the internal network.
 
 To expose it publicly, add the following configuration to your `vars.yml` file (adapt to your needs):
 
@@ -72,16 +67,13 @@ To expose it publicly, add the following configuration to your `vars.yml` file (
 typesense_hostname: "typesense.example.com"
 ```
 
->[!NOTE]
->
-> - Hosting Typesense under a subpath (by configuring the `typesense_path_prefix` variable) does not seem to be possible due to Typesense's technical limitations.
-> - When exposing the instance, it is recommended to consider to set a password (see [this section](https://docs.typesense.app/configuration/additional-options/#password) for the necessary configuration) as well as enable a service for authentication such as [authentik](authentik.md) and [Tinyauth](tinyauth.md) based on your use-case.
+**Note**: hosting Typesense under a subpath (by configuring the `typesense_path_prefix` variable) does not seem to be possible due to Typesense's technical limitations.
 
 ## Usage
 
 After running the command for installation, Typesense becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `typesense_hostname`. With the configuration above, the service is hosted at `https://typesense.example.com`.
 
-To get started, refer to [the documentation](https://docs.typesense.app/guides/digital-picture-frame-typesense-old-tablet/) and other pages for guides about how to display pictures on devices.
+To get started, refer to [the documentation](https://typesense.org/docs/guide/) for guides about how to integrate Typesense.
 
 ## Troubleshooting
 

--- a/docs/services/typesense.md
+++ b/docs/services/typesense.md
@@ -18,24 +18,24 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Immich Kiosk
+# Typesense
 
-The playbook can install and configure [Immich Kiosk](https://immichkiosk.app) for you.
+The playbook can install and configure [Typesense](https://typesense.app) for you.
 
-Immich Kiosk is a software for displaying photos and videos on your [Immich](https://immich.app) server in highly customizable slideshows that run in browsers and other devices.
+Typesense is a software for displaying photos and videos on your [Immich](https://immich.app) server in highly customizable slideshows that run in browsers and other devices.
 
-See the project's [documentation](https://docs.immichkiosk.app) to learn what Immich Kiosk does and why it might be useful to you.
+See the project's [documentation](https://docs.typesense.app) to learn what Typesense does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Immich Kiosk](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md) online
-- 📁 `roles/galaxy/immich_kiosk/docs/configuring-immich-kiosk.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Typesense](https://github.com/mother-of-all-self-hosting/ansible-role-typesense), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md) online
+- 📁 `roles/galaxy/typesense/docs/configuring-typesense.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
 This service requires the following other services:
 
 - [Immich](immich.md)
-- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Immich Kiosk publicly
+- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Typesense publicly
 
 ## Adjusting the playbook configuration
 
@@ -44,45 +44,45 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# immich_kiosk                                                         #
+# typesense                                                            #
 #                                                                      #
 ########################################################################
 
-immich_kiosk_enabled: true
+typesense_enabled: true
 
 ########################################################################
 #                                                                      #
-# /immich_kiosk                                                        #
+# /typesense                                                           #
 #                                                                      #
 ########################################################################
 ```
 
 ### Set the Immich's API key and URLs
 
-It is also necessary to specify the API key and URLs of the Immich's instance. See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md#set-the-immich-instances-api-key) on the role's documentation for details.
+It is also necessary to specify the API key and URLs of the Immich's instance. See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#set-the-immich-instances-api-key) on the role's documentation for details.
 
 ### Expose the instance publicly (optional)
 
-By default, the Immich Kiosk is not exposed externally, as it is mainly intended to be used in the internal network, connected to the Immich server.
+By default, the Typesense is not exposed externally, as it is mainly intended to be used in the internal network, connected to the Immich server.
 
 To expose it publicly, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
-# The hostname at which Immich Kiosk is served.
-immich_kiosk_hostname: "immichkiosk.example.com"
+# The hostname at which Typesense is served.
+typesense_hostname: "typesense.example.com"
 ```
 
 >[!NOTE]
 >
-> - Hosting Immich Kiosk under a subpath (by configuring the `immich_kiosk_path_prefix` variable) does not seem to be possible due to Immich Kiosk's technical limitations.
-> - When exposing the instance, it is recommended to consider to set a password (see [this section](https://docs.immichkiosk.app/configuration/additional-options/#password) for the necessary configuration) as well as enable a service for authentication such as [authentik](authentik.md) and [Tinyauth](tinyauth.md) based on your use-case.
+> - Hosting Typesense under a subpath (by configuring the `typesense_path_prefix` variable) does not seem to be possible due to Typesense's technical limitations.
+> - When exposing the instance, it is recommended to consider to set a password (see [this section](https://docs.typesense.app/configuration/additional-options/#password) for the necessary configuration) as well as enable a service for authentication such as [authentik](authentik.md) and [Tinyauth](tinyauth.md) based on your use-case.
 
 ## Usage
 
-After running the command for installation, Immich Kiosk becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `immich_kiosk_hostname`. With the configuration above, the service is hosted at `https://immichkiosk.example.com`.
+After running the command for installation, Typesense becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `typesense_hostname`. With the configuration above, the service is hosted at `https://typesense.example.com`.
 
-To get started, refer to [the documentation](https://docs.immichkiosk.app/guides/digital-picture-frame-immich-kiosk-old-tablet/) and other pages for guides about how to display pictures on devices.
+To get started, refer to [the documentation](https://docs.typesense.app/guides/digital-picture-frame-typesense-old-tablet/) and other pages for guides about how to display pictures on devices.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/typesense.md
+++ b/docs/services/typesense.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 Tiz
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Immich Kiosk
+
+The playbook can install and configure [Immich Kiosk](https://immichkiosk.app) for you.
+
+Immich Kiosk is a software for displaying photos and videos on your [Immich](https://immich.app) server in highly customizable slideshows that run in browsers and other devices.
+
+See the project's [documentation](https://docs.immichkiosk.app) to learn what Immich Kiosk does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Immich Kiosk](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md) online
+- 📁 `roles/galaxy/immich_kiosk/docs/configuring-immich-kiosk.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Immich](immich.md)
+- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Immich Kiosk publicly
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# immich_kiosk                                                         #
+#                                                                      #
+########################################################################
+
+immich_kiosk_enabled: true
+
+########################################################################
+#                                                                      #
+# /immich_kiosk                                                        #
+#                                                                      #
+########################################################################
+```
+
+### Set the Immich's API key and URLs
+
+It is also necessary to specify the API key and URLs of the Immich's instance. See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md#set-the-immich-instances-api-key) on the role's documentation for details.
+
+### Expose the instance publicly (optional)
+
+By default, the Immich Kiosk is not exposed externally, as it is mainly intended to be used in the internal network, connected to the Immich server.
+
+To expose it publicly, add the following configuration to your `vars.yml` file (adapt to your needs):
+
+```yaml
+# The hostname at which Immich Kiosk is served.
+immich_kiosk_hostname: "immichkiosk.example.com"
+```
+
+>[!NOTE]
+>
+> - Hosting Immich Kiosk under a subpath (by configuring the `immich_kiosk_path_prefix` variable) does not seem to be possible due to Immich Kiosk's technical limitations.
+> - When exposing the instance, it is recommended to consider to set a password (see [this section](https://docs.immichkiosk.app/configuration/additional-options/#password) for the necessary configuration) as well as enable a service for authentication such as [authentik](authentik.md) and [Tinyauth](tinyauth.md) based on your use-case.
+
+## Usage
+
+After running the command for installation, Immich Kiosk becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `immich_kiosk_hostname`. With the configuration above, the service is hosted at `https://immichkiosk.example.com`.
+
+To get started, refer to [the documentation](https://docs.immichkiosk.app/guides/digital-picture-frame-immich-kiosk-old-tablet/) and other pages for guides about how to display pictures on devices.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-immich-kiosk/blob/main/docs/configuring-immich-kiosk.md#troubleshooting) on the role's documentation for details.

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -158,6 +158,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Tinyauth](https://tinyauth.app/) | Simple authentication middleware that adds a login screen or OAuth with providers to your Docker services | [Link](services/tinyauth.md) |
 | [Traefik](https://doc.traefik.io/traefik/) | A container-aware reverse-proxy server | [Link](services/traefik.md) |
 | [TSDProxy](https://almeidapaulopt.github.io/tsdproxy/) | A proxy for virtual services in Tailscale | [Link](services/tsdproxy.md) |
+| [Typesense](https://typesense.org) | Fast and typo-tolerant fulltext search engine | [Link](services/typesense.md) |
 | [Uptime Kuma](https://uptime.kuma.pet/) | A fancy self-hosted monitoring tool | [Link](services/uptime-kuma.md) |
 | [Valkey](https://valkey.io/) | A flexible distributed key-value datastore that is optimized for caching and other realtime workloads. | [Link](services/valkey.md) |
 | [Vaultwarden](https://github.com/dani-garcia/vaultwarden) | A lightweight unofficial and compatible implementation of the [Bitwarden](https://bitwarden.com/) password manager | [Link](services/vaultwarden.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -837,6 +837,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (tsdproxy_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'tsdproxy']} if tsdproxy_enabled else omit) }}
   # /role-specific:tsdproxy
 
+  # role-specific:typesense
+  - |-
+    {{ ({'name': (typesense_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'typesense']} if typesense_enabled else omit) }}
+  # /role-specific:typesense
+
   # role-specific:uptime_kuma
   - |-
     {{ ({'name': (uptime_kuma_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'uptime-kuma']} if uptime_kuma_enabled else omit) }}
@@ -9528,6 +9533,47 @@ container_socket_proxy_api_images_enabled: "{{ true if tsdproxy_docker_endpoint 
 #                                                                      #
 ########################################################################
 # /role-specific:tsdproxy
+
+
+
+# role-specific:typesense
+########################################################################
+#                                                                      #
+# typesense                                                            #
+#                                                                      #
+########################################################################
+
+typesense_enabled: false
+
+typesense_identifier: "{{ mash_playbook_service_identifier_prefix }}typesense"
+
+typesense_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}typesense"
+
+typesense_uid: "{{ mash_playbook_uid }}"
+typesense_gid: "{{ mash_playbook_gid }}"
+
+typesense_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+typesense_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and typesense_hostname | length > 0 }}"
+typesense_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+typesense_environment_variables_api_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'a.typesense', rounds=655555) | to_uuid }}"
+
+# role-specific:traefik
+typesense_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+typesense_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /typesense                                                           #
+#                                                                      #
+########################################################################
+# /role-specific:typesense
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -607,6 +607,10 @@
   version: v1.4.7-0
   name: tsdproxy
   activation_prefix: tsdproxy_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-typesense.git
+  version: v29.0-0
+  name: typesense
+  activation_prefix: typesense_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-uptime_kuma.git
   version: v1.23.16-8
   name: uptime_kuma

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -637,6 +637,10 @@
     - role: galaxy/tsdproxy
     # /role-specific:tsdproxy
 
+    # role-specific:typesense
+    - role: galaxy/typesense
+    # /role-specific:typesense
+
     # role-specific:uptime_kuma
     - role: galaxy/uptime_kuma
     # /role-specific:uptime_kuma


### PR DESCRIPTION
Typesense is a search engine like Elasticsearch, which can be integrated with services like [Vikunja](https://vikunja.io/docs/typesense/). Tested the integration and confirmed it worked.