### PR TITLE
ifix: Reverting this change for now as causes authentik instances to …

### DIFF
--- a/templates/requirements.yml
+++ b/templates/requirements.yml
@@ -57,7 +57,7 @@
   name: authelia
   activation_prefix: authelia_
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-authentik.git
-  version: v2026.5.0-0
+  version: v2026.2.3-0
   name: authentik
   activation_prefix: authentik_
 - src: git+https://github.com/spatterIight/ansible-role-autobrr.git


### PR DESCRIPTION
…not be reachable

Revert "Update dependency authentik to v2026.5.0-0"

This reverts commit 967dfa5f8033e5620f8bfcfd2a9dab4c481af62e.

Reasoning: There seems to be an issue with the new rust-based worker that causes authentik to either not start or to not load on page visit. This was reported in the chat and confirmed by me. The root cause is still unknown. While reverting back is not great, it likely causes less harm than having future updates crash. Hopefully a fix can be quickly identified.