### PR TITLE
Wire Collabora and Owncast restart flags to role-computed values

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -248,7 +248,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:collabora_online
   - |-
-    {{ ({'name': (collabora_online_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'collabora-online']} if collabora_online_enabled else omit) }}
+    {{ ({'name': (collabora_online_identifier + '.service'), 'priority': 2000, 'restart_necessary': (collabora_online_restart_necessary | bool), 'groups': ['mash', 'collabora-online']} if collabora_online_enabled else omit) }}
   # /role-specific:collabora_online
 
   # role-specific:converse
@@ -877,7 +877,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:owncast
   - |-
-    {{ ({'name': (owncast_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'owncast']} if owncast_enabled else omit) }}
+    {{ ({'name': (owncast_identifier + '.service'), 'priority': 2000, 'restart_necessary': (owncast_restart_necessary | bool), 'groups': ['mash', 'owncast']} if owncast_enabled else omit) }}
   # /role-specific:owncast
 
   # role-specific:oxitraffic


### PR DESCRIPTION
## Summary
This replaces a contaminated prior PR with a clean, scoped wiring fix in `templates/group_vars_mash_servers`.

- Collabora: `restart_necessary` now uses `(collabora_online_restart_necessary | bool)`
- Owncast: `restart_necessary` now uses `(owncast_restart_necessary | bool)`

## Root Cause
Both services had hardcoded `restart_necessary: true` in MASH service wiring, which conflicts with role-computed conditional restart behavior.

## Compatibility
No restart mode change. This only restores intended conditional-restart semantics where role logic already computes `*_restart_necessary`.

## Validation
- `pre-commit run --all-files` passed
- `ansible-lint .` passed

## Notes
This PR supersedes closed PR #2030, which had unrelated historical commits/files.
