### PR TITLE
[docs] setup navidrome with oauth2-proxy authentication

### DIFF
--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -122,6 +122,114 @@ navidrome_container_additional_volumes:
 ########################################################################
 ```
 
+## Securing Navidrome behind OAuth2-Proxy
+
+Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
+
+It is possible to configure the OAuth2-Proxy role to protect Navidrome via OAuth2/OIDC.
+
+Below you will find a sample configutaration that works with the Nextcloud OIDC provider.
+
+```
+########################################################################
+#                                                                      #
+# navidrome                                                            #
+#                                                                      #
+########################################################################
+
+navidrome_enabled: true
+navidrome_hostname: navidrome.hostname
+
+navidrome_oidc_client_enabled: true
+navidrome_oidc_redirect_uris: "https://{{ navidrome_hostname }}/oauth2/callback"
+navidrome_oidc_client_id: "" 	  # pwgen -s 64 1
+navidrome_oidc_client_secret: ""  # pwgen -s 64 1
+
+navidrome_environment_variables_additional_variables: |
+  ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12
+  ND_EXTAUTH_USERHEADER=X-Auth-Request-Preferred-Username
+
+navidrome_container_labels_middlewares:
+  - "{{ navidrome_container_labels_traefik_compression_middleware_name if navidrome_container_labels_traefik_compression_middleware_enabled }}"
+  - "{{ navidrome_identifier ~ '-slashless-redirect' if navidrome_container_labels_traefik_path_prefix != '/' }}"
+  - "{{ navidrome_identifier + '-add-request-headers' if navidrome_container_labels_traefik_additional_request_headers.keys() | length > 0 }}"
+  - "{{ navidrome_identifier + '-add-response-headers' if navidrome_container_labels_traefik_additional_response_headers.keys() | length > 0 }}"
+
+navidrome_container_labels_additional_labels_custom:
+  # Create a middleware which catches "unauthenticated" errors and serves the OAuth-Proxy sign in page.
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.status=401-403
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.service={{ oauth2_proxy_identifier }}
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.query=/oauth2/sign_in?rd={url}
+
+  # Create a middleware which passes each incoming request to OAuth2-Proxy,
+  # so it can decide whether it should be let through (to Hubsite) or should blocked (serving the OAuth2-Proxy sign in page).
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
+
+  # Let the HTTP header defined in ND_EXTAUTH_USERHEADER get passed from OAuth2-Proxy to Navidrome.
+  # See more information about this in the comments for `oauth2_proxy_environment_variable_set_xauthrequest`.
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username
+
+  # Inject the 2 middlewares defined above into the router of the Navidrome service
+  - traefik.http.routers.{{ navidrome_identifier }}.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }},{{ navidrome_identifier }}-oauth-errors,{{ navidrome_identifier }}-oauth-auth
+
+  # Authentication bypass for share and subsonic endpoints
+  # This is necessary if you want to stream music over the subsonic API and let unauthenticated users access the music that you want to share
+  - traefik.http.routers.{{ navidrome_identifier }}-public.rule={{ navidrome_container_labels_traefik_rule }} && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
+  - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.entrypoints={{ navidrome_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.tls={{ navidrome_container_labels_traefik_tls | to_json }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.tls.certResolver={{ navidrome_container_labels_traefik_tls_certResolver }}
+
+########################################################################
+#                                                                      #
+# /navidrome                                                           #
+#                                                                      #
+########################################################################
+```
+
+Then, configure OAuth2-Proxy:
+
+```
+########################################################################
+#                                                                      #
+# oauth2_proxy                                                         #
+#                                                                      #
+########################################################################
+
+oauth2_proxy_enabled: true
+
+oauth2_proxy_environment_variable_provider: oidc
+oauth2_proxy_environment_variable_provider_display_name: "Nextcloud"
+
+oauth2_proxy_environment_variable_oidc_issuer_url: "https://{{ nextcloud_hostname }}"
+oauth2_proxy_environment_variable_redirect_url: "{{ navidrome_oidc_redirect_uris }}"
+oauth2_proxy_environment_variable_client_id: "{{ navidrome_oidc_client_id }}"
+oauth2_proxy_environment_variable_client_secret: "{{ navidrome_oidc_client_secret }}"
+
+oauth2_proxy_environment_variable_code_challenge_method: S256
+
+# Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
+oauth2_proxy_environment_variable_cookie_secret: ""
+
+oauth2_proxy_environment_variables_additional_variables: |
+  OAUTH2_PROXY_WHITELIST_DOMAINS=.oauthprovider.hostname:*
+  
+oauth2_proxy_container_labels_additional_labels_custom:
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.service={{ oauth2_proxy_identifier }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.entrypoints={{ oauth2_proxy_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.tls={{ oauth2_proxy_container_labels_traefik_tls }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.tls.certResolver={{ oauth2_proxy_container_labels_traefik_tls_certResolver }}
+
+########################################################################
+#                                                                      #
+# /oauth2_proxy                                                        #
+#                                                                      #
+########################################################################
+```
+
 ## Usage
 
 After running the command for installation, the Navidrome instance becomes available at the URL specified with `navidrome_hostname` and `navidrome_path_prefix`. With the configuration above, the service is hosted at `https://mash.example.com/navidrome`.

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -130,7 +130,7 @@ It is possible to configure the OAuth2-Proxy role to protect Navidrome via OAuth
 
 Below you will find a sample configutaration that works with the Nextcloud OIDC provider.
 
-```
+```yml
 ########################################################################
 #                                                                      #
 # navidrome                                                            #
@@ -191,7 +191,7 @@ navidrome_container_labels_additional_labels_custom:
 
 Then, configure OAuth2-Proxy:
 
-```
+```yml
 ########################################################################
 #                                                                      #
 # oauth2_proxy                                                         #

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -1,6 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2023 Slavi Pantaleev
 SPDX-FileCopyrightText: 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2026 Timofej Luitle
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -208,7 +208,7 @@ navidrome_container_labels_additional_labels_custom:
 > [!NOTE]
 > Currently Navidrome user auto-creation from external sources is tightly coupled to serving the webpage index and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.
 
-Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
+Configure OAuth2-Proxy as follows (e.g. with Keycloak):
 
 ```yml
 ########################################################################

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -141,8 +141,7 @@ Below you will find a sample configuration with the [Nextcloud OIDC provider](ht
 # Your other Navidrome configuration goes here.
 # See the documentation in navidrome.md.
 
-# Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES
-# to include traefik's internal IP
+# Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES to include traefik's internal IP
 # Specify the HTTP header containing the username (expects Remote-User by default)
 navidrome_environment_variables_additional_variables: |
   ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -248,6 +248,8 @@ oauth2_proxy_container_labels_additional_labels_custom:
 ########################################################################
 ```
 
+The first account to login via OAuth2-Proxy will become an administrator, subsequent logins will be created as non-admin user.
+
 ## Usage
 
 After running the command for installation, the Navidrome instance becomes available at the URL specified with `navidrome_hostname` and `navidrome_path_prefix`. With the configuration above, the service is hosted at `https://mash.example.com/navidrome`.

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -142,7 +142,8 @@ Below you will find a sample configuration with the [Nextcloud OIDC provider](ht
 # See the documentation in navidrome.md.
 
 # Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES
-# Specify the HTTP header containing the username (defaults to Remote-User)
+# to include traefik's internal IP
+# Specify the HTTP header containing the username (expects Remote-User by default)
 navidrome_environment_variables_additional_variables: |
   ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12
   ND_EXTAUTH_USERHEADER=X-Auth-Request-Preferred-Username
@@ -193,6 +194,20 @@ navidrome_container_labels_additional_labels_custom:
 ########################################################################
 ```
 
+
+> [!CAUTION]
+> Above configuration uses the less invasive 1. mode documented in [oauth2-proxy.md](./oauth2-proxy.md) and navidrome will see requests as coming from traefik.
+> Accordingly we tell navidrome to trust the username header coming from our traefik reverse-proxy.
+> 
+> But navidrome will automatically create new users at first login passed on by the username header if the source is trusted.
+> 
+> In order to keep traefik from forwarding our trusted username header from external clients and granting them new accounts we need to strip this header from all external requests:
+> ```yml
+> navidrome_container_labels_traefik_additional_request_headers_custom:
+>   X-Auth-Request-Preferred-Username: ""
+> ```
+
+
 Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 
 ```yml
@@ -204,10 +219,10 @@ Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 
 oauth2_proxy_enabled: true
 
-oauth2_proxy_environment_variable_provider: oidc
-oauth2_proxy_environment_variable_provider_display_name: "Nextcloud"
+oauth2_proxy_environment_variable_provider: keycloak-oidc
+oauth2_proxy_environment_variable_provider_display_name: Keycloak
 
-oauth2_proxy_environment_variable_oidc_issuer_url: "https://{{ nextcloud_hostname }}"
+oauth2_proxy_environment_variable_oidc_issuer_url: https://keycloak.example.com/realms/my-realm
 oauth2_proxy_environment_variable_redirect_url: "https://{{ navidrome_hostname }}/oauth2/callback"
 # Authorize oauth2-proxy with your oidc credentials
 oauth2_proxy_environment_variable_client_id: ""
@@ -217,9 +232,6 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 
 # Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ""
-
-oauth2_proxy_environment_variables_additional_variables: |
-  OAUTH2_PROXY_WHITELIST_DOMAINS=.nextcloud.hostname:*
   
 oauth2_proxy_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -224,11 +224,11 @@ oauth2_proxy_enabled: true
 oauth2_proxy_environment_variable_provider: keycloak-oidc
 oauth2_proxy_environment_variable_provider_display_name: Keycloak
 
-oauth2_proxy_environment_variable_oidc_issuer_url: https://keycloak.example.com/realms/my-realm
-oauth2_proxy_environment_variable_redirect_url: "https://{{ navidrome_hostname }}/oauth2/callback"
 # Authorize oauth2-proxy with your oidc credentials
 oauth2_proxy_environment_variable_client_id: ""
 oauth2_proxy_environment_variable_client_secret: ""
+oauth2_proxy_environment_variable_oidc_issuer_url: https://keycloak.example.com/realms/my-realm
+oauth2_proxy_environment_variable_redirect_url: "https://{{ navidrome_hostname }}/oauth2/callback"
 
 oauth2_proxy_environment_variable_code_challenge_method: S256
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -194,7 +194,7 @@ navidrome_container_labels_additional_labels_custom:
 
 
 > [!CAUTION]
-> As we use the less invasive 1. mode documented in [oauth2-proxy.md](./oauth2-proxy.md) navidrome will see requests as coming from traefik.
+> As we use the less invasive 2. mode documented in [oauth2-proxy.md](./oauth2-proxy.md) navidrome will see requests as coming from traefik.
 > Accordingly we tell navidrome to trust the username header coming from our traefik reverse-proxy.
 > 
 > But navidrome will automatically create new users at first login passed on by the username header if the source is trusted.
@@ -205,7 +205,7 @@ navidrome_container_labels_additional_labels_custom:
 >   X-Auth-Request-Preferred-Username: ""
 > ```
 >
-> Consider the more invasive 2. mode of oauth2-proxy if you want to exclude traefik from your trusted IPs altogether and only accept authorization requests from oauth2-proxy directly.
+> Consider the more invasive 1. mode of oauth2-proxy if you want to exclude traefik from your trusted IPs altogether and only accept authorization requests from oauth2-proxy directly.
 
 > [!NOTE]
 > Currently Navidrome user auto-creation from external sources is tightly coupled to serving the webpage index and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -125,7 +125,7 @@ navidrome_container_additional_volumes:
 
 ## Securing Navidrome behind OAuth2-Proxy
 
-Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
+Navidrome currently only supports [external authentication]([https://www.navidrome.org/docs/usage/integration/authentication/](https://www.navidrome.org/docs/getting-started/extauth-quickstart/)) via a trusted reverse-proxy.
 
 It is possible to configure the OAuth2-Proxy role to protect Navidrome via OAuth2/OIDC.
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -127,9 +127,9 @@ navidrome_container_additional_volumes:
 
 Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 
-Nevertheless, it is possible to configure the [OAuth2-Proxy](./oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
+Leveraging the [OAuth2-Proxy](./oauth2-proxy.md) role it is possible to protect Navidrome behind OAuth2/OIDC.
 
-Below you will find a sample configutaration that works with the [Nextcloud OIDC provider](https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/main/docs/configuring-oidc-provider.md).
+Below you will find a sample configuration with the [Nextcloud OIDC provider](https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/main/docs/configuring-oidc-provider.md).
 
 ```yml
 ########################################################################

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -158,7 +158,6 @@ navidrome_container_labels_middlewares:
   - "{{ navidrome_identifier + '-add-request-headers' if navidrome_container_labels_traefik_additional_request_headers.keys() | length > 0 }}"
   - "{{ navidrome_identifier + '-add-response-headers' if navidrome_container_labels_traefik_additional_response_headers.keys() | length > 0 }}"
 
-# Add oauth-related labels
 navidrome_container_labels_additional_labels_custom:
   # Create a middleware which catches "unauthenticated" errors and serves the OAuth-Proxy sign in page.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.status=401-403

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -123,7 +123,7 @@ navidrome_container_additional_volumes:
 ########################################################################
 ```
 
-## Securing Navidrome behind OAuth2-Proxy
+### Securing Navidrome behind OAuth2-Proxy
 
 Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -178,7 +178,7 @@ navidrome_container_labels_additional_labels_custom:
 
   # Authentication bypass for share and subsonic endpoints
   # Necessary if you want to stream music over the subsonic API and access shared content without authentication
-  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`{{ navidrome_path_prefix }}/share/`) || PathPrefix(`{{ navidrome_path_prefix }}/rest/`))
+  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
   - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.entrypoints={{ navidrome_container_labels_traefik_entrypoints }}

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -127,7 +127,7 @@ navidrome_container_additional_volumes:
 
 Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 
-It is possible to configure the [OAuth2-Proxy](./oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
+Nevertheless, it is possible to configure the [OAuth2-Proxy](./oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
 
 Below you will find a sample configutaration that works with the [Nextcloud OIDC provider](https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/main/docs/configuring-oidc-provider.md).
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -203,6 +203,7 @@ navidrome_container_labels_additional_labels_custom:
 > ```yml
 > navidrome_container_labels_traefik_additional_request_headers_custom:
 >   X-Auth-Request-Preferred-Username: ""
+> ```
 
 
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -206,7 +206,7 @@ navidrome_container_labels_additional_labels_custom:
 > ```
 
 > [!NOTE]
-> Currently Navidrome user auto-creation from external sources is tightly coupled to serving the index webpage and may fail when the webpage is cached, e.g. when changing accounts within the same browser.
+> Currently Navidrome user auto-creation from external sources is tightly coupled to serving the index webpage and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.
 
 Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -178,7 +178,7 @@ navidrome_container_labels_additional_labels_custom:
 
   # Authentication bypass for share and subsonic endpoints
   # Necessary if you want to stream music over the subsonic API and access shared content without authentication
-  - traefik.http.routers.{{ navidrome_identifier }}-public.rule={{ navidrome_container_labels_traefik_rule }} && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
+  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`{{ navidrome_path_prefix }}/share/`) || PathPrefix(`{{ navidrome_path_prefix }}/rest/`))
   - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.entrypoints={{ navidrome_container_labels_traefik_entrypoints }}

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -169,7 +169,7 @@ navidrome_container_labels_additional_labels_custom:
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
 
-  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to Navidrome to identify users.
+  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to identify users in Navidrome.
   # See more information about this in the comments for `oauth2_proxy_environment_variable_set_xauthrequest`.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -131,6 +131,9 @@ Leveraging the [OAuth2-Proxy](./oauth2-proxy.md) role it is possible to protect 
 
 Below you will find a sample configuration with the [Nextcloud OIDC provider](https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/main/docs/configuring-oidc-provider.md).
 
+> [!NOTE]
+> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, adjust the `PathPrefix` of the public rule to bypass authentication correctly.
+
 ```yml
 ########################################################################
 #                                                                      #

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -248,7 +248,7 @@ oauth2_proxy_container_labels_additional_labels_custom:
 ########################################################################
 ```
 
-The first account to login via OAuth2-Proxy will become an administrator, subsequent logins will be created as non-admin user.
+The first user to login via OAuth2-Proxy will become an administrator, subsequent logins will be created as non-admin user.
 
 ## Usage
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -206,7 +206,7 @@ navidrome_container_labels_additional_labels_custom:
 > ```
 
 > [!NOTE]
-> Currently Navidrome user auto-creation from external sources is tightly coupled to serving the index webpage and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.
+> Currently Navidrome user auto-creation from external sources is tightly coupled to serving the webpage index and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.
 
 Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -199,7 +199,7 @@ navidrome_container_labels_additional_labels_custom:
 > 
 > But navidrome will automatically create new users at first login passed on by the username header if the source is trusted.
 > 
-> In order to keep traefik from forwarding our trusted username header from external clients and granting them new accounts we need to strip this header from all external requests:
+> Therefore we need to strip this header from all external requests in order to avoid risking unauthorized user creation:
 > ```yml
 > navidrome_container_labels_traefik_additional_request_headers_custom:
 >   X-Auth-Request-Preferred-Username: ""

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -127,7 +127,7 @@ navidrome_container_additional_volumes:
 
 Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 
-It is possible to configure the OAuth2-Proxy role to protect Navidrome via OAuth2/OIDC.
+It is possible to configure the [OAuth2-Proxy](https://github.com/zenphonix/mash-playbook/blob/docs-update/docs/services/oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
 
 Below you will find a sample configutaration that works with the Nextcloud OIDC provider.
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -194,7 +194,7 @@ navidrome_container_labels_additional_labels_custom:
 
 
 > [!CAUTION]
-> Above configuration uses the less invasive 1. mode documented in [oauth2-proxy.md](./oauth2-proxy.md) and navidrome will see requests as coming from traefik.
+> As we use the less invasive 1. mode documented in [oauth2-proxy.md](./oauth2-proxy.md) navidrome will see requests as coming from traefik.
 > Accordingly we tell navidrome to trust the username header coming from our traefik reverse-proxy.
 > 
 > But navidrome will automatically create new users at first login passed on by the username header if the source is trusted.

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -138,19 +138,20 @@ Below you will find a sample configutaration that works with the [Nextcloud OIDC
 #                                                                      #
 ########################################################################
 
-navidrome_enabled: true
-navidrome_hostname: navidrome.hostname
+# Your other Navidrome configuration goes here.
+# See the documentation in navidrome.md.
 
-navidrome_oidc_client_enabled: true
-navidrome_oidc_redirect_uris: "https://{{ navidrome_hostname }}/oauth2/callback"
-# Put your oauth2/oidc credentials here
-navidrome_oidc_client_id: ""
-navidrome_oidc_client_secret: ""
-
+# Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES
+# Specify the header containing the username (defaults to Remote-User)
 navidrome_environment_variables_additional_variables: |
   ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12
   ND_EXTAUTH_USERHEADER=X-Auth-Request-Preferred-Username
 
+# Block potentially malicious forwarding of the username-header from external clients
+navidrome_container_labels_traefik_additional_request_headers_custom:
+  X-Auth-Request-Preferred-Username: ""
+
+# Recollect middlewares from templates/labels.j2
 navidrome_container_labels_middlewares:
   - "{{ navidrome_container_labels_traefik_compression_middleware_name if navidrome_container_labels_traefik_compression_middleware_enabled }}"
   - "{{ navidrome_identifier ~ '-slashless-redirect' if navidrome_container_labels_traefik_path_prefix != '/' }}"

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -231,7 +231,7 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 # Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ""
 
-#Serve the oauth2-proxy authentication page
+# Serve the oauth2-proxy authentication page
 oauth2_proxy_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.service={{ oauth2_proxy_identifier }}

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -142,22 +142,23 @@ Below you will find a sample configutaration that works with the [Nextcloud OIDC
 # See the documentation in navidrome.md.
 
 # Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES
-# Specify the header containing the username (defaults to Remote-User)
+# Specify the HTTP header containing the username (defaults to Remote-User)
 navidrome_environment_variables_additional_variables: |
   ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12
   ND_EXTAUTH_USERHEADER=X-Auth-Request-Preferred-Username
 
-# Block potentially malicious forwarding of the username-header from external clients
+# Block potentially malicious forwarding of the username header from external clients
 navidrome_container_labels_traefik_additional_request_headers_custom:
   X-Auth-Request-Preferred-Username: ""
 
-# Recollect middlewares from templates/labels.j2
+# Recollect middlewares from templates/labels.j2 for reuse
 navidrome_container_labels_middlewares:
   - "{{ navidrome_container_labels_traefik_compression_middleware_name if navidrome_container_labels_traefik_compression_middleware_enabled }}"
   - "{{ navidrome_identifier ~ '-slashless-redirect' if navidrome_container_labels_traefik_path_prefix != '/' }}"
   - "{{ navidrome_identifier + '-add-request-headers' if navidrome_container_labels_traefik_additional_request_headers.keys() | length > 0 }}"
   - "{{ navidrome_identifier + '-add-response-headers' if navidrome_container_labels_traefik_additional_response_headers.keys() | length > 0 }}"
 
+# Add oauth-related labels
 navidrome_container_labels_additional_labels_custom:
   # Create a middleware which catches "unauthenticated" errors and serves the OAuth-Proxy sign in page.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.status=401-403
@@ -165,11 +166,11 @@ navidrome_container_labels_additional_labels_custom:
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.query=/oauth2/sign_in?rd={url}
 
   # Create a middleware which passes each incoming request to OAuth2-Proxy,
-  # so it can decide whether it should be let through (to Hubsite) or should blocked (serving the OAuth2-Proxy sign in page).
+  # so it can decide whether it should be let through (to Navidrome) or should be forwarded to the OAuth2-Proxy sign in page.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
 
-  # Let the HTTP header defined in ND_EXTAUTH_USERHEADER get passed from OAuth2-Proxy to Navidrome.
+  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to Navidrome.
   # See more information about this in the comments for `oauth2_proxy_environment_variable_set_xauthrequest`.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username
 
@@ -177,7 +178,7 @@ navidrome_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ navidrome_identifier }}.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }},{{ navidrome_identifier }}-oauth-errors,{{ navidrome_identifier }}-oauth-auth
 
   # Authentication bypass for share and subsonic endpoints
-  # This is necessary if you want to stream music over the subsonic API and let unauthenticated users access the music that you want to share
+  # Necessary if you want to stream music over the subsonic API and access shared content without authentication
   - traefik.http.routers.{{ navidrome_identifier }}-public.rule={{ navidrome_container_labels_traefik_rule }} && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
   - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
@@ -192,7 +193,7 @@ navidrome_container_labels_additional_labels_custom:
 ########################################################################
 ```
 
-Then, configure OAuth2-Proxy:
+Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 
 ```yml
 ########################################################################
@@ -207,9 +208,10 @@ oauth2_proxy_environment_variable_provider: oidc
 oauth2_proxy_environment_variable_provider_display_name: "Nextcloud"
 
 oauth2_proxy_environment_variable_oidc_issuer_url: "https://{{ nextcloud_hostname }}"
-oauth2_proxy_environment_variable_redirect_url: "{{ navidrome_oidc_redirect_uris }}"
-oauth2_proxy_environment_variable_client_id: "{{ navidrome_oidc_client_id }}"
-oauth2_proxy_environment_variable_client_secret: "{{ navidrome_oidc_client_secret }}"
+oauth2_proxy_environment_variable_redirect_url: "https://{{ navidrome_hostname }}/oauth2/callback"
+# Authorize oauth2-proxy with your oidc credentials
+oauth2_proxy_environment_variable_client_id: ""
+oauth2_proxy_environment_variable_client_secret: ""
 
 oauth2_proxy_environment_variable_code_challenge_method: S256
 
@@ -217,7 +219,7 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 oauth2_proxy_environment_variable_cookie_secret: ""
 
 oauth2_proxy_environment_variables_additional_variables: |
-  OAUTH2_PROXY_WHITELIST_DOMAINS=.oauthprovider.hostname:*
+  OAUTH2_PROXY_WHITELIST_DOMAINS=.nextcloud.hostname:*
   
 oauth2_proxy_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -231,7 +231,7 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 # Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ""
 
-Serve the oauth2-proxy authentication page
+#Serve the oauth2-proxy authentication page
 oauth2_proxy_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.service={{ oauth2_proxy_identifier }}

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -125,7 +125,7 @@ navidrome_container_additional_volumes:
 
 ## Securing Navidrome behind OAuth2-Proxy
 
-Navidrome currently only supports [external authentication]([https://www.navidrome.org/docs/usage/integration/authentication/](https://www.navidrome.org/docs/getting-started/extauth-quickstart/)) via a trusted reverse-proxy.
+Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 
 It is possible to configure the OAuth2-Proxy role to protect Navidrome via OAuth2/OIDC.
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -230,7 +230,8 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 
 # Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ""
-  
+
+Serve the oauth2-proxy authentication page
 oauth2_proxy_container_labels_additional_labels_custom:
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)
   - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.service={{ oauth2_proxy_identifier }}

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -264,3 +264,5 @@ You can also connect various Subsonic-API-compatible [apps](https://www.navidrom
 ## Recommended other services
 
 - [Syncthing](syncthing.md) — a continuous file synchronization program which synchronizes files between two or more computers in real time. See [Syncthing integration](#syncthing-integration)
+- [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
+

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -127,9 +127,9 @@ navidrome_container_additional_volumes:
 
 Navidrome currently only supports [external authentication](https://www.navidrome.org/docs/usage/integration/authentication/) via a trusted reverse-proxy.
 
-It is possible to configure the [OAuth2-Proxy](https://github.com/zenphonix/mash-playbook/blob/docs-update/docs/services/oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
+It is possible to configure the [OAuth2-Proxy](./oauth2-proxy.md) role to protect Navidrome via OAuth2/OIDC.
 
-Below you will find a sample configutaration that works with the Nextcloud OIDC provider.
+Below you will find a sample configutaration that works with the [Nextcloud OIDC provider](https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/main/docs/configuring-oidc-provider.md).
 
 ```yml
 ########################################################################

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -169,7 +169,7 @@ navidrome_container_labels_additional_labels_custom:
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
 
-  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to Navidrome.
+  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to Navidrome to identify users.
   # See more information about this in the comments for `oauth2_proxy_environment_variable_set_xauthrequest`.
   - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -143,7 +143,7 @@ navidrome_hostname: navidrome.hostname
 
 navidrome_oidc_client_enabled: true
 navidrome_oidc_redirect_uris: "https://{{ navidrome_hostname }}/oauth2/callback"
-# Put your oauth2/oidc credentials below:
+# Put your oauth2/oidc credentials here
 navidrome_oidc_client_id: ""
 navidrome_oidc_client_secret: ""
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -204,6 +204,8 @@ navidrome_container_labels_additional_labels_custom:
 > navidrome_container_labels_traefik_additional_request_headers_custom:
 >   X-Auth-Request-Preferred-Username: ""
 > ```
+>
+> Consider the more invasive 2. mode of oauth2-proxy if you want to exclude traefik from your trusted IPs altogether and only accept authorization requests from oauth2-proxy directly.
 
 > [!NOTE]
 > Currently Navidrome user auto-creation from external sources is tightly coupled to serving the webpage index and may fail when the webpage is loaded from cache upon first login, e.g. when changing accounts within the same browser.

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -205,7 +205,8 @@ navidrome_container_labels_additional_labels_custom:
 >   X-Auth-Request-Preferred-Username: ""
 > ```
 
-
+> [!NOTE]
+> Currently Navidrome user auto-creation from external sources is tightly coupled to serving the index webpage and may fail when the webpage is cached, e.g. when changing accounts within the same browser.
 
 Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):
 

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -203,7 +203,7 @@ navidrome_container_labels_additional_labels_custom:
 > ```yml
 > navidrome_container_labels_traefik_additional_request_headers_custom:
 >   X-Auth-Request-Preferred-Username: ""
-> ```
+
 
 
 Configure OAuth2-Proxy as follows (e.g. with Nextcloud OIDC provider):

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -264,5 +264,4 @@ You can also connect various Subsonic-API-compatible [apps](https://www.navidrom
 ## Recommended other services
 
 - [Syncthing](syncthing.md) — a continuous file synchronization program which synchronizes files between two or more computers in real time. See [Syncthing integration](#syncthing-integration)
-- [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, and others) to SSO-protect services which do not support SSO natively
-
+- [OAuth2-Proxy](oauth2-proxy.md) — Reverse proxy and static file server that provides authentication using OpenID Connect providers (Google, GitHub, authentik, Keycloak, Nextcloud and others) to SSO-protect services which do not support SSO natively

--- a/docs/services/navidrome.md
+++ b/docs/services/navidrome.md
@@ -143,8 +143,9 @@ navidrome_hostname: navidrome.hostname
 
 navidrome_oidc_client_enabled: true
 navidrome_oidc_redirect_uris: "https://{{ navidrome_hostname }}/oauth2/callback"
-navidrome_oidc_client_id: "" 	  # pwgen -s 64 1
-navidrome_oidc_client_secret: ""  # pwgen -s 64 1
+# Put your oauth2/oidc credentials below:
+navidrome_oidc_client_id: ""
+navidrome_oidc_client_secret: ""
 
 navidrome_environment_variables_additional_variables: |
   ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -15,7 +15,7 @@ OAuth2-Proxy can be used in 2 different modes:
 
 1. Capturing incoming traffic for the app (e.g. https://app.example.com/), and then proxying it to the application container if the user is authenticated
 
-2. Letting the application itself capture incoming traffic for itself (on https://app.example.com/) and use Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware to authenticate the request via OAuth2-Proxy. In this case, OAuth2-Proxy will only handle the `/oauth2/` prefix on the application domain (e.g. https://app.example.com/oauth/).
+2. Letting the application itself capture incoming traffic for itself (on https://app.example.com/) and use Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware to authenticate the request via OAuth2-Proxy. In this case, OAuth2-Proxy will only handle the `/oauth2/` prefix on the application domain (e.g. https://app.example.com/oauth2/).
 
 The 1st one is a bit invasive, as it requires moving all custom reverse-proxying configuration for the handled domain to the OAuth2-Proxy side.
 
@@ -91,7 +91,7 @@ oauth2_proxy_container_labels_additional_labels_custom:
 ########################################################################
 ```
 
-After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service oauth-2proxy`.
+After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service oauth2-proxy`.
 
 This merely configures OAuth2-Proxy to handle the `/oauth2/` paths for Hubsite's domain.
 

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -74,7 +74,7 @@ oauth2_proxy_environment_variable_redirect_url: "https://{{ hubsite_hostname }}/
 
 oauth2_proxy_environment_variable_code_challenge_method: S256
 
-# Generate this with: `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
+# Generate this with: `python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ''
 
 oauth2_proxy_container_labels_additional_labels_custom:

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -78,11 +78,11 @@ oauth2_proxy_environment_variable_code_challenge_method: S256
 oauth2_proxy_environment_variable_cookie_secret: ''
 
 oauth2_proxy_container_labels_additional_labels_custom:
-  traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.rule=Host(`{{ hubsite_hostname }}`) && PathPrefix(`/oauth2/`)
-  traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.service={{ oauth2_proxy_identifier }}
-  traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.entrypoints={{ oauth2_proxy_container_labels_traefik_entrypoints }}
-  traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls={{ oauth2_proxy_container_labels_traefik_tls }}
-  traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls.certResolver={{ oauth2_proxy_container_labels_traefik_tls_certResolver }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.rule=Host(`{{ hubsite_hostname }}`) && PathPrefix(`/oauth2/`)
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.service={{ oauth2_proxy_identifier }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.entrypoints={{ oauth2_proxy_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls={{ oauth2_proxy_container_labels_traefik_tls }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls.certResolver={{ oauth2_proxy_container_labels_traefik_tls_certResolver }}
 
 ########################################################################
 #                                                                      #

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -104,7 +104,10 @@ This merely configures OAuth2-Proxy to handle the `/oauth2/` paths for Navidrome
 
 Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain Navidrome is running, we need to set up Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware, so that all Navidrome requests would consult OAuth2-Proxy.
 
-The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy.
+The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy and the [Externalized Authentication Quick Start](https://www.navidrome.org/docs/getting-started/extauth-quickstart/) guide.
+
+> [!NOTE]
+> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, edit the PathPrefix of the public rule to bypass authentication correctly.
 
 ```yml
 ########################################################################
@@ -153,7 +156,7 @@ navidrome_container_labels_additional_labels_custom:
 
   # Authentication bypass for share and subsonic endpoints
   # Necessary if you want to stream music over the subsonic API and access shared content without authentication
-  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`{{ navidrome_path_prefix }}/share/`) || PathPrefix(`{{ navidrome_path_prefix }}/rest/`))
+  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`/share/`) || PathPrefix(`/rest/`))
   - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
   - traefik.http.routers.{{ navidrome_identifier }}-public.entrypoints={{ navidrome_container_labels_traefik_entrypoints }}
@@ -163,6 +166,61 @@ navidrome_container_labels_additional_labels_custom:
 ########################################################################
 #                                                                      #
 # /navidrome                                                           #
+#                                                                      #
+########################################################################
+```
+
+After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service hubsite`.
+
+Specific services (e.g. [Nextcloud](nextcloud.md)) provide Ansible variables (`nextcloud_container_labels_traefik_http_middlewares_custom`) for injecting new middlewares at a specific position (priority) in the list. Others services (Ansible roles) do not support this yet, which would prevent you from using them this way. Consider submitting an issue or better yet opening a PR to improve these services.
+
+### Ihatemoney configuration adjustments
+
+Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain Ihatemoney is running, we need to set up Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware, so that all Ihatemoney requests would consult OAuth2-Proxy.
+
+The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy.
+
+```yml
+########################################################################
+#                                                                      #
+# ihatemoney                                                           #
+#                                                                      #
+########################################################################
+
+# Your other Ihatemoney configuration goes here.
+# See the documentation in ihatemoney.md.
+
+# Enable public project creation to resecure the endpoint with oauth2-proxy
+ihatemoney_public_project_creation: true
+
+# Recollect middlewares from templates/labels.j2 for reuse
+ihatemoney_container_labels_middlewares:
+  - "{{ ihatemoney_identifier ~ '-add-request-headers' if ihatemoney_container_labels_traefik_additional_request_headers.keys() | length > 0 }}"
+  - "{{ ihatemoney_identifier ~ '-add-response-headers' if ihatemoney_container_labels_traefik_additional_response_headers.keys() | length > 0 }}"
+
+ihatemoney_container_labels_additional_labels:
+  # Create a middleware which catches "unauthenticated" errors and serves the OAuth-Proxy sign in page.
+  - traefik.http.middlewares.{{ ihatemoney_identifier }}-oauth-errors.errors.status=401-403
+  - traefik.http.middlewares.{{ ihatemoney_identifier }}-oauth-errors.errors.service={{ oauth2_proxy_identifier }}
+  - traefik.http.middlewares.{{ ihatemoney_identifier }}-oauth-errors.errors.query=/oauth2/sign_in?rd={url}
+
+  # Create a middleware which passes each incoming request to OAuth2-Proxy,
+  # so it can decide whether it should be let through (to Ihatemoney) or should be forwarded to the OAuth2-Proxy sign in page.
+  - traefik.http.middlewares.{{ ihatemoney_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
+  - traefik.http.middlewares.{{ ihatemoney_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
+
+  # Create a router for /create, /admin and /dashboard endpoints to secure with oauth2-proxy
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.rule={{ ihatemoney_container_labels_traefik_rule }} && (PathPrefix(`/create`) || PathPrefix(`/admin`) || PathPrefix(`/dashboard`))
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.service={{ ihatemoney_identifier }}
+  # Inject the forwardauth middlewares defined above
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.middlewares={{ ihatemoney_container_labels_middlewares | select() | join(',') }},{{ ihatemoney_identifier }}-oauth-errors,{{ ihatemoney_identifier }}-oauth-auth
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.entrypoints={{ ihatemoney_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.tls={{ ihatemoney_container_labels_traefik_tls | to_json }}
+  - traefik.http.routers.{{ ihatemoney_identifier }}-private.tls.certResolver={{ ihatemoney_container_labels_traefik_tls_certResolver }}
+
+########################################################################
+#                                                                      #
+# /ihatemoney                                                          #
 #                                                                      #
 ########################################################################
 ```

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -107,7 +107,7 @@ Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain N
 The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy and the [Externalized Authentication Quick Start](https://www.navidrome.org/docs/getting-started/extauth-quickstart/) guide.
 
 > [!NOTE]
-> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, edit the PathPrefix of the public rule to bypass authentication correctly.
+> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, edit the `PathPrefix` of the public rule to bypass authentication correctly.
 
 ```yml
 ########################################################################

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -169,8 +169,6 @@ navidrome_container_labels_additional_labels_custom:
 
 After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service hubsite`.
 
-Some [services](../supported-services.md) already define their own `middlewares` in their Traefik `labels` file, so you may not be able to inject new ones the same way as done for Navidrome above.
-
 Specific services (e.g. [Nextcloud](nextcloud.md)) provide Ansible variables (`nextcloud_container_labels_traefik_http_middlewares_custom`) for injecting new middlewares at a specific position (priority) in the list. Others services (Ansible roles) do not support this yet, which would prevent you from using them this way. Consider submitting an issue or better yet opening a PR to improve these services.
 
 

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -107,7 +107,7 @@ Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain N
 The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy and the [Externalized Authentication Quick Start](https://www.navidrome.org/docs/getting-started/extauth-quickstart/) guide.
 
 > [!NOTE]
-> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, edit the `PathPrefix` of the public rule to bypass authentication correctly.
+> This example assumes that you serve Navidrome under a dedicated hostname. If you are serving Navidrome under a path prefix, adjust the `PathPrefix` of the public rule to bypass authentication correctly.
 
 ```yml
 ########################################################################

--- a/docs/services/oauth2-proxy.md
+++ b/docs/services/oauth2-proxy.md
@@ -44,9 +44,9 @@ This can be any of the supported providers. If hosting your own (via this playbo
 
 The configuration is [provider](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/)-specific and also depends on the service you're SSO-protecting, on which server it runs (in relation to OAuth-Proxy), etc.
 
-Below is a **sample** configuration for protecting a static website (in this case powered by the [Hubsite](hubsite.md)) service via [Keycloak](keycloak.md).
+Below is a **sample** configuration for protecting a static website (in this case powered by the [Navidrome](navidrome.md)) service via [Keycloak](keycloak.md).
 
-For this to work as described here, both OAuth2-Proxy and the protected service (e.g. [Hubsite](hubsite.md)) need to run on the same machine.
+For this to work as described here, both OAuth2-Proxy and the protected service (e.g. [Navidrome](navidrome.md)) need to run on the same machine.
 
 Keycloak may run anywhere.
 
@@ -67,22 +67,24 @@ oauth2_proxy_enabled: true
 oauth2_proxy_environment_variable_provider: keycloak-oidc
 oauth2_proxy_environment_variable_provider_display_name: SSO
 
-oauth2_proxy_environment_variable_client_id: hubsite
-oauth2_proxy_environment_variable_client_secret: ''
+# Authorize oauth2-proxy with your oidc credentials
+oauth2_proxy_environment_variable_client_id: ""
+oauth2_proxy_environment_variable_client_secret: ""
 oauth2_proxy_environment_variable_oidc_issuer_url: https://keycloak.example.com/realms/my-realm
-oauth2_proxy_environment_variable_redirect_url: "https://{{ hubsite_hostname }}/oauth2/callback"
+oauth2_proxy_environment_variable_redirect_url: "https://{{ navidrome_hostname }}/oauth2/callback"
 
 oauth2_proxy_environment_variable_code_challenge_method: S256
 
 # Generate this with: `python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())'`
 oauth2_proxy_environment_variable_cookie_secret: ''
 
+# Serve the oauth2-proxy authentication page
 oauth2_proxy_container_labels_additional_labels_custom:
-  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.rule=Host(`{{ hubsite_hostname }}`) && PathPrefix(`/oauth2/`)
-  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.service={{ oauth2_proxy_identifier }}
-  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.entrypoints={{ oauth2_proxy_container_labels_traefik_entrypoints }}
-  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls={{ oauth2_proxy_container_labels_traefik_tls }}
-  - traefik.http.routers.{{ oauth2_proxy_identifier }}-hubsite.tls.certResolver={{ oauth2_proxy_container_labels_traefik_tls_certResolver }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.rule=Host(`{{ navidrome_hostname }}`) && PathPrefix(`/oauth2/`)
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.service={{ oauth2_proxy_identifier }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.entrypoints={{ oauth2_proxy_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.tls={{ oauth2_proxy_container_labels_traefik_tls }}
+  - traefik.http.routers.{{ oauth2_proxy_identifier }}-navidrome.tls.certResolver={{ oauth2_proxy_container_labels_traefik_tls_certResolver }}
 
 ########################################################################
 #                                                                      #
@@ -93,59 +95,81 @@ oauth2_proxy_container_labels_additional_labels_custom:
 
 After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service oauth2-proxy`.
 
-This merely configures OAuth2-Proxy to handle the `/oauth2/` paths for Hubsite's domain.
+This merely configures OAuth2-Proxy to handle the `/oauth2/` paths for Navidrome's domain.
 
-[Hubsite configuration adjustments](#hubsite-configuration-adjustments) are also necessary, so proceed to do those as well.
+[Navidrome configuration adjustments](#navidrome-configuration-adjustments) are also necessary, so proceed to do those as well.
 
 
-### Hubsite configuration adjustments
+### Navidrome configuration adjustments
 
-Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain Hubsite is running, we need to set up Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware, so that all Hubsite requests would consult OAuth2-Proxy.
+Now that OAuth2-Proxy is ready and handling the `/oauth2/` paths on the domain Navidrome is running, we need to set up Traefik's [ForwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) middleware, so that all Navidrome requests would consult OAuth2-Proxy.
 
 The configuration described below is based on the official [Configuring for use with the Traefik (v2) ForwardAuth middleware](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#configuring-for-use-with-the-traefik-v2-forwardauth-middleware) documentation of OAuth2-Proxy.
 
 ```yml
 ########################################################################
 #                                                                      #
-# hubsite                                                              #
+# navidrome                                                            #
 #                                                                      #
 ########################################################################
 
-# Your other Hubsite configuration goes here.
-# See the documentation in hubsite.md.
+# Your other Navidrome configuration goes here.
+# See the documentation in navidrome.md.
 
-hubsite_container_labels_additional_labels_custom:
+# Enable external authentication by setting ND_EXTAUTH_TRUSTEDSOURCES to include traefik's internal IP
+# Specify the HTTP header containing the username (expects Remote-User by default)
+navidrome_environment_variables_additional_variables: |
+  ND_EXTAUTH_TRUSTEDSOURCES=172.16.0.0/12
+  ND_EXTAUTH_USERHEADER=X-Auth-Request-Preferred-Username
+
+# Block potentially malicious forwarding of the username header from external clients
+navidrome_container_labels_traefik_additional_request_headers_custom:
+  X-Auth-Request-Preferred-Username: ""
+
+# Recollect middlewares from templates/labels.j2 for reuse
+navidrome_container_labels_middlewares:
+  - "{{ navidrome_container_labels_traefik_compression_middleware_name if navidrome_container_labels_traefik_compression_middleware_enabled }}"
+  - "{{ navidrome_identifier ~ '-slashless-redirect' if navidrome_container_labels_traefik_path_prefix != '/' }}"
+  - "{{ navidrome_identifier + '-add-request-headers' if navidrome_container_labels_traefik_additional_request_headers.keys() | length > 0 }}"
+  - "{{ navidrome_identifier + '-add-response-headers' if navidrome_container_labels_traefik_additional_response_headers.keys() | length > 0 }}"
+
+navidrome_container_labels_additional_labels_custom:
   # Create a middleware which catches "unauthenticated" errors and serves the OAuth-Proxy sign in page.
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-errors.errors.status=401-403
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-errors.errors.service={{ oauth2_proxy_identifier }}
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-errors.errors.query=/oauth2/sign_in?rd={url}
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.status=401-403
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.service={{ oauth2_proxy_identifier }}
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-errors.errors.query=/oauth2/sign_in?rd={url}
 
   # Create a middleware which passes each incoming request to OAuth2-Proxy,
-  # so it can decide whether it should be let through (to Hubsite) or should blocked (serving the OAuth2-Proxy sign in page).
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
+  # so it can decide whether it should be let through (to Navidrome) or should be forwarded to the OAuth2-Proxy sign in page.
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.address=http://{{ oauth2_proxy_identifier }}:{{ oauth2_proxy_container_process_http_port }}/oauth2/auth
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
 
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-auth.forwardAuth.trustForwardHeader=true
-
-  # Let a few HTTP headers set by OAuth2-Proxy get passed to Hubsite.
-  # Hubsite is a static website, so it cannot make use of them.
-  # Nevertheless, this is here as an example of how you can whitelist headers,
-  # so that applications which can make use of these headers can benefit from it.
+  # Allow forwarding the HTTP header defined in ND_EXTAUTH_USERHEADER to identify users in Navidrome.
   # See more information about this in the comments for `oauth2_proxy_environment_variable_set_xauthrequest`.
-  - traefik.http.middlewares.{{ hubsite_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username, X-Auth-Request-Groups
+  - traefik.http.middlewares.{{ navidrome_identifier }}-oauth-auth.forwardAuth.authResponseHeaders=X-Auth-Request-Preferred-Username
 
-  # Inject the 2 middlewares defined above into the router of the Hubsite service
-  - traefik.http.routers.{{ hubsite_identifier }}.middlewares={{ hubsite_identifier }}-oauth-errors,{{ hubsite_identifier }}-oauth-auth
+  # Inject the 2 middlewares defined above into the router of the Navidrome service
+  - traefik.http.routers.{{ navidrome_identifier }}.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }},{{ navidrome_identifier }}-oauth-errors,{{ navidrome_identifier }}-oauth-auth
+
+  # Authentication bypass for share and subsonic endpoints
+  # Necessary if you want to stream music over the subsonic API and access shared content without authentication
+  - traefik.http.routers.{{ navidrome_identifier }}-public.rule=Host(`{{ navidrome_hostname }}`) && (PathPrefix(`{{ navidrome_path_prefix }}/share/`) || PathPrefix(`{{ navidrome_path_prefix }}/rest/`))
+  - traefik.http.routers.{{ navidrome_identifier }}-public.service={{ navidrome_identifier }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.middlewares={{ navidrome_container_labels_middlewares | select() | join(',') }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.entrypoints={{ navidrome_container_labels_traefik_entrypoints }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.tls={{ navidrome_container_labels_traefik_tls | to_json }}
+  - traefik.http.routers.{{ navidrome_identifier }}-public.tls.certResolver={{ navidrome_container_labels_traefik_tls_certResolver }}
 
 ########################################################################
 #                                                                      #
-# /hubsite                                                             #
+# /navidrome                                                           #
 #                                                                      #
 ########################################################################
 ```
 
 After adding this to your `vars.yml` file, [re-run the playbook](../installing.md): `just install-service hubsite`.
 
-Some [services](../supported-services.md) already define their own `middlewares` in their Traefik `labels` file, so you may not be able to inject new ones the same way as done for Hubsite above.
+Some [services](../supported-services.md) already define their own `middlewares` in their Traefik `labels` file, so you may not be able to inject new ones the same way as done for Navidrome above.
 
 Specific services (e.g. [Nextcloud](nextcloud.md)) provide Ansible variables (`nextcloud_container_labels_traefik_http_middlewares_custom`) for injecting new middlewares at a specific position (priority) in the list. Others services (Ansible roles) do not support this yet, which would prevent you from using them this way. Consider submitting an issue or better yet opening a PR to improve these services.
 


### PR DESCRIPTION
A thorough guide to how to setup oauth2-proxy as a OIDC provider for navidrome via [Externalized Authentication](https://www.navidrome.org/docs/usage/integration/authentication/) + some minor corrections