### PR TITLE
Update Sonarr (v4.0.17-0 → v4.0.17-1)

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -1198,7 +1198,7 @@ mash_playbook_devture_systemd_service_manager_services_list_auto_itemized:
 
   # role-specific:sonarr
   - |-
-    {{ ({'name': (sonarr_identifier + '.service'), 'priority': 2000, 'restart_necessary': true, 'groups': ['mash', 'sonarr']} if sonarr_enabled else omit) }}
+    {{ ({'name': (sonarr_identifier + '.service'), 'priority': 2000, 'restart_necessary': (sonarr_restart_necessary | bool), 'groups': ['mash', 'sonarr']} if sonarr_enabled else omit) }}
   # /role-specific:sonarr
 
   # role-specific:soundcloak

--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -865,7 +865,7 @@
   name: solidinvoice
   activation_prefix: solidinvoice_
 - src: git+https://github.com/spatterIight/ansible-role-sonarr.git
-  version: v4.0.17-0
+  version: v4.0.17-1
   name: sonarr
   activation_prefix: sonarr_
 - src: git+https://seed.radicle.garden/z381JyLARWwSiZnYotVXehYcQEw7u.git


### PR DESCRIPTION
Requires https://github.com/spatterIight/ansible-role-sonarr/pull/13 and a new release `v4.0.17-1`.