### PR TITLE
Update FlareSolverr (v3.4.1-0 → v3.4.1-1)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -425,7 +425,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:flaresolverr
   - |-
-    {{ ({'name': (flaresolverr_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'flaresolverr']} if flaresolverr_enabled else omit) }}
+    {{ ({'name': (flaresolverr_identifier + '.service'), 'priority': 2000, 'restart_necessary': (flaresolverr_restart_necessary | bool), 'groups': ['mash', 'flaresolverr']} if flaresolverr_enabled else omit) }}
   # /role-specific:flaresolverr
 
   # role-specific:flatnotes

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -273,7 +273,7 @@
   name: filebrowser_quantum
   activation_prefix: filebrowser_quantum_
 - src: git+https://github.com/sudo-Tiz/ansible-role-flaresolverr.git
-  version: v3.4.1-0
+  version: v3.4.1-1
   name: flaresolverr
   activation_prefix: flaresolverr_
 - src: git+https://seed.radicle.garden/z49LkutSMcaLA2DBazn1h4V6Pn6GK.git


### PR DESCRIPTION
Requires https://github.com/sudo-Tiz/ansible-role-flaresolverr/pull/4 and a new release `v3.4.1-1`