### PR TITLE
jellyseerr service depends on jellyseerr, not jellyfin

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -440,7 +440,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:jellyseerr
   - |-
-    {{ ({'name': (jellyseerr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'jellyseerr']} if jellyfin_enabled else omit) }}
+    {{ ({'name': (jellyseerr_identifier + '.service'), 'priority': 2000, 'groups': ['mash', 'jellyseerr']} if jellyseerr_enabled else omit) }}
   # /role-specific:jellyseerr
 
   # role-specific:jitsi


### PR DESCRIPTION
This causes problem when jellyfin is enabled but jellyseerr is not, as the playbook tries to enable/start jellyseerr service but nothing was installed for it.