### PR TITLE
Add pre-commit safety hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,9 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
+      - id: check-merge-conflict
+        args: ["--assume-in-merge"]
+      - id: detect-private-key
       - id: check-json
       - id: check-shebang-scripts-are-executable
       - id: check-toml


### PR DESCRIPTION
Add two standard pre-commit-hooks safety checks to catch unresolved merge conflict markers and accidentally committed private keys before they reach the repository.