### PR TITLE
Add Gotify

### DIFF
--- a/docs/services/gotify.md
+++ b/docs/services/gotify.md
@@ -1,0 +1,91 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 Thomas Miceli
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Opengist
+
+The playbook can install and configure [Opengist](https://opengist.io) for you.
+
+Opengist is a self-hosted pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface.
+
+See the project's [documentation](https://opengist.io/docs/) to learn what Opengist does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Opengist](https://codeberg.org/acioustick/ansible-role-opengist), you can check them via:
+- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md) online
+- 📁 `roles/galaxy/opengist/docs/configuring-opengist.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- [Traefik](traefik.md) reverse-proxy server
+- (optional) [Postgres](postgres.md) / MySQL / [MariaDB](mariadb.md) database — Opengist will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# opengist                                                             #
+#                                                                      #
+########################################################################
+
+opengist_enabled: true
+
+opengist_hostname: opengist.example.com
+
+########################################################################
+#                                                                      #
+# /opengist                                                            #
+#                                                                      #
+########################################################################
+```
+
+**Note**: hosting Opengist under a subpath (by configuring the `opengist_path_prefix` variable) does not seem to be possible due to Opengist's technical limitations.
+
+### Set 32-byte hex digits for secret key
+
+You also need to specify **32-byte hex digits** for session store and encrypting MFA data on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
+
+```yaml
+opengist_environment_variables_secret_key: YOUR_SECRET_KEY_HERE
+```
+
+>[!NOTE]
+> Other type of values such as one generated with `pwgen -s 64 1` does not work.
+
+### Select database to use (optional)
+
+By default Opengist is configured to use Postgres, but you can choose other database such as SQLite and MySQL. See [this section](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md#specify-database-optional) on the role's documentation for details.
+
+## Usage
+
+After running the command for installation, the Opengist instance becomes available at the URL specified with `opengist_hostname`. With the configuration above, the service is hosted at `https://opengist.example.com`.
+
+To get started, open the URL with a web browser, and register the account. **Note that the first registered user becomes an administrator automatically.**
+
+## Troubleshooting
+
+See [this section](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [PrivateBin](privatebin.md) — Minimalist, open source online pastebin where the server has zero knowledge of pasted data

--- a/docs/services/gotify.md
+++ b/docs/services/gotify.md
@@ -18,24 +18,24 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Opengist
+# Gotify
 
-The playbook can install and configure [Opengist](https://opengist.io) for you.
+The playbook can install and configure [Gotify](https://gotify.io) for you.
 
-Opengist is a self-hosted pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface.
+Gotify is a self-hosted pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface.
 
-See the project's [documentation](https://opengist.io/docs/) to learn what Opengist does and why it might be useful to you.
+See the project's [documentation](https://gotify.io/docs/) to learn what Gotify does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Opengist](https://codeberg.org/acioustick/ansible-role-opengist), you can check them via:
-- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md) online
-- 📁 `roles/galaxy/opengist/docs/configuring-opengist.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Gotify](https://codeberg.org/acioustick/ansible-role-gotify), you can check them via:
+- 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md) online
+- 📁 `roles/galaxy/gotify/docs/configuring-gotify.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
 This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
-- (optional) [Postgres](postgres.md) / MySQL / [MariaDB](mariadb.md) database — Opengist will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+- (optional) [Postgres](postgres.md) / MySQL / [MariaDB](mariadb.md) database — Gotify will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
 
 ## Adjusting the playbook configuration
 
@@ -44,29 +44,29 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# opengist                                                             #
+# gotify                                                               #
 #                                                                      #
 ########################################################################
 
-opengist_enabled: true
+gotify_enabled: true
 
-opengist_hostname: opengist.example.com
+gotify_hostname: gotify.example.com
 
 ########################################################################
 #                                                                      #
-# /opengist                                                            #
+# /gotify                                                              #
 #                                                                      #
 ########################################################################
 ```
 
-**Note**: hosting Opengist under a subpath (by configuring the `opengist_path_prefix` variable) does not seem to be possible due to Opengist's technical limitations.
+**Note**: hosting Gotify under a subpath (by configuring the `gotify_path_prefix` variable) does not seem to be possible due to Gotify's technical limitations.
 
 ### Set 32-byte hex digits for secret key
 
 You also need to specify **32-byte hex digits** for session store and encrypting MFA data on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
 
 ```yaml
-opengist_environment_variables_secret_key: YOUR_SECRET_KEY_HERE
+gotify_environment_variables_secret_key: YOUR_SECRET_KEY_HERE
 ```
 
 >[!NOTE]
@@ -74,17 +74,17 @@ opengist_environment_variables_secret_key: YOUR_SECRET_KEY_HERE
 
 ### Select database to use (optional)
 
-By default Opengist is configured to use Postgres, but you can choose other database such as SQLite and MySQL. See [this section](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md#specify-database-optional) on the role's documentation for details.
+By default Gotify is configured to use Postgres, but you can choose other database such as SQLite and MySQL. See [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md#specify-database-optional) on the role's documentation for details.
 
 ## Usage
 
-After running the command for installation, the Opengist instance becomes available at the URL specified with `opengist_hostname`. With the configuration above, the service is hosted at `https://opengist.example.com`.
+After running the command for installation, the Gotify instance becomes available at the URL specified with `gotify_hostname`. With the configuration above, the service is hosted at `https://gotify.example.com`.
 
 To get started, open the URL with a web browser, and register the account. **Note that the first registered user becomes an administrator automatically.**
 
 ## Troubleshooting
 
-See [this section](https://codeberg.org/acioustick/ansible-role-opengist/src/branch/master/docs/configuring-opengist.md#troubleshooting) on the role's documentation for details.
+See [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md#troubleshooting) on the role's documentation for details.
 
 ## Related services
 

--- a/docs/services/gotify.md
+++ b/docs/services/gotify.md
@@ -20,11 +20,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Gotify
 
-The playbook can install and configure [Gotify](https://gotify.io) for you.
+The playbook can install and configure [Gotify](https://gotify.net) for you.
 
-Gotify is a self-hosted pastebin powered by Git. All snippets are stored in a Git repository and can be read and/or modified using standard Git commands, or with the web interface.
+Gotify is a simple server for sending and receiving messages.
 
-See the project's [documentation](https://gotify.io/docs/) to learn what Gotify does and why it might be useful to you.
+See the project's [documentation](https://gotify.net/docs/) to learn what Gotify does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Gotify](https://codeberg.org/acioustick/ansible-role-gotify), you can check them via:
 - 🌐 [the role's documentation](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md) online
@@ -35,7 +35,7 @@ For details about configuring the [Ansible role for Gotify](https://codeberg.org
 This service requires the following other services:
 
 - [Traefik](traefik.md) reverse-proxy server
-- (optional) [Postgres](postgres.md) / MySQL / [MariaDB](mariadb.md) database — Gotify will default to [SQLite](https://www.sqlite.org/) if Postgres is not enabled
+- [Postgres](postgres.md) / MySQL / [MariaDB](mariadb.md) / [SQLite](https://www.sqlite.org/) database
 
 ## Adjusting the playbook configuration
 
@@ -61,26 +61,19 @@ gotify_hostname: gotify.example.com
 
 **Note**: hosting Gotify under a subpath (by configuring the `gotify_path_prefix` variable) does not seem to be possible due to Gotify's technical limitations.
 
-### Set 32-byte hex digits for secret key
+### Select database to use
 
-You also need to specify **32-byte hex digits** for session store and encrypting MFA data on the database. To do so, add the following configuration to your `vars.yml` file. The value can be generated with `openssl rand -hex 32` or in another way.
+It is necessary to select a database used by Gotify from a MySQL compatible database, Postgres, and SQLite. See [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md#specify-database) on the role's documentation for details.
 
-```yaml
-gotify_environment_variables_secret_key: YOUR_SECRET_KEY_HERE
-```
+### Set the username and password for the first user
 
->[!NOTE]
-> Other type of values such as one generated with `pwgen -s 64 1` does not work.
-
-### Select database to use (optional)
-
-By default Gotify is configured to use Postgres, but you can choose other database such as SQLite and MySQL. See [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md#specify-database-optional) on the role's documentation for details.
+You also need to set an initial username and password for the first user. Refer to [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branch/master/docs/configuring-gotify.md#specify-username-and-password-for-the-first-user) on the role's documentation.
 
 ## Usage
 
 After running the command for installation, the Gotify instance becomes available at the URL specified with `gotify_hostname`. With the configuration above, the service is hosted at `https://gotify.example.com`.
 
-To get started, open the URL with a web browser, and register the account. **Note that the first registered user becomes an administrator automatically.**
+To get started, open the URL with a web browser to log in to the instance. **Note that the first registered user becomes an administrator automatically.**
 
 ## Troubleshooting
 
@@ -88,4 +81,4 @@ See [this section](https://codeberg.org/acioustick/ansible-role-gotify/src/branc
 
 ## Related services
 
-- [PrivateBin](privatebin.md) — Minimalist, open source online pastebin where the server has zero knowledge of pasted data
+- [ntfy](ntfy.md) — Simple HTTP-based pub-sub notification service to send you push notifications from any computer

--- a/docs/services/ntfy.md
+++ b/docs/services/ntfy.md
@@ -109,3 +109,7 @@ If you are configuring UnifiedPush on a [Matrix](https://matrix.org) client, you
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-ntfy/blob/main/docs/configuring-ntfy.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Gotify](gotify.md) — Simple server for sending and receiving messages

--- a/docs/services/uptime-kuma.md
+++ b/docs/services/uptime-kuma.md
@@ -70,3 +70,8 @@ If you have enabled a self-hosted [ntfy](ntfy.md) server, it is possible to set 
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting//ansible-role-uptime_kuma/blob/main/docs/configuring-uptime-kuma.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Gotify](gotify.md) — Simple server for sending and receiving messages
+- [ntfy](ntfy.md) — Simple HTTP-based pub-sub notification service to send you push notifications from any computer

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -65,6 +65,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Ghostfolio](https://ghostfol.io/) | Wealth management free software to keep track of assets such as stocks, bonds, ETFs, etc.| [Link](services/ghostfolio.md) |
 | [Gitea](https://gitea.io/) | A painless self-hosted [Git](https://git-scm.com/) service. | [Link](services/gitea.md) |
 | [GotHub](https://codeberg.org/gothub/gothub) | View GitHub repositories without exposing your IP address, browsing habits, and other browser fingerprinting data to the website | [Link](services/gothub.md) |
+| [Gotify](https://gotosocial.org/) | Simple server for sending and receiving messages | [Link](services/gotify.md) |
 | [GoToSocial](https://gotosocial.org/) | A self-hosted [ActivityPub](https://activitypub.rocks/) social network server | [Link](services/gotosocial.md) |
 | [Grafana](https://grafana.com/) | An open and composable observability and data visualization platform, often used with [Prometheus](services/prometheus.md) | [Link](services/grafana.md) |
 | [Grafana Loki](https://grafana.com/docs/loki/latest/) | Open-source log aggregation system that helps collect, store, and analyze logs in a scalable and efficient manner | [Link](services/grafana-loki.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -332,6 +332,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (gothub_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'gothub']} if gothub_enabled else omit) }}
   # /role-specific:gothub
 
+  # role-specific:gotify
+  - |-
+    {{ ({'name': (gotify_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'gotify']} if gotify_enabled else omit) }}
+  # /role-specific:gotify
+
   # role-specific:gotosocial
   - |-
     {{ ({'name': (gotosocial_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'gotosocial']} if gotosocial_enabled else omit) }}
@@ -1077,6 +1082,17 @@ mash_playbook_postgres_managed_databases_auto_itemized:
       } if gitea_enabled and gitea_database_hostname == postgres_connection_hostname and gitea_database_type == 'postgres' else omit)
     }}
   # /role-specific:gitea
+
+  # role-specific:gotify
+  - |-
+    {{
+      ({
+        'name': gotify_database_name,
+        'username': gotify_database_postgres_username,
+        'password': gotify_database_postgres_password,
+      } if gotify_enabled and gotify_database_postgres_hostname == postgres_connection_hostname and gotify_database_type == 'postgres' else omit)
+    }}
+  # /role-specific:gotify
 
   # role-specific:gotosocial
   - |-
@@ -3808,6 +3824,67 @@ gothub_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_prima
 
 
 
+# role-specific:gotify
+########################################################################
+#                                                                      #
+# gotify                                                               #
+#                                                                      #
+########################################################################
+
+gotify_enabled: false
+
+gotify_identifier: "{{ mash_playbook_service_identifier_prefix }}gotify"
+
+gotify_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}gotify"
+
+gotify_uid: "{{ mash_playbook_uid }}"
+gotify_gid: "{{ mash_playbook_gid }}"
+
+gotify_systemd_required_services_list_auto: |
+  {{
+    ([mariadb_identifier ~ '.service'] if mariadb_enabled | default(false) and gotify_database_mysql_hostname == mariadb_connection_hostname and gotify_database_type == 'mysql' else [])
+    +
+    ([postgres_identifier ~ '.service'] if postgres_enabled | default(false) and gotify_database_postgres_hostname == postgres_connection_hostname and gotify_database_type == 'postgres' else [])
+  }}
+
+gotify_container_additional_networks_auto: |
+  {{
+    ([mariadb_container_network] if mariadb_enabled | default(false) and gotify_database_mysql_hostname == mariadb_connection_hostname and gotify_container_network != mariadb_container_network and gotify_database_type == 'mysql' else [])
+    +
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([postgres_container_network] if postgres_enabled | default(false) and gotify_database_postgres_hostname == postgres_connection_hostname and gotify_container_network != postgres_container_network and gotify_database_type == 'postgres' else [])
+  }}
+
+gotify_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"
+gotify_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+# role-specific:mariadb
+gotify_database_mysql_hostname: "{{ mariadb_connection_hostname if mariadb_enabled else '' }}"
+gotify_database_mysql_port: "{{ mariadb_connection_port if mariadb_enabled else '3306' }}"
+gotify_database_mysql_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'm.gotify', rounds=655555) | to_uuid }}"
+# /role-specific:mariadb
+
+# role-specific:postgres
+gotify_database_postgres_hostname: "{{ postgres_connection_hostname if postgres_enabled else '' }}"
+gotify_database_postgres_port: "{{ postgres_connection_port if postgres_enabled else '5432' }}"
+gotify_database_postgres_password: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'p.gotify', rounds=655555) | to_uuid }}"
+# /role-specific:postgres
+
+# role-specific:traefik
+gotify_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+gotify_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /gotify                                                              #
+#                                                                      #
+########################################################################
+# /role-specific:gotify
+
+
+
 # role-specific:gotosocial
 ########################################################################
 #                                                                      #
@@ -6369,6 +6446,17 @@ mash_playbook_mariadb_managed_databases_auto_itemized:
       } if forgejo_enabled and forgejo_database_mysql_hostname == mariadb_connection_hostname and forgejo_database_type == 'mysql' else omit)
     }}
   # /role-specific:forgejo
+
+  # role-specific:gotify
+  - |-
+    {{
+      ({
+        'name': gotify_database_name,
+        'username': gotify_database_mysql_username,
+        'password': gotify_database_mysql_password,
+      } if gotify_enabled and gotify_database_mysql_hostname == mariadb_connection_hostname and gotify_database_type == 'mysql' else omit)
+    }}
+  # /role-specific:gotify
 
   # role-specific:healthchecks
   - |-

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -9684,6 +9684,10 @@ uptime_kuma_gid: "{{ mash_playbook_gid }}"
 uptime_kuma_container_additional_networks_auto: |
   {{
     ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+    +
+    ([ntfy_container_network] if ntfy_enabled | default(false) and gotify_container_network != ntfy_container_network else [])
+    +
+    ([gotify_container_network] if gotify_enabled | default(false) and gotify_container_network != gotify_container_network else [])
   }}
 
 uptime_kuma_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled }}"

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -203,6 +203,10 @@
   version: v2025.3.9-0
   name: gothub
   activation_prefix: gothub_
+- src: git+https://codeberg.org/acioustick/ansible-role-gotify.git
+  version: v2.7.3-0
+  name: gotify
+  activation_prefix: gotify_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-gotosocial.git
   version: v0.19.2-1
   name: gotosocial

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -273,6 +273,10 @@
     - role: galaxy/gothub
     # /role-specific:gothub
 
+    # role-specific:gotify
+    - role: galaxy/gotify
+    # /role-specific:gotify
+
     # role-specific:gotosocial
     - role: galaxy/gotosocial
     # /role-specific:gotosocial


### PR DESCRIPTION
[Gotify](https://gotify.net) is a simple server for sending and receiving messages.

This includes an experiment that the default database is not automatically set; users will have to select the database to use explicitly. Ref: https://github.com/mother-of-all-self-hosting/mash-playbook/issues/1061