### PR TITLE
stirling-pdf: update v1.3.2-1 -> v1.5.0-0

### DIFF
--- a/docs/services/stirling-pdf.md
+++ b/docs/services/stirling-pdf.md
@@ -43,7 +43,7 @@ stirling_pdf_install_calibre: false
 
 ### Optional Configuration
 
-You can decide if you want to configure via environment variables. Environment variables outrank the configuration file. 
+You can decide if you want to configure via environment variables. Environment variables outrank the configuration file.
 Using the configuration file via `stirling_pdf_extra_config` is not encurage, since stirling-pdf override it at application start ([see](https://github.com/Bergruebe/ansible-role-stirling-pdf/issues/7)).
 
 To set addition environment variables use `stirling_pdf_environment_variables_extensions` in your `vars.yml` file.

--- a/docs/services/stirling-pdf.md
+++ b/docs/services/stirling-pdf.md
@@ -43,20 +43,16 @@ stirling_pdf_install_calibre: false
 
 ### Optional Configuration
 
-You can decide if you want to configure via environment variables or a configuration file. Environment variables outrank the configuration file.
+You can decide if you want to configure via environment variables. Environment variables outrank the configuration file. 
+Using the configuration file via `stirling_pdf_extra_config` is not encurage, since stirling-pdf override it at application start ([see](https://github.com/Bergruebe/ansible-role-stirling-pdf/issues/7)).
 
 To set addition environment variables use `stirling_pdf_environment_variables_extensions` in your `vars.yml` file.
-To use the configuration file, use `stirling_pdf_extra_config` in your `vars.yml` file.
 
 ```yaml
-stirling_pdf_extra_config: |
-  	system:
-    	defaultLocale: 'de-DE'
-
-# OR
-
 stirling_pdf_environment_variables_extensions: |
-	SYSTEM_DEFAULTLOCALE=de-DE
+  SYSTEM_DEFAULTLOCALE=de-DE
+  SYSTEM_DEFAULTLOCALE=de-DE
+  SECURITY_ENABLELOGIN=false
 ```
 
 Find all possible arguments in the [official documentation](https://docs.stirlingpdf.com/Advanced%20Configuration/How%20to%20add%20configurations).

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -633,7 +633,7 @@
   name: ssh
   activation_prefix: system_security_ssh_
 - src: git+https://github.com/Bergruebe/ansible-role-stirling-pdf.git
-  version: v1.3.2-1
+  version: v1.5.0-0
   name: stirling_pdf
   activation_prefix: stirling_pdf_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-swap.git


### PR DESCRIPTION
This update solves a bug that prevented the container from starting.
Also the documentation is changed, to use environment variables instead of the config file.