### PR TITLE
Update Jackett (v0.24.1622-0 → v0.24.1870-0)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -587,7 +587,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:jackett
   - |-
-    {{ ({'name': (jackett_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'jackett']} if jackett_enabled else omit) }}
+    {{ ({'name': (jackett_identifier + '.service'), 'priority': 2000, 'restart_necessary': (jackett_restart_necessary | bool), 'groups': ['mash', 'jackett']} if jackett_enabled else omit) }}
   # /role-specific:jackett
 
   # role-specific:jellyfin

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -393,7 +393,7 @@
   name: inspircd
   activation_prefix: inspircd_
 - src: git+https://github.com/spatterIight/ansible-role-jackett.git
-  version: v0.24.1622-0
+  version: v0.24.1622-1
   name: jackett
   activation_prefix: jackett_
 - src: git+https://github.com/spatterIight/ansible-role-jellyfin.git


### PR DESCRIPTION
Requires https://github.com/spatterIight/ansible-role-jackett/pull/9 and a new release `v0.24.1622-1`