### PR TITLE
Update Radarr (v6.1.1-0 → v6.1.1-1)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1067,7 +1067,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:radarr
   - |-
-    {{ ({'name': (radarr_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'radarr']} if radarr_enabled else omit) }}
+    {{ ({'name': (radarr_identifier + '.service'), 'priority': 2000, 'restart_necessary': (radarr_restart_necessary | bool), 'groups': ['mash', 'radarr']} if radarr_enabled else omit) }}
   # /role-specific:radarr
 
   # role-specific:radicale

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -765,7 +765,7 @@
   name: rabbitmq
   activation_prefix: rabbitmq_
 - src: git+https://github.com/spatterIight/ansible-role-radarr.git
-  version: v6.1.1-0
+  version: v6.1.1-1
   name: radarr
   activation_prefix: radarr_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-radicale.git


### PR DESCRIPTION
Require https://github.com/spatterIight/ansible-role-radarr/pull/15 and a new release `v6.1.1-1`.