### PR TITLE
Add Meilisearch

### DIFF
--- a/docs/services/meilisearch.md
+++ b/docs/services/meilisearch.md
@@ -20,11 +20,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Meilisearch
 
-The playbook can install and configure [Meilisearch](https://meilisearch.org) for you.
+The playbook can install and configure [Meilisearch](https://www.meilisearch.com) for you.
 
-Meilisearch is a fast and typo-tolerant fulltext search engine like ElasticSearch.
+Meilisearch is a typo-tolerant fulltext search engine like ElasticSearch with a RESTful search API.
 
-See the project's [documentation](https://meilisearch.org/docs/) to learn what Meilisearch does and why it might be useful to you.
+See the project's [documentation](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch) to learn what Meilisearch does and why it might be useful to you.
 
 For details about configuring the [Ansible role for Meilisearch](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch), you can check them via:
 - 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch/blob/main/docs/configuring-meilisearch.md) online
@@ -73,7 +73,11 @@ meilisearch_hostname: "meilisearch.example.com"
 
 After running the command for installation, Meilisearch becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `meilisearch_hostname`. With the configuration above, the service is hosted at `https://meilisearch.example.com`.
 
-To get started, refer to [the documentation](https://meilisearch.org/docs/guide/) for guides about how to integrate Meilisearch.
+To get started, refer to [the documentation](https://www.meilisearch.com/docs/learn/getting_started/what_is_meilisearch) for guides about how to integrate Meilisearch.
+
+### Obtaining API keys
+
+**It is [not recommended](https://www.meilisearch.com/docs/learn/security/basic_security) to use the master key for operations anything but managing other API keys.** See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch/blob/main/docs/configuring-meilisearch.md#obtaining-api-keys) about the instruction to obtain those API keys.
 
 ## Troubleshooting
 

--- a/docs/services/meilisearch.md
+++ b/docs/services/meilisearch.md
@@ -82,3 +82,7 @@ To get started, refer to [the documentation](https://www.meilisearch.com/docs/le
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch/blob/main/docs/configuring-meilisearch.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Typesense](typesense.md) — Fast and typo-tolerant fulltext search engine

--- a/docs/services/meilisearch.md
+++ b/docs/services/meilisearch.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Aaron Raimist
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Dominik Zajac
+SPDX-FileCopyrightText: 2020 Mickaël Cornière
+SPDX-FileCopyrightText: 2022 François Darveau
+SPDX-FileCopyrightText: 2022 Julian Foad
+SPDX-FileCopyrightText: 2022 Warren Bailey
+SPDX-FileCopyrightText: 2023 Antonis Christofides
+SPDX-FileCopyrightText: 2023 Felix Stupp
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 Tiz
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Typesense
+
+The playbook can install and configure [Typesense](https://typesense.org) for you.
+
+Typesense is a fast and typo-tolerant fulltext search engine like ElasticSearch.
+
+See the project's [documentation](https://typesense.org/docs/) to learn what Typesense does and why it might be useful to you.
+
+For details about configuring the [Ansible role for Typesense](https://github.com/mother-of-all-self-hosting/ansible-role-typesense), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md) online
+- 📁 `roles/galaxy/typesense/docs/configuring-typesense.md` locally, if you have [fetched the Ansible roles](../installing.md)
+
+## Dependencies
+
+This service requires the following other services:
+
+- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Typesense publicly
+
+## Adjusting the playbook configuration
+
+To enable this service, add the following configuration to your `vars.yml` file and re-run the [installation](../installing.md) process:
+
+```yaml
+########################################################################
+#                                                                      #
+# typesense                                                            #
+#                                                                      #
+########################################################################
+
+typesense_enabled: true
+
+########################################################################
+#                                                                      #
+# /typesense                                                           #
+#                                                                      #
+########################################################################
+```
+
+### Expose the instance publicly (optional)
+
+By default, the Typesense instance is not exposed externally, as it is mainly intended to be used in the internal network.
+
+To expose it publicly, add the following configuration to your `vars.yml` file (adapt to your needs):
+
+```yaml
+# The hostname at which Typesense is served.
+typesense_hostname: "typesense.example.com"
+```
+
+**Note**: hosting Typesense under a subpath (by configuring the `typesense_path_prefix` variable) does not seem to be possible due to Typesense's technical limitations.
+
+## Usage
+
+After running the command for installation, Typesense becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `typesense_hostname`. With the configuration above, the service is hosted at `https://typesense.example.com`.
+
+To get started, refer to [the documentation](https://typesense.org/docs/guide/) for guides about how to integrate Typesense.
+
+## Troubleshooting
+
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/meilisearch.md
+++ b/docs/services/meilisearch.md
@@ -18,23 +18,23 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Typesense
+# Meilisearch
 
-The playbook can install and configure [Typesense](https://typesense.org) for you.
+The playbook can install and configure [Meilisearch](https://meilisearch.org) for you.
 
-Typesense is a fast and typo-tolerant fulltext search engine like ElasticSearch.
+Meilisearch is a fast and typo-tolerant fulltext search engine like ElasticSearch.
 
-See the project's [documentation](https://typesense.org/docs/) to learn what Typesense does and why it might be useful to you.
+See the project's [documentation](https://meilisearch.org/docs/) to learn what Meilisearch does and why it might be useful to you.
 
-For details about configuring the [Ansible role for Typesense](https://github.com/mother-of-all-self-hosting/ansible-role-typesense), you can check them via:
-- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md) online
-- 📁 `roles/galaxy/typesense/docs/configuring-typesense.md` locally, if you have [fetched the Ansible roles](../installing.md)
+For details about configuring the [Ansible role for Meilisearch](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch), you can check them via:
+- 🌐 [the role's documentation](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch/blob/main/docs/configuring-meilisearch.md) online
+- 📁 `roles/galaxy/meilisearch/docs/configuring-meilisearch.md` locally, if you have [fetched the Ansible roles](../installing.md)
 
 ## Dependencies
 
 This service requires the following other services:
 
-- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Typesense publicly
+- (optional) [Traefik](traefik.md) — a reverse-proxy server for exposing Meilisearch publicly
 
 ## Adjusting the playbook configuration
 
@@ -43,38 +43,38 @@ To enable this service, add the following configuration to your `vars.yml` file 
 ```yaml
 ########################################################################
 #                                                                      #
-# typesense                                                            #
+# meilisearch                                                          #
 #                                                                      #
 ########################################################################
 
-typesense_enabled: true
+meilisearch_enabled: true
 
 ########################################################################
 #                                                                      #
-# /typesense                                                           #
+# /meilisearch                                                         #
 #                                                                      #
 ########################################################################
 ```
 
 ### Expose the instance publicly (optional)
 
-By default, the Typesense instance is not exposed externally, as it is mainly intended to be used in the internal network.
+By default, the Meilisearch instance is not exposed externally, as it is mainly intended to be used in the internal network.
 
 To expose it publicly, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
-# The hostname at which Typesense is served.
-typesense_hostname: "typesense.example.com"
+# The hostname at which Meilisearch is served.
+meilisearch_hostname: "meilisearch.example.com"
 ```
 
-**Note**: hosting Typesense under a subpath (by configuring the `typesense_path_prefix` variable) does not seem to be possible due to Typesense's technical limitations.
+**Note**: hosting Meilisearch under a subpath (by configuring the `meilisearch_path_prefix` variable) does not seem to be possible due to Meilisearch's technical limitations.
 
 ## Usage
 
-After running the command for installation, Typesense becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `typesense_hostname`. With the configuration above, the service is hosted at `https://typesense.example.com`.
+After running the command for installation, Meilisearch becomes available internally to other services on the same network. If the service is exposed to the internet, it becomes available at the URL specified with `meilisearch_hostname`. With the configuration above, the service is hosted at `https://meilisearch.example.com`.
 
-To get started, refer to [the documentation](https://typesense.org/docs/guide/) for guides about how to integrate Typesense.
+To get started, refer to [the documentation](https://meilisearch.org/docs/guide/) for guides about how to integrate Meilisearch.
 
 ## Troubleshooting
 
-See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#troubleshooting) on the role's documentation for details.
+See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch/blob/main/docs/configuring-meilisearch.md#troubleshooting) on the role's documentation for details.

--- a/docs/services/typesense.md
+++ b/docs/services/typesense.md
@@ -78,3 +78,7 @@ To get started, refer to [the documentation](https://typesense.org/docs/guide/) 
 ## Troubleshooting
 
 See [this section](https://github.com/mother-of-all-self-hosting/ansible-role-typesense/blob/main/docs/configuring-typesense.md#troubleshooting) on the role's documentation for details.
+
+## Related services
+
+- [Meilisearch](meilisearch.md) — Typo-tolerant fulltext search engine with a RESTful search API

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -100,6 +100,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 | [Matrix Rooms Search API](https://github.com/etkecc/mrs) | A fully-featured, standalone, matrix rooms search service. | [Link](services/mrs.md) |
 | [Matterbridge](https://github.com/42wim/matterbridge) | Bridges Messenger Chatrooms | [Link](services/matterbridge.md) |
 | [MediaWiki](https://www.mediawiki.org) | Popular free and open-source wiki software | [Link](services/mediawiki.md) |
+| [Meilisearch](https://www.meilisearch.com) | Typo-tolerant fulltext search engine with a RESTful search API | [Link](services/meilisearch.md) |
 | [Minecraft](https://docker-minecraft-server.readthedocs.io) | The popular voxel-based sandbox game | [Link](services/minecraft.md) |
 | [Miniflux](https://miniflux.app/) | Minimalist and opinionated feed reader. | [Link](services/miniflux.md) |
 | [Misskey](https://misskey-hub.net/en/) | Free decentralized microblogging platform based on the ActivityPub protocol | [Link](services/misskey.md) |

--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -520,6 +520,11 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
     {{ ({'name': (mediawiki_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'mediawiki']} if mediawiki_enabled else omit) }}
   # /role-specific:mediawiki
 
+  # role-specific:meilisearch
+  - |-
+    {{ ({'name': (meilisearch_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'meilisearch']} if meilisearch_enabled else omit) }}
+  # /role-specific:meilisearch
+
   # role-specific:minecraft
   - |-
     {{ ({'name': (minecraft_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'minecraft']} if minecraft_enabled else omit) }}
@@ -6904,6 +6909,47 @@ mediawiki_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_pr
 #                                                                      #
 ########################################################################
 # /role-specific:mediawiki
+
+
+
+# role-specific:meilisearch
+########################################################################
+#                                                                      #
+# meilisearch                                                          #
+#                                                                      #
+########################################################################
+
+meilisearch_enabled: false
+
+meilisearch_identifier: "{{ mash_playbook_service_identifier_prefix }}meilisearch"
+
+meilisearch_base_path: "{{ mash_playbook_base_path }}/{{ mash_playbook_service_base_directory_name_prefix }}meilisearch"
+
+meilisearch_uid: "{{ mash_playbook_uid }}"
+meilisearch_gid: "{{ mash_playbook_gid }}"
+
+meilisearch_container_additional_networks_auto: |
+  {{
+    ([mash_playbook_reverse_proxyable_services_additional_network] if mash_playbook_reverse_proxyable_services_additional_network else [])
+  }}
+
+# Only enable Traefik labels if a hostname is set (indicating that this will be exposed publicly)
+meilisearch_container_labels_traefik_enabled: "{{ mash_playbook_traefik_labels_enabled and meilisearch_hostname | length > 0 }}"
+meilisearch_container_labels_traefik_docker_network: "{{ mash_playbook_reverse_proxyable_services_additional_network }}"
+
+meilisearch_environment_variables_master_key: "{{ '%s' | format(mash_playbook_generic_secret_key) | password_hash('sha512', 'meilisearch.k', rounds=655555) | to_uuid }}"
+
+# role-specific:traefik
+meilisearch_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+meilisearch_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+# /role-specific:traefik
+
+########################################################################
+#                                                                      #
+# /meilisearch                                                         #
+#                                                                      #
+########################################################################
+# /role-specific:meilisearch
 
 
 

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -340,6 +340,10 @@
   version: v1.43.3-0
   name: mediawiki
   activation_prefix: mediawiki_
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-meilisearch.git
+  version: v1.22.3-0
+  name: meilisearch
+  activation_prefix: meilisearch_
 - src: git+https://github.com/XHawk87/ansible-role-minecraft.git
   version: v2025.4.2-0
   name: minecraft

--- a/templates/setup.yml
+++ b/templates/setup.yml
@@ -405,6 +405,10 @@
     - role: galaxy/mediawiki
     # /role-specific:mediawiki
 
+    # role-specific:meilisearch
+    - role: galaxy/meilisearch
+    # /role-specific:meilisearch
+
     # role-specific:minecraft
     - role: galaxy/minecraft
     # /role-specific:minecraft


### PR DESCRIPTION
[Meilisearch](https://www.meilisearch.com) is a typo-tolerant fulltext search engine like ElasticSearch with a RESTful search API. I've tested the tag to output the API keys.