### PR TITLE
Fix typo in ansible in docker container mounting ssh key

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -93,7 +93,7 @@ docker run \
 --rm \
 -w /work \
 --mount type=bind,src=`pwd`,dst=/work \
---mount type=bind,src$HOME/.ssh/id_ed25519,dst=/root/.ssh/id_ed25519,ro \
+--mount type=bind,src=$HOME/.ssh/id_ed25519,dst=/root/.ssh/id_ed25519,ro \
 --entrypoint=/bin/sh \
 ghcr.io/devture/ansible:11.6.0-r0-0
 ```


### PR DESCRIPTION
Without this change, docker complains about starting the container with an invalid argument for --mount