### PR TITLE
Update Jellyfin (v10.11.8-1 → v10.11.8-2)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -592,7 +592,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:jellyfin
   - |-
-    {{ ({'name': (jellyfin_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'jellyfin']} if jellyfin_enabled else omit) }}
+    {{ ({'name': (jellyfin_identifier + '.service'), 'priority': 2000, 'restart_necessary': (jellyfin_restart_necessary | bool), 'groups': ['mash', 'jellyfin']} if jellyfin_enabled else omit) }}
   # /role-specific:jellyfin
 
   # role-specific:jitsi

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -397,7 +397,7 @@
   name: jackett
   activation_prefix: jackett_
 - src: git+https://github.com/spatterIight/ansible-role-jellyfin.git
-  version: v10.11.8-1
+  version: v10.11.8-2
   name: jellyfin
   activation_prefix: jellyfin_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git


### PR DESCRIPTION
Requires https://github.com/spatterIight/ansible-role-jellyfin/pull/26 and a new release `v10.11.8-2`.