### PR TITLE
Make Headscale a wanted dependency of Headplane

### DIFF
--- a/templates/group_vars_mash_servers
+++ b/templates/group_vars_mash_servers
@@ -7181,9 +7181,12 @@ headplane_gid: "{{ mash_playbook_gid }}"
 
 headplane_systemd_required_services_list_auto: |
   {{
-    ([headscale_identifier ~ '.service'] if headscale_enabled | default(false) and headplane_headscale_hostname == headscale_identifier and headplane_container_network != headscale_container_network else [])
-    +
     ([container_socket_proxy_identifier + '.service'] if container_socket_proxy_enabled | default(false) else [])
+  }}
+
+headplane_systemd_wanted_services_list_auto: |
+  {{
+    ([headscale_identifier ~ '.service'] if headscale_enabled | default(false) and headplane_headscale_hostname == headscale_identifier and headplane_container_network != headscale_container_network else [])
   }}
 
 headplane_container_additional_networks_auto: |


### PR DESCRIPTION
## Summary

- move locally managed Headscale from Headplane's required services to its wanted services
- keep Docker and the container socket proxy requirements unchanged
- avoid unnecessary hard systemd lifecycle coupling between Headplane and Headscale

## Why

Headplane 0.7 can start while Headscale is unavailable and retries capability detection in the background ([upstream change](https://github.com/tale/headplane/commit/56c5e5ac8c548caca88fa035ce93c5949de071d1)).

MASH currently adds local Headscale to Headplane's required-service list. The role renders that as both `Requires=` and `After=`, imposing hard activation and ordering coupling.

This change renders `Wants=` only. Starting Headplane still asks systemd to start Headscale, but it does not wait for Headscale's activation job or make successful Headscale activation a condition of starting Headplane. Headplane still relies on Headscale for useful operation; temporary unavailability is handled by Headplane 0.7's retry behavior.

## Validation

- `just prek run --files templates/group_vars_mash_servers`
- `just prek-run-on-all`
- regenerated `group_vars/mash_servers`
- verified the socket proxy remains required and local Headscale is wanted only
- the same dependency change was successfully exercised during a Headplane 0.7 production validation
