### PR TITLE
Docs: move documentation out of examples/hosts and various clarifications

### DIFF
--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -1,17 +1,17 @@
 <!--
-SPDX-FileCopyrightText: 2018 - 2025 Slavi Pantaleev
-SPDX-FileCopyrightText: 2018 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2018-2024 MDAD project contributors
+SPDX-FileCopyrightText: 2018-2025 Slavi Pantaleev
 SPDX-FileCopyrightText: 2020 Sabine Laszakovits
 SPDX-FileCopyrightText: 2021 Cody Neiman
 SPDX-FileCopyrightText: 2021 Matthew Cengia
 SPDX-FileCopyrightText: 2021 Toni Spets
 SPDX-FileCopyrightText: 2022 Julian Foad
 SPDX-FileCopyrightText: 2022 Vladimir Panteleev
-SPDX-FileCopyrightText: 2022 - 2023 Julian-Samuel Gebühr
-SPDX-FileCopyrightText: 2023 MASH project contributors
-SPDX-FileCopyrightText: 2023 Shreyas Ajjarapu
+SPDX-FileCopyrightText: 2022, 2023 Julian-Samuel Gebühr
 SPDX-FileCopyrightText: 2023 Nikita Chernyi
-SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2023 Shreyas Ajjarapu
+SPDX-FileCopyrightText: 2023-2026 MASH project contributors
+SPDX-FileCopyrightText: 2024-2026 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -34,7 +34,60 @@ If you've configured your DNS records and retrieved the playbook's source code t
 
 6. (optional, advanced) you may wish to keep your `inventory` directory under version control with [git](https://git-scm.com/) or any other version-control system. The `inventory` directory path is ignored via `.gitignore`, so it won't be part of the playbook repository. You can safely create a new git repository inside that directory with `git init`, etc.
 
-For a basic installation, that's all you need.
+## Inventory connection options
+
+The `inventory/hosts` file defines which servers Ansible manages and how it connects to them.
+
+`ansible_host` is the address or hostname Ansible uses for SSH. This is often the server's public IP address, but it can be another SSH-reachable address if your control node reaches the server through a private network, VPN, or other routing. It does not by itself define where services are publicly reachable; public DNS records and service hostnames are configured separately in [Configuring DNS settings](configuring-dns.md) and in your `vars.yml` file.
+
+The default example connects as `root`:
+
+```ini
+[mash_servers]
+mash.example.com ansible_host=YOUR_SERVER_SSH_ADDRESS_HERE ansible_ssh_user=root
+```
+
+To connect as a non-root user and elevate privileges with sudo, use `ansible_become`:
+
+```ini
+[mash_servers]
+mash.example.com ansible_host=YOUR_SERVER_SSH_ADDRESS_HERE ansible_ssh_user=username ansible_become=true ansible_become_user=root
+```
+
+If sudo requires a password, let Ansible ask for it interactively by adding `--ask-become-pass` to your `ansible-playbook` or `just` command. If you need to store `ansible_become_password`, keep it in an encrypted Vault variable instead of plaintext inventory.
+
+If your SSH private key is protected by a passphrase, unlock it before running the playbook, for example with `ssh-agent` and `ssh-add`. Ansible's default SSH connection plugin does not provide an interactive channel for decrypting SSH private keys during a playbook run, so an encrypted key that has not been loaded may fail instead of prompting you. See Ansible's [SSH connection plugin documentation](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/ssh_connection.html) for details.
+
+For encrypted Ansible Vault files, add `--ask-vault-pass` to your commands. Inventories using named or multiple Vault IDs may need `--vault-id <id>@prompt` instead. See Ansible's [Vault password documentation](https://docs.ansible.com/projects/ansible/latest/vault_guide/vault_managing_passwords.html). When both Vault and sudo passwords are required, pass both flags, for example:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start --ask-vault-pass --ask-become-pass
+```
+
+or the equivalent [`just`](just.md) command:
+
+```sh
+just install-all --ask-vault-pass --ask-become-pass
+```
+
+If SSH listens on a non-standard port, add `ansible_port`:
+
+```ini
+mash.example.com ansible_host=YOUR_SERVER_SSH_ADDRESS_HERE ansible_ssh_user=root ansible_port=2222
+```
+
+If you run this playbook on the same server that it manages, you can use a local Ansible connection. Keep the inventory host name aligned with the `inventory/host_vars/<host>/vars.yml` directory, and set `ansible_connection` for that host:
+
+```ini
+[mash_servers]
+mash.example.com ansible_connection=local
+```
+
+This keeps the host identity and host-specific variables consistent while using a local connection. Ansible's inventory and connection behavior is documented in its [inventory guide](https://docs.ansible.com/projects/ansible/latest/inventory_guide/intro_inventory.html) and [connection details](https://docs.ansible.com/projects/ansible/latest/inventory_guide/connection_details.html).
+
+Python interpreter requirements and discovery problems are covered in [Prerequisites](prerequisites.md#managed-node). If Ansible detects the wrong Python interpreter for a host, set an explicit value such as `ansible_python_interpreter=/usr/bin/python3`.
+
+## Configuring interoperability with other services
 
 If you're installing services on the same server using another playbook (like [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy)) or you already have [Traefik](./services/traefik.md) or [Docker](./services/docker.md) installed on the server, consult our [Interoperability](./interoperability.md) documentation.
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -46,7 +46,11 @@ It is recommended to get yourself familiar with the [playbook tags](playbook-tag
 
 If you **don't** use SSH keys for authentication, but rather a regular password, you may need to add `--ask-pass` to the all Ansible (or `just`) commands.
 
-If you **do** use SSH keys for authentication, **and** use a non-root user to *become* root (sudo), you may need to add `-K` (`--ask-become-pass`) to all Ansible commands.
+If your SSH private key is protected by a passphrase, make sure it is unlocked before running the playbook, for example with `ssh-agent` and `ssh-add`. See [Configuring the playbook](configuring-playbook.md#inventory-connection-options) for more connection and credential options.
+
+If you **do** use SSH keys for authentication, **and** use a non-root user to *become* root (sudo), you may need to add `--ask-become-pass` to all Ansible commands.
+
+If your inventory uses encrypted Ansible Vault files, you may need to add `--ask-vault-pass` to raw `ansible-playbook` commands. When using `just`, pass the same long flag form, for example `just install-all --ask-vault-pass`.
 
 There 2 ways to start the installation process — depending on whether you're [Installing a brand new server (without importing data)](#installing-a-brand-new-server-without-importing-data) or [Installing a server into which you'll import old data](#installing-a-server-into-which-youll-import-old-data).
 

--- a/docs/just.md
+++ b/docs/just.md
@@ -27,6 +27,8 @@ Here are some examples of shortcuts:
 | `just start-all`                               | (Re-)starts all services                                                                                       |
 | `just stop-group postgres`                     | Stop only the Postgres service                                                                                 |
 
+When both Vault and sudo/become credentials are required, pass both prompt flags together. For example: `just install-all --ask-vault-pass --ask-become-pass`.
+
 While [our documentation on prerequisites](prerequisites.md) lists `just` as one of the requirements for installation, using `just` is optional. If you find it difficult to install it, do not find it useful, or want to prefer raw `ansible-playbook` commands for some reason, feel free to run all commands manually. For example, you can run `ansible-galaxy` directly to install the Ansible roles: `rm -rf roles/galaxy; ansible-galaxy install -r requirements.yml -p roles/galaxy/ --force`.
 
 ## Difference between playbook tags and shortcuts

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -14,13 +14,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <sup>Prerequisites > [Configuring DNS settings](configuring-dns.md) > [Getting the playbook](getting-the-playbook.md) > [Configuring the playbook](configuring-playbook.md) > [Installing](installing.md)</sup>
 
-To install services using this Ansible playbook, you need to prepare several requirements both on your local computer (where you will run the playbook to configure the server) and the server (where the playbook will install the services for you). **These requirements need to be set up manually** before proceeding to the next step.
+To install services using this Ansible playbook, you need to prepare several requirements both on the Ansible control node (where you will run the playbook to configure the server) and the managed node (the server where the playbook will install services for you). See Ansible's [basic concepts](https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html) documentation for the terminology. **These requirements need to be set up manually** before proceeding to the next step.
 
 We will be using `example.com` as the domain in the following instruction. Please remember to replace it with your own domain before running any commands.
 
-## Your local computer
+## Control node
 
 - [Ansible](http://ansible.com/) program. It's used to run this playbook and configures your server for you. Take a look at [our guide about Ansible](ansible.md) for more information, as well as [version requirements](ansible.md#supported-ansible-versions) and alternative ways to run Ansible.
+
+- [Python](https://www.python.org/) on the control node. Ansible and helper commands run locally, so the control node's Python version must be supported by the Ansible version you use. See Ansible's [ansible-core support matrix](https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) for current control-node and managed-node Python support.
 
 - [passlib](https://passlib.readthedocs.io/en/stable/index.html) Python library. See [this official documentation](https://passlib.readthedocs.io/en/stable/install.html#installation-instructions) for an instruction to install it. On most distros, you need to install some `python-passlib` or `py3-passlib` package, etc.
 
@@ -32,7 +34,7 @@ We will be using `example.com` as the domain in the following instruction. Pleas
 
 - (Optional) [regex](https://github.com/mrabarnett/mrab-regex) Python library for running `just optimize`. On most distros, you need to install some `python-regex` or `py3-regex` package, etc.
 
-## Server
+## Managed node
 
 - (Recommended) An **x86** server running one of these operating systems that make use of [systemd](https://systemd.io/):
   - **Archlinux**
@@ -48,7 +50,7 @@ We will be using `example.com` as the domain in the following instruction. Pleas
 
 - `root` access to your server (or a user capable of elevating to `root` via `sudo`).
 
-- [Python](https://www.python.org/). Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python3`). On some distros, Ansible may incorrectly [detect the Python version](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) (2 vs 3) and you may need to explicitly specify the interpreter path in `inventory/hosts` during installation (e.g. `ansible_python_interpreter=/usr/bin/python3`)
+- [Python](https://www.python.org/) on the managed node. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python3`). The managed node's Python version must also be supported by the Ansible version you use. On some distros, Ansible may incorrectly [detect the Python interpreter](https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html) and you may need to explicitly specify the interpreter path in `inventory/hosts` during installation (e.g. `ansible_python_interpreter=/usr/bin/python3`)
 
 - [sudo](https://www.sudo.ws/), even when you've configured Ansible to log in as `root`, because this Ansible playbook sometimes uses the Ansible [become](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html) module to perform tasks as another user (e.g. `mash`) and the `become` module's default implementation uses `sudo`. Some distributions, like a minimal Debian net install, do not include the `sudo` package by default.
 

--- a/examples/hosts
+++ b/examples/hosts
@@ -1,20 +1,7 @@
-# To connect using a non-root user (and elevate to root with sudo later),
-# replace `ansible_ssh_user=root` with something like this: `ansible_ssh_user=username ansible_become=true ansible_become_user=root`.
-# If sudo requires a password, either add `ansible_become_password=PASSWORD_HERE` to the host line
-# or tell Ansible to ask you for the password interactively by adding a `--ask-become-pass` (`-K`) flag to all `ansible-playbook` (or `just`) commands.
-#
-# For improved Ansible performance, SSH pipelining is enabled by default in `ansible.cfg`.
-# If this causes SSH connection troubles, disable it by adding `ansible_ssh_pipelining=False`
-# to the host line below or by adding `ansible_ssh_pipelining: False` to your variables file.
-#
-# If SSH is configured to listen to a non-standard port (i.e. something different than port 22), you need to add `ansible_port=<your configured SSH port>`.
-#
-# If you're running this Ansible playbook on the same server as the one you're installing to,
-# consider adding an additional `ansible_connection=local` argument to the host line below.
-#
-# Ansible may fail to discover which Python interpreter to use on the host for some distros (like Ubuntu 20.04).
-# You may sometimes need to explicitly add the argument `ansible_python_interpreter=/usr/bin/python3`
-# to the host line below.
+# This file defines which servers the playbook manages.
+# For non-root SSH users, sudo/become, non-standard SSH ports, local
+# connections, and Python interpreter settings, see:
+# docs/configuring-playbook.md#inventory-connection-options
 
 [mash_servers]
-<your-domain> ansible_host=<your-server's external IP address> ansible_ssh_user=root
+<your-domain> ansible_host=YOUR_SERVER_SSH_ADDRESS_HERE ansible_ssh_user=root


### PR DESCRIPTION
I attempt to address the issue https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4604, though I've ended up doing so for MASH rather than MDAD initially.

I've also added af few other changes that I believe would be helpful based on the issues/questions seen raised by users :) 