### PR TITLE
fix: Update Kutt URL from kutt.it to kutt.to

### DIFF
--- a/docs/services/kutt.md
+++ b/docs/services/kutt.md
@@ -20,7 +20,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Kutt
 
-The playbook can install and configure [Kutt](https://kutt.it) for you.
+The playbook can install and configure [Kutt](https://kutt.to) for you.
 
 Kutt is a modern URL shortener with support for custom domains with functions like statistics and user management.
 

--- a/docs/supported-services.md
+++ b/docs/supported-services.md
@@ -130,7 +130,7 @@ Below is an exhaustive list of the free and open-source software for self-hostin
 | [Keycloak](https://www.keycloak.org/) | An identity and access management solution | [Link](services/keycloak.md) |
 | [KeyDB](https://docs.keydb.dev/) | An in-memory data store used by millions of developers as a database, cache, streaming engine, and message broker | [Link](services/keydb.md) |
 | [keyoxide-web](https://codeberg.org/keyoxide/keyoxide-web) | Web client for [Keyoxide](https://keyoxide.org/), a decentralized tool to create and verify decentralized online identities | [Link](services/keyoxide.md) |
-| [Kutt](https://kutt.it/) | Modern URL shortener with support for custom domains | [Link](services/kutt.md) |
+| [Kutt](https://kutt.to/) | Modern URL shortener with support for custom domains | [Link](services/kutt.md) |
 | [LabelStudio](https://labelstud.io/) | Data labeling tool that supports multiple projects, users, and data types in one platform | [Link](services/labelstudio.md) |
 | [Lago](https://www.getlago.com/) | Metering and usage-based billing | [Link](services/lago.md) |
 | [LanguageTool](https://languagetool.org/) | An online grammar, style and spell checker | [Link](services/languagetool.md) |


### PR DESCRIPTION
The TLD has changed, as you can see in the in the repo: https://github.com/thedevs-network/kutt/issues/1011