### PR TITLE
Allow encoded characters in traefik for collabora online

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -2269,15 +2269,35 @@ traefik_additional_domains_to_obtain_certificates_for_auto: "{{ mash_playbook_tr
 traefik_config_providers_docker_endpoint: "{{ container_socket_proxy_endpoint if container_socket_proxy_enabled else 'unix:///var/run/docker.sock' }}"
 # /role-specific:container_socket_proxy
 
-# role-specific:collabora_online
-traefik_config_entrypoint_web_http_encodedCharacters_enabled: "{{ collabora_online_enabled }}"
-traefik_config_entrypoint_web_http_encodedCharacters_allowEncodedQuestionMark: "{{ collabora_online_enabled }}"
-traefik_config_entrypoint_web_http_encodedCharacters_allowEncodedSlash: "{{ collabora_online_enabled }}"
+traefik_config_entrypoint_web_http_encodedCharacters_enabled: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
 
-traefik_config_entrypoint_web_secure_http_encodedCharacters_enabled: "{{ collabora_online_enabled }}"
-traefik_config_entrypoint_web_secure_http_encodedCharacters_allowEncodedQuestionMark: "{{ collabora_online_enabled }}"
-traefik_config_entrypoint_web_secure_http_encodedCharacters_allowEncodedSlash: "{{ collabora_online_enabled }}"
-# /role-specific:collabora_online
+traefik_config_entrypoint_web_http_encodedCharacters_allowEncodedQuestionMark: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
+
+traefik_config_entrypoint_web_http_encodedCharacters_allowEncodedSlash: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
+
+traefik_config_entrypoint_web_secure_http_encodedCharacters_enabled: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
+
+traefik_config_entrypoint_web_secure_http_encodedCharacters_allowEncodedQuestionMark: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
+
+traefik_config_entrypoint_web_secure_http_encodedCharacters_allowEncodedSlash: |
+  {{
+    collabora_online_enabled | default(false)
+  }}
 
 ########################################################################
 #                                                                      #


### PR DESCRIPTION
Traefik v3.6.4 introduced a more restrictive way of handling encoded characters in paths:
https://doc.traefik.io/traefik/migrate/v3/#v364
Which lead to an inaccessible Collabora Online websocket. Adding allowEncodedSlash and allowEndodedQuestionMark options in traefik fixes this issue.