### PR TITLE
Update Headplane (v0.6.2-0 → v0.6.2-1)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -513,7 +513,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:headplane
   - |-
-    {{ ({'name': (headplane_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'headplane']} if headplane_enabled else omit) }}
+    {{ ({'name': (headplane_identifier + '.service'), 'priority': 2000, 'restart_necessary': (headplane_restart_necessary | bool), 'groups': ['mash', 'headplane']} if headplane_enabled else omit) }}
   # /role-specific:headplane
 
   # role-specific:headscale

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -337,7 +337,7 @@
   name: grafana
   activation_prefix: grafana_
 - src: git+https://github.com/spatterIight/ansible-role-headplane.git
-  version: v0.6.2-0
+  version: v0.6.2-1
   name: headplane
   activation_prefix: headplane_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-headscale.git


### PR DESCRIPTION
Requires https://github.com/spatterIight/ansible-role-headplane/pull/8 and a new release `v0.6.2-1`