### PR TITLE
Set role repositories' URLs to `matchSourceUrls`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,11 @@
       "ignoreUnstable": false,
       "versioning": "loose",
       "matchSourceUrls": [
-        "https://github.com/devture/com.devture.ansible.role{/,}**",
-        "https://github.com/mother-of-all-self-hosting{/,}**"
+        "https://codeberg.org{/,}**",
+        "https://github.com{/,}**",
+        "https://gitlab.com{/,}**",
+        "https://iris.radicle.xyz{/,}**",
+        "https://seed.radicle.garden{/,}**"
       ]
     }
   ],


### PR DESCRIPTION
Including those URLs to `matchSourceUrls` apparently lets Renovate detect updates of the roles managed outside of the MASH organization as well. It also has Renovate track minor or patch level updates of GitHub Action.

cf. https://github.com/mother-of-all-self-hosting/mash-playbook-test/issues/3 and https://github.com/mother-of-all-self-hosting/mash-playbook-test/pulls?q=is%3Apr%20is%3Aclosed (private repository)

This is tested with some cases. It looks fine, but it is not yet to be confirmed to work for every repository.